### PR TITLE
Move to Testing Library in AirportIllustration, Alert, Badge and Breadcrumbs

### DIFF
--- a/packages/orbit-components/src/AirportIllustration/__tests__/index.test.js
+++ b/packages/orbit-components/src/AirportIllustration/__tests__/index.test.js
@@ -1,49 +1,45 @@
 // @flow
 import * as React from "react";
-import { shallow, mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
 
 import AirportIllustration from "../index";
 import { SIZE_OPTIONS } from "../../primitives/IllustrationPrimitive/consts";
 import SPACINGS_AFTER from "../../common/getSpacingToken/consts";
 import defaultTheme from "../../defaultTheme";
 
-const size = SIZE_OPTIONS.EXTRASMALL;
 const name = "BGYFastTrack";
 const dataTest = "test";
 
-const URL = "//images.kiwi.com/illustrations/0x90/BGYFastTrack-Q85.png";
-const URL_RETINA = "//images.kiwi.com/illustrations/0x180/BGYFastTrack-Q85.png 2x";
-
 describe(`AirportIllustration of ${name}`, () => {
-  const component = shallow(
-    <AirportIllustration
-      size={size}
-      name={name}
-      dataTest={dataTest}
-      spaceAfter={SPACINGS_AFTER.NORMAL}
-    />,
-  );
-
-  const mountedComponent = mount(
-    <AirportIllustration
-      size={size}
-      name={name}
-      dataTest={dataTest}
-      spaceAfter={SPACINGS_AFTER.NORMAL}
-    />,
-  );
+  beforeEach(() => {
+    render(
+      <AirportIllustration
+        size={SIZE_OPTIONS.EXTRASMALL}
+        name={name}
+        dataTest="test"
+        spaceAfter={SPACINGS_AFTER.NORMAL}
+      />,
+    );
+  });
 
   it("should have passed props", () => {
-    expect(component.prop("size")).toBe(size);
-    expect(component.render().prop("alt")).toBe(name);
-    expect(component.render().prop("data-test")).toBe(dataTest);
+    expect(screen.getByRole("img")).toHaveAttribute("alt", name);
+    expect(screen.getByRole("img")).toHaveAttribute("data-test", dataTest);
   });
 
   it("should render proper image", () => {
-    expect(component.render().attr("src")).toContain(URL);
-    expect(component.render().attr("srcset")).toContain(URL_RETINA);
+    expect(screen.getByRole("img").getAttribute("src")).toMatchInlineSnapshot(
+      `"//images.kiwi.com/illustrations/0x90/BGYFastTrack-Q85.png"`,
+    );
+    expect(screen.getByRole("img").getAttribute("srcset")).toMatchInlineSnapshot(
+      `"//images.kiwi.com/illustrations/0x180/BGYFastTrack-Q85.png 2x, //images.kiwi.com/illustrations/0x270/BGYFastTrack-Q85.png 3x"`,
+    );
   });
+
   it("should have margin-bottom", () => {
-    expect(mountedComponent).toHaveStyleRule("margin-bottom", defaultTheme.orbit.spaceSmall);
+    expect(getComputedStyle(screen.getByRole("img"))).toHaveProperty(
+      "margin-bottom",
+      defaultTheme.orbit.spaceSmall,
+    );
   });
 });

--- a/packages/orbit-components/src/Alert/__tests__/index.test.js
+++ b/packages/orbit-components/src/Alert/__tests__/index.test.js
@@ -1,39 +1,40 @@
 // @flow
 import * as React from "react";
-import { shallow, mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import Alert from "../index";
 import defaultTheme from "../../defaultTheme";
 import SPACINGS_AFTER from "../../common/getSpacingToken/consts";
-import { CLOSE_BUTTON_DATA_TEST } from "../consts";
 
 const message = "Alert message";
 
 describe("Alert", () => {
   it("should contain children", () => {
-    const component = shallow(<Alert>{message}</Alert>);
-    expect(component.find("Alert__Content").children().exists()).toBe(true);
+    render(<Alert>{message}</Alert>);
+    expect(screen.getByText(message)).toBeInTheDocument();
   });
   it("should have data-test", () => {
     const dataTest = "test";
-    const component = shallow(<Alert dataTest={dataTest}>{message}</Alert>);
-    expect(component.render().prop("data-test")).toBe(dataTest);
+    render(<Alert dataTest={dataTest}>{message}</Alert>);
+    expect(screen.getByTestId(dataTest)).toBeInTheDocument();
   });
   it("should have margin-bottom", () => {
-    const component = mount(<Alert spaceAfter={SPACINGS_AFTER.NORMAL}>{message}</Alert>);
-    expect(component).toHaveStyleRule("margin-bottom", defaultTheme.orbit.spaceSmall);
+    const { container } = render(<Alert spaceAfter={SPACINGS_AFTER.NORMAL}>{message}</Alert>);
+    expect(getComputedStyle(container.firstChild)).toHaveProperty(
+      "margin-bottom",
+      defaultTheme.orbit.spaceSmall,
+    );
   });
   it("should be closable", () => {
     const onClose = jest.fn();
-    const component = shallow(
+    render(
       <Alert onClose={onClose} closable>
         {message}
       </Alert>,
     );
 
-    const ButtonLink = component.find("AlertCloseButton");
-    expect(ButtonLink.prop("dataTest")).toBe(CLOSE_BUTTON_DATA_TEST);
-    ButtonLink.simulate("click");
+    userEvent.click(screen.getByRole("button"));
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/packages/orbit-components/src/Badge/__tests__/index.test.js
+++ b/packages/orbit-components/src/Badge/__tests__/index.test.js
@@ -1,33 +1,34 @@
 // @flow
 
 import * as React from "react";
-import { shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
 
 import Badge from "../index";
 import Sightseeing from "../../icons/Sightseeing";
-import defaultTheme from "../../defaultTheme";
 
 describe("Badge", () => {
   const content = "badge";
   const type = "info";
   const dataTest = "test";
-  const icon = <Sightseeing />;
+  const icon = <Sightseeing ariaLabel="sightseeing" />;
   const ariaLabel = content;
 
-  const component = shallow(
-    <Badge icon={icon} type={type} dataTest={dataTest} ariaLabel={ariaLabel}>
-      {content}
-    </Badge>,
-  );
+  beforeEach(() => {
+    render(
+      <Badge icon={icon} type={type} dataTest={dataTest} ariaLabel={ariaLabel}>
+        {content}
+      </Badge>,
+    );
+  });
 
   it("should have passed props", () => {
-    expect(component.prop("background")).toBe(defaultTheme.orbit.paletteBlueLight);
-    expect(component.prop("foregroundColor")).toBe(defaultTheme.orbit.paletteBlueDark);
-    expect(component.render().prop("data-test")).toBe(dataTest);
-    expect(component.render().prop("aria-label")).toBe(ariaLabel);
-    expect(component.prop("icon")).toBe(icon);
+    const style = getComputedStyle(screen.getByTestId(dataTest));
+    expect(style.border).toMatchInlineSnapshot(`"1px solid #d0e9fb"`);
+    expect(screen.getByTestId(dataTest)).toBeInTheDocument();
+    expect(screen.getByLabelText(ariaLabel)).toBeInTheDocument();
+    expect(screen.getByLabelText("sightseeing")).toBeInTheDocument();
   });
   it("should contain a content", () => {
-    expect(component.render().text()).toBe(content);
+    expect(screen.getByText(content)).toBeInTheDocument();
   });
 });

--- a/packages/orbit-components/src/Breadcrumbs/__tests__/index.test.js
+++ b/packages/orbit-components/src/Breadcrumbs/__tests__/index.test.js
@@ -1,55 +1,52 @@
 // @flow
+/* eslint-disable no-restricted-syntax */
 
 import * as React from "react";
-import { shallow } from "enzyme";
-import { render } from "react-dom";
-import { nullthrows } from "@adeira/js";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import Breadcrumbs from "../index";
 import BreadcrumbsItem from "../BreadcrumbsItem";
 
-let screen;
-const body = nullthrows(document.body, "Expected document to have a body");
-
-beforeEach(() => {
-  screen = document.createElement("div");
-  body.appendChild(screen);
-});
-
-afterEach(() => {
-  body.removeChild(screen);
-});
+// jsdom doesn't support @media queries, so for <Hide> the computed value of
+// "display" is "none", which @testing-library/react (impressively) detects as
+// inaccessible, so we're replacing <Hide> with a dummy component
+jest.mock("../../Hide", () => ({ children }) => children);
 
 describe("Breadcrumbs", () => {
   const dataTest = "test";
   const onGoBack = jest.fn();
-  const component = shallow(
-    <Breadcrumbs dataTest={dataTest} onGoBack={onGoBack}>
-      <BreadcrumbsItem href="https://kiwi.com">Kiwi.com</BreadcrumbsItem>
-    </Breadcrumbs>,
-  );
-  const wrapper = component.find("Breadcrumbs__StyledBreadcrumbs");
-  const list = component.find("Breadcrumbs__StyledBreadcrumbsList");
+  beforeEach(() => {
+    render(
+      <Breadcrumbs dataTest={dataTest} onGoBack={onGoBack}>
+        <BreadcrumbsItem href="https://kiwi.com">Kiwi.com</BreadcrumbsItem>
+      </Breadcrumbs>,
+    );
+  });
+  afterEach(() => {
+    onGoBack.mockClear();
+  });
   it("nav should contain label, role and data-test", () => {
-    expect(wrapper.render().prop("name")).toBe("nav");
-    expect(wrapper.render().prop("role")).toBe("navigation");
-    expect(wrapper.render().prop("aria-label")).toBe("Breadcrumb");
-    expect(wrapper.render().prop("data-test")).toBe(dataTest);
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+    expect(screen.getByLabelText("Breadcrumb")).toBeInTheDocument();
+    expect(screen.getByTestId(dataTest)).toBeInTheDocument();
   });
   it("ol should contain correct item type", () => {
-    expect(list.render().prop("name")).toBe("ol");
-    expect(list.render().prop("attribs").itemtype).toContain("BreadcrumbList");
+    expect(screen.getByRole("list")).toHaveAttribute(
+      "itemType",
+      expect.stringContaining("BreadcrumbList"),
+    );
   });
   it("children should contain active and contentKey", () => {
-    expect(list.find("BreadcrumbsItem").prop("active")).toBe(true);
-    expect(list.find("BreadcrumbsItem").prop("contentKey")).toBe(1);
+    expect(screen.getByRole("listitem")).toHaveAttribute("aria-current", "page");
+    expect(document.querySelector("meta")).toHaveAttribute("content", "1");
   });
   it("should execute onGoBack", () => {
-    component.find("GoBackButton").simulate("click");
-    expect(onGoBack).toHaveBeenCalled();
+    for (const backBtn of screen.getAllByRole("button", { name: "Back" })) {
+      userEvent.click(backBtn);
+    }
 
-    component.find("[dataTest='BreadcrumbsBack']").simulate("click");
-    expect(onGoBack).toHaveBeenCalled();
+    expect(onGoBack).toHaveBeenCalledTimes(2);
   });
 
   it("should render as a link when backHref is passed", () => {
@@ -57,10 +54,11 @@ describe("Breadcrumbs", () => {
       <Breadcrumbs backHref="https://orbit.kiwi" dataTest={dataTest} onGoBack={onGoBack}>
         <BreadcrumbsItem href="https://kiwi.com">Kiwi.com</BreadcrumbsItem>
       </Breadcrumbs>,
-      screen,
     );
 
-    expect(screen.querySelector('a[href="https://orbit.kiwi"]')).not.toBeNull();
+    for (const backLink of screen.getAllByRole("link", { name: "Back" })) {
+      expect(backLink).toHaveAttribute("href", "https://orbit.kiwi");
+    }
   });
 
   it("should render as a link when backHref is passed without onGoBack", () => {
@@ -68,10 +66,11 @@ describe("Breadcrumbs", () => {
       <Breadcrumbs backHref="https://orbit.kiwi" dataTest={dataTest}>
         <BreadcrumbsItem href="https://kiwi.com">Kiwi.com</BreadcrumbsItem>
       </Breadcrumbs>,
-      screen,
     );
 
-    expect(screen.querySelector('a[href="https://orbit.kiwi"]')).not.toBeNull();
+    for (const backLink of screen.getAllByRole("link", { name: "Back" })) {
+      expect(backLink).toHaveAttribute("href", "https://orbit.kiwi");
+    }
   });
 });
 
@@ -81,39 +80,52 @@ describe("Breadcrumbs", () => {
   const title = "Kiwi.com";
   const dataTest = "test";
   const id = "id";
-  const component = shallow(
-    <BreadcrumbsItem id={id} href={url} onClick={onClick} dataTest={dataTest} active contentKey={2}>
-      {title}
-    </BreadcrumbsItem>,
-  );
-  const anchor = component.find("BreadcrumbsItem__StyledBreadcrumbsItemAnchor");
+  beforeEach(() => {
+    render(
+      <BreadcrumbsItem
+        id={id}
+        href={url}
+        onClick={onClick}
+        dataTest={dataTest}
+        active
+        contentKey={2}
+      >
+        {title}
+      </BreadcrumbsItem>,
+    );
+  });
   it("li contains props", () => {
-    expect(component.render().prop("name")).toBe("li");
-    expect(component.render().prop("data-test")).toBe(dataTest);
-    expect(component.render().prop("attribs").itemprop).toBe("itemListElement");
-    expect(component.render().prop("attribs").itemtype).toContain("ListItem");
-    expect(component.render().prop("aria-current")).toBe("page");
-    expect(anchor.render().prop("itemid")).toBe(id);
+    expect(screen.getByRole("listitem")).toBeInTheDocument();
+    expect(screen.getByTestId(dataTest)).toBeInTheDocument();
+    expect(screen.getByRole("listitem")).toHaveAttribute("itemprop", "itemListElement");
+    expect(screen.getByRole("listitem")).toHaveAttribute(
+      "itemtype",
+      expect.stringContaining("ListItem"),
+    );
+    expect(screen.getByRole("listitem")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link")).toHaveAttribute("itemid", id);
   });
   it("anchor contains props", () => {
-    expect(anchor.render().prop("href")).toBe(url);
-    expect(anchor.render().prop("itemprop")).toBe("item");
-    expect(anchor.render().prop("itemtype")).toContain("WebPage");
-    expect(anchor.children().find("span").render().prop("itemprop")).toBe("name");
-    expect(anchor.children().find("span").children().text()).toBe(title);
+    expect(screen.getByRole("link")).toHaveAttribute("href", url);
+    expect(screen.getByRole("link")).toHaveAttribute("itemprop", "item");
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "itemtype",
+      expect.stringContaining("WebPage"),
+    );
+    expect(screen.getByText(title)).toHaveAttribute("itemprop", "name");
   });
   it("meta contains props", () => {
-    expect(component.children().find("meta").render().prop("itemprop")).toBe("position");
-    expect(component.children().find("meta").prop("content")).toBe(2);
+    expect(document.querySelector("meta")).toHaveAttribute("itemprop", "position");
+    expect(document.querySelector("meta")).toHaveAttribute("content", "2");
   });
   it("itemid defaults to href when no id attribute", () => {
-    const componentWithoutID = shallow(
+    cleanup();
+    render(
       <BreadcrumbsItem href={url} onClick={onClick} dataTest={dataTest} active contentKey={2}>
         {title}
       </BreadcrumbsItem>,
     );
-    const anchorWithoutID = componentWithoutID.find("BreadcrumbsItem__StyledBreadcrumbsItemAnchor");
 
-    expect(anchorWithoutID.render().prop("itemid")).toBe(url);
+    expect(screen.getByRole("link")).toHaveAttribute("itemid", url);
   });
 });

--- a/packages/orbit-components/src/Breadcrumbs/index.js
+++ b/packages/orbit-components/src/Breadcrumbs/index.js
@@ -69,12 +69,7 @@ const Breadcrumbs = (props: Props) => {
   return (
     <>
       <Hide on={["smallMobile", "mediumMobile"]}>
-        <StyledBreadcrumbs
-          aria-label="Breadcrumb"
-          role="navigation"
-          data-test={dataTest}
-          spaceAfter={spaceAfter}
-        >
+        <StyledBreadcrumbs aria-label="Breadcrumb" data-test={dataTest} spaceAfter={spaceAfter}>
           <StyledBreadcrumbsList itemScope itemType="http://schema.org/BreadcrumbList">
             {onGoBack || backHref ? <GoBackButton backHref={backHref} onClick={onGoBack} /> : null}
             {React.Children.map(children, (item, key) => {


### PR DESCRIPTION
- chore: update Jest libdef
- test(AirportIllustration): use TestingLibrary
- test(Alert): use Testing Library
- test(Badge): use Testing Library
- test(Breadcrumbs): use Testing Library
- chore(Breadcrumbs): remove implied ARIA role
<br/><br/><br/><url>LiveURL: https://orbit-test-enzyme-to-testing-library.surge.sh</url>