### PR TITLE
ci: fix release workflow tag pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "@kiwicom/[a-z-]+@[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   release-notary:


### PR DESCRIPTION
Tags are prefixed with the package name since converting to the monorepo.
<br/><br/><br/><url>LiveURL: https://orbit-ci-fix-release.surge.sh</url>