### PR TITLE
ci: bootstrap packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: yarn
+          command: yarn bootstrap
 
       - run:
           name: Testing, Linting, Type Checking
@@ -40,7 +40,7 @@ jobs:
           - v1-dependencies-
       - run:
           name: Install dependencies
-          command: yarn
+          command: yarn bootstrap
       - run:
           name: Build and deploy
           command: yarn orbit-components deploy:storybook --ci --host-token-env-variable=GITHUB_TOKEN
@@ -57,7 +57,7 @@ jobs:
           - v1-dependencies-
       - run:
           name: Install dependencies
-          command: yarn
+          command: yarn bootstrap
       - run:
           name: Build storybook
           command: yarn orbit-components build:storybook

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: preactjs/compressed-size-action@v2
         with:
-          build-script: orbit-components build
+          build-script: lerna bootstrap
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "packages/orbit-components/lib/**/*.js"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: preactjs/compressed-size-action@v2
         with:
-          build-script: yarn orbit-components build
+          build-script: orbit-components build
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "packages/orbit-components/lib/**/*.js"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "packages/*"
   ],
   "scripts": {
+    "bootstrap": "lerna bootstrap",
     "orbit-components": "yarn workspace @kiwicom/orbit-components",
     "prepare": "yarn orbit-components build",
     "prettier:test": "prettier --check '**/*.md'",


### PR DESCRIPTION
1. fix build failure in compressed size action
2. run Lerna's [`bootstrap` command](https://github.com/lerna/lerna/tree/f6e7a13e60fefc523d701efddfcf0ed41a77749b/commands/bootstrap) in CI, which symlinks packages and other stuff

Btw, we should run `yarn bootstrap` locally to first initialize the monorepo and when adding/removing packages. Currently we only have one `orbit-components`, but when we add `orbit-design-tokens`, `bootstrap` script is needed to symlink the dependency.