### PR TITLE
chore: fix typo in Babel plugin's Jest config

### DIFF
--- a/packages/babel-plugin-orbit-components/jest.config.js
+++ b/packages/babel-plugin-orbit-components/jest.config.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   displayName: "babel-plugin-orbit-components",
-  testEnvironent: "node",
+  testEnvironment: "node",
 };


### PR DESCRIPTION
<br/><br/><br/><url>LiveURL: https://orbit-chore-babel-plugin-jest-config.surge.sh</url>