### PR TITLE
chore: remove exact cross-dependency versioning

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,9 +7,6 @@
     "packages/*"
   ],
   "command": {
-    "init": {
-      "exact": true
-    },
     "version": {
       "message": "chore(release): publish"
     }


### PR DESCRIPTION
As agreed, I'm removing exact cross-dependency versioning to leave the strategy that we were using before. We can always change it later if needed.<br/><br/><br/><url>LiveURL: https://orbit-components-chore-monorepo-fixes.surge.sh</url>