### PR TITLE
fix(Table): updating default align and removing unnecessary vertical-align options

### DIFF
--- a/packages/orbit-components/src/Table/README.md
+++ b/packages/orbit-components/src/Table/README.md
@@ -124,16 +124,12 @@ Table below contains all types of the props in TableCell component.
 
 #### enum
 
-| align      | whiteSpace   | VerticalAlign   | as     | scope        |
-| :--------- | :----------- | --------------- | :----- | :----------- |
-| `"left"`   | `"nowrap"`   | `"nowrap"`      | `"th"` | `"col"`      |
-| `"center"` | `"pre"`      | `"sub"`         | `"td"` | `"row"`      |
-| `"right"`  | `"pre-line"` | `"super"`       |        | `"colgroup"` |
-|            |              | `"text-top"`    |        | `"rowgroup"` |
-|            |              | `"text-bottom"` |
-|            |              | `"middle"`      |
-|            |              | `"top"`         |
-|            |              | `"bottom"`      |
+| align      | whiteSpace   | VerticalAlign | as     | scope        |
+| :--------- | :----------- | ------------- | :----- | :----------- |
+| `"left"`   | `"nowrap"`   | `"baseline"`  | `"th"` | `"col"`      |
+| `"center"` | `"pre"`      | `"middle"`    | `"td"` | `"row"`      |
+| `"right"`  | `"pre-line"` | `"top"`       |        | `"colgroup"` |
+|            |              | `"bottom"`    |        | `"rowgroup"` |
 
 ### TableFooter
 

--- a/packages/orbit-components/src/Table/TableCell/index.d.ts
+++ b/packages/orbit-components/src/Table/TableCell/index.d.ts
@@ -10,15 +10,7 @@ type Align = "left" | "center" | "right";
 type As = "th" | "td";
 type Scope = "col" | "row" | "colgroup" | "rowgroup";
 type WhiteSpace = "nowrap" | "pre" | "pre-line" | "pre-wrap";
-type VerticalAlign =
-  | "baseline"
-  | "sub"
-  | "super"
-  | "text-top"
-  | "text-bottom"
-  | "middle"
-  | "top"
-  | "bottom";
+type VerticalAlign = "baseline" | "middle" | "top" | "bottom";
 
 interface Props extends SharedProps {
   readonly as?: As;

--- a/packages/orbit-components/src/Table/TableCell/index.js
+++ b/packages/orbit-components/src/Table/TableCell/index.js
@@ -30,7 +30,7 @@ StyledTableCell.defaultProps = {
 };
 
 const TableCell = ({
-  align = ALIGN_OPTIONS.CENTER,
+  align = ALIGN_OPTIONS.LEFT,
   scope,
   as = TYPE_AS.TD,
   verticalAlign,

--- a/packages/orbit-components/src/Table/TableCell/index.js.flow
+++ b/packages/orbit-components/src/Table/TableCell/index.js.flow
@@ -8,15 +8,7 @@ type Align = "left" | "center" | "right";
 type As = "th" | "td";
 type Scope = "col" | "row" | "colgroup" | "rowgroup";
 type WhiteSpace = "nowrap" | "pre" | "pre-line" | "pre-wrap";
-type VerticalAlign =
-  | "baseline"
-  | "sub"
-  | "super"
-  | "text-top"
-  | "text-bottom"
-  | "middle"
-  | "top"
-  | "bottom";
+type VerticalAlign = "baseline" | "middle" | "top" | "bottom";
 
 export type Props = {|
   +children?: React$Node,


### PR DESCRIPTION
BREAKING CHANGE:
Changing default align from `center` to `left` as to align this with common defaults as default HTML Table acts like this.
Removing  unnecessary vertical-align options as `sub`, `super`, `text-top`, `text-bottom` are reduced in to `baseline` in table context more [here](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align#Values_for_table_cells) 

