### PR TITLE
Add prettier to orbit-components dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint:check": "eslint . --report-unused-disable-directives",
     "flow:check": "flow check",
     "test": "jest --config=jest.json",
-    "test-ci": "yarn flow:check && yarn eslint && yarn test --ci --maxWorkers=2 && yarn prettier:test",
+    "test-ci": "yarn flow:check && yarn eslint:check && yarn test --ci --maxWorkers=2 && yarn prettier:test",
     "update-supported-browsers": "markdown --path .github/contribution/testing-conventions.md && git add .github/contribution/testing-conventions.md",
     "release": "lerna version --conventional-commits"
   },

--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -125,6 +125,7 @@
     "loki": "^0.15.0",
     "make-runnable": "^1.3.6",
     "mkdirp": "^1.0.4",
+    "prettier": "^2.0.5",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-element-to-jsx-string": "^14.3.1",


### PR DESCRIPTION
- `buildExample.js` uses `prettier`, so it needs to be in the dependencies
- this mistake slipped past us because I made a mistake in the `test-ci` script, now it's fixed
<br/><br/><br/><url>LiveURL: https://orbit-components-chore-add-prettier-to-orbit-components.surge.sh</url>