### PR TITLE
build: move prepublishOnly to correct package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "orbit-components": "yarn workspace @kiwicom/orbit-components",
     "build-ci": "lerna bootstrap && yarn orbit-components build",
     "postinstall": "yarn orbit-components build:icons && yarn orbit-components build:typeFiles",
-    "prepublishOnly": "yarn orbit-components build",
     "prettier:test": "prettier --check '**/*.md'",
     "eslint:check": "eslint . --report-unused-disable-directives",
     "flow:check": "flow check",

--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -5,6 +5,7 @@
   "sideEffects": false,
   "scripts": {
     "storybook": "start-storybook -p 6007 -c .storybook --ci -s ./static",
+    "prepublishOnly": "yarn build",
     "build": "yarn clean && yarn build:icons && yarn build:iconFont && yarn build:typeFiles && yarn build:lib && yarn build:module && yarn build:umd",
     "build:lib": "babel --out-dir lib --ignore **/*.stories.js,**/*.test.js,**/*.storyshot.js,**/__examples__/*.js,**/examples.js src && yarn copy:lib",
     "build:module": "cross-env BABEL_TARGET=\"js-esm\" babel --out-dir es --ignore **/*.stories.js,**/*.test.js,**/*.storyshot.js,**/__examples__/*.js,**/examples.js src && yarn copy:module",


### PR DESCRIPTION
Lerna publishes packages by running the publish command for each package
individually, therefore `prepublishOnly` in the root `package.json` will
never run. This should be the correct place for it.
<br/><br/><br/><url>LiveURL: https://orbit-build-prepublish-only.surge.sh</url>