### PR TITLE
test: improve failure message for the Babel plugin

### DIFF
--- a/packages/babel-plugin-orbit-components/package.json
+++ b/packages/babel-plugin-orbit-components/package.json
@@ -33,6 +33,6 @@
   "scripts": {
     "generateTestFile": "node scripts/generateImports.js",
     "build": "babel __fixtures__/index.js --out-file dist/index.js --root-mode upward",
-    "test": "yarn generateTestFile && yarn build && node dist/index.js"
+    "test": "yarn generateTestFile && yarn build && node scripts/testRequire.js"
   }
 }

--- a/packages/babel-plugin-orbit-components/scripts/testRequire.js
+++ b/packages/babel-plugin-orbit-components/scripts/testRequire.js
@@ -1,0 +1,19 @@
+// @noflow
+
+// to avoid an ESLint issue with --report-unused-disable-directives
+const path = "../dist";
+
+try {
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  require(path);
+} catch (err) {
+  const match = err.message.match(/Cannot find module '([^']*\/(\w+))'/);
+  if (match) {
+    console.error(
+      `\n@kiwicom/babel-plugin-orbit-components did not correctly transform the import path for the module "${match[2]}", "${match[1]}" doesn't exist. Make sure to configure it properly.\n`,
+    );
+  } else {
+    console.error(err);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
When I got the error in the former screenshot (it was for another module), it took me a while to figure out what it meant even though I was the one who reviewed the PR that added this test, so I wanted to improve the error message.

Before:

<img width="665" alt="Screen Shot 2020-09-29 at 12 47 11" src="https://user-images.githubusercontent.com/471278/94549060-e905a580-0251-11eb-8cf3-920f6625ef1c.png">

After:

<img width="658" alt="Screen Shot 2020-09-29 at 12 40 22" src="https://user-images.githubusercontent.com/471278/94548945-c1aed880-0251-11eb-8d41-e480ab8452ed.png">
<br/><br/><br/><url>LiveURL: https://orbit-test-babel-plugin-dx.surge.sh</url>