### PR TITLE
chore: don't run deploy on master branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: Surge Deploy
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Because we use `github.head_ref` (branch name) variable for deployment to surge, we don't have to do it for pushes to master. We use GH pages for master branch. <br/><br/><br/><url>LiveURL: https://orbit-chore-deploy-run.surge.sh</url>