### PR TITLE
chore: add display name to Jest project

### DIFF
--- a/packages/orbit-components/jest.config.js
+++ b/packages/orbit-components/jest.config.js
@@ -1,6 +1,7 @@
 // @noflow
 
 module.exports = {
+  displayName: "orbit-components",
   setupFiles: ["raf/polyfill", "./config/enzymeConfig", "./config/registerContext"],
   setupFilesAfterEnv: ["./config/jestSetupFramework"],
   snapshotSerializers: ["enzyme-to-json/serializer"],


### PR DESCRIPTION
By adding `displayName` to all projects we can use [`--selectProjects`](https://jestjs.io/docs/en/cli#--selectprojects-project1--projectn) to run tests only for specific projects.
<br/><br/><br/><url>LiveURL: https://orbit-components-chore-jest-display-name.surge.sh</url>