### PR TITLE
fix: support icons entry point with Babel plugin

### DIFF
--- a/packages/babel-plugin-orbit-components/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin-orbit-components/__tests__/__snapshots__/index.test.js.snap
@@ -83,12 +83,14 @@ exports[`transform imports as expected 11 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 import { Alert, ModalSection, mediaQueries } from "@kiwicom/orbit-components";
 import { Passengers, Invoice } from "@kiwicom/orbit-components/lib/icons";
+import { Accommodation } from "@kiwicom/orbit-components/icons";
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 import mediaQueries from "@kiwicom/orbit-components/lib/utils/mediaQuery";
 import ModalSection from "@kiwicom/orbit-components/lib/Modal/ModalSection";
 import Alert from "@kiwicom/orbit-components/lib/Alert";
 import Invoice from "@kiwicom/orbit-components/lib/icons/Invoice";
 import Passengers from "@kiwicom/orbit-components/lib/icons/Passengers";
+import Accommodation from "@kiwicom/orbit-components/lib/icons/Accommodation";
 `;
 
 exports[`transform imports as expected 12 1`] = `

--- a/packages/babel-plugin-orbit-components/__tests__/index.test.js
+++ b/packages/babel-plugin-orbit-components/__tests__/index.test.js
@@ -44,7 +44,8 @@ test.each([
   [
     // mixed
     `import { Alert, ModalSection, mediaQueries } from "@kiwicom/orbit-components";
-import { Passengers, Invoice } from "@kiwicom/orbit-components/lib/icons";`,
+import { Passengers, Invoice } from "@kiwicom/orbit-components/lib/icons";
+import { Accommodation } from "@kiwicom/orbit-components/icons";`,
   ],
 
   // REPORTED ISSUES:

--- a/packages/babel-plugin-orbit-components/index.js
+++ b/packages/babel-plugin-orbit-components/index.js
@@ -47,7 +47,11 @@ const pathOverwrites = {
   TripSegment: "deprecated/TripSegment",
 };
 
-const parsedImportPaths = ["@kiwicom/orbit-components", "@kiwicom/orbit-components/lib/icons"];
+const parsedImportPaths = [
+  "@kiwicom/orbit-components",
+  "@kiwicom/orbit-components/lib/icons",
+  "@kiwicom/orbit-components/icons",
+];
 
 module.exports = function orbitComponents(babel) {
   const t = babel.types;
@@ -72,8 +76,12 @@ module.exports = function orbitComponents(babel) {
             spec = t.importDefaultSpecifier(t.identifier(spec.local.name));
 
             // icons will already have /lib in the name, this adds the /lib to normal components
-            if (importedPath.indexOf("/lib") === -1) {
-              importedPath += "/lib";
+            if (!importedPath.includes("/lib")) {
+              if (importedPath.includes("icons")) {
+                importedPath = importedPath.replace("icons", "lib/icons");
+              } else {
+                importedPath += "/lib";
+              }
             }
 
             if (pathOverwrites[importedName]) {


### PR DESCRIPTION
This was supposed to be part of #2237.<br/><br/><br/><url>LiveURL: https://orbit-fix-babel-import-icons.surge.sh</url>