### PR TITLE
fix: force eol to lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto eol=lf
+*.gif binary
+*.jpg binary
+*.eot binary
+*.woff binary
+*.svg binary
+*.ttf binary
+*.png binary
+*.otf binary
+*.tif binary


### PR DESCRIPTION
// every contributor now pushes git changes from unix OS as far as i know,
// but just in case if someone would like to contribute from windows,
// it will be useful to enforce eol to lf
<br/><br/><br/><url>LiveURL: https://orbit-fix-line-endings.surge.sh</url>