### PR TITLE
feat: add an agnostic entry point for icons

### DIFF
--- a/packages/orbit-components/icons/package.json
+++ b/packages/orbit-components/icons/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kiwicom/orbit-components/icons",
+  "private": true,
+  "main": "../lib/icons/index.js",
+  "module": "../es/icons/index.js"
+}

--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -47,6 +47,7 @@
     "es",
     "lib",
     "umd",
+    "icons",
     "orbit-icons-font",
     "orbit-icons-font.zip",
     "orbit-svgs.zip",


### PR DESCRIPTION
While icons can be imported from the root entry point:

```js
import { Icons } from "@kiwicom/orbit-components"
```

this way all icons end up in the bundle. Instead we should provide another entry point just for icons:

```js
import { Accommodation } from "@kiwicom/orbit-components/icons";
```

This way tools that support ES, like webpack, will import from
`@kiwicom/orbit-components/es/icons`. Others will import from `*/lib/icons`.
<br/><br/><br/><url>LiveURL: https://orbit-feat-import-icons.surge.sh</url>