### PR TITLE
FIX: Stepper flex in IE

### DIFF
--- a/src/Stepper/StepperStateless/index.js
+++ b/src/Stepper/StepperStateless/index.js
@@ -11,7 +11,7 @@ import type { StateLessProps } from "./index.js.flow";
 const StyledStepper = styled.div`
   display: flex;
   width: 100%;
-  flex: 1 1 100%;
+  flex: 1 1 auto;
 `;
 
 const StyledStepperInput = styled.input`


### PR DESCRIPTION
Due to IE, it needs to be used `flex: 1 1 auto` and explicit `width: 100%`, because `flex-basis` doesn't count with `box-sizing: border-box` which results in cropped `Stepper` in some use cases.