### PR TITLE
fix(Tile): newWindow icon on external 

### DIFF
--- a/packages/orbit-components/src/Tile/components/TileHeader/index.js
+++ b/packages/orbit-components/src/Tile/components/TileHeader/index.js
@@ -76,12 +76,9 @@ StyledTileDescription.defaultProps = {
 };
 
 const IconRight = ({ external, expandable, className }) => {
-  if (expandable) {
-    return <ChevronDown className={className} />;
-  }
-  if (external) {
-    return <NewWindow className={className} />;
-  }
+  if (expandable) return <ChevronDown className={className} />;
+  if (external) return <NewWindow className={className} />;
+
   return <ChevronRight className={className} reverseOnRtl />;
 };
 

--- a/packages/orbit-components/src/Tile/index.js
+++ b/packages/orbit-components/src/Tile/index.js
@@ -61,6 +61,7 @@ const Tile = ({
           title={title}
           description={description}
           icon={icon}
+          external={external}
           header={header}
           expandable={expandable}
           noHeaderIcon={noHeaderIcon}


### PR DESCRIPTION
[jira backlog issue](https://jira.kiwi.com/browse/ORBIT-1044)

prop `external` for `TileHeader` just was missing.<br/><br/><br/><url>LiveURL: https://orbit-fix-tile.surge.sh</url>