### PR TITLE
ci: fix invalid tag pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - "@kiwicom/[a-z-]+@[0-9]+.[0-9]+.[0-9]+"
+      - "@kiwicom/*@[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   release-notary:


### PR DESCRIPTION
I incorrectly fixed it in #2240. See the [filter pattern cheat sheet](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet).<br/><br/><br/><url>LiveURL: https://orbit-ci-fix-tag-pattern.surge.sh</url>