### PR TITLE
ci: add missing build step to compressed size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: preactjs/compressed-size-action@v2
         with:
-          build-script: lerna bootstrap
+          build-script: build-ci
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "packages/orbit-components/lib/**/*.js"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "orbit-components": "yarn workspace @kiwicom/orbit-components",
+    "build-ci": "lerna bootstrap && yarn orbit-components build",
     "prepare": "yarn orbit-components build",
     "prettier:test": "prettier --check '**/*.md'",
     "eslint:check": "eslint . --report-unused-disable-directives",


### PR DESCRIPTION
<br/><br/><br/><url>LiveURL: https://orbit-components-ci-fix-compressed-size.surge.sh</url>