### PR TITLE
fix: move collapsable aria labels to the focusable button

### DIFF
--- a/packages/orbit-components/src/Collapse/index.js
+++ b/packages/orbit-components/src/Collapse/index.js
@@ -9,7 +9,6 @@ import ChevronDown from "../icons/ChevronDown";
 import Slide from "../utils/Slide";
 import defaultTheme from "../defaultTheme";
 import randomID from "../utils/randomID";
-import useTranslate from "../hooks/useTranslate";
 import useBoundingRect from "../hooks/useBoundingRect";
 
 import type { Props } from "./index";
@@ -81,7 +80,6 @@ const Collapse = ({
   );
   const expanded = isControlledComponent ? expandedProp : expandedState;
   const [{ height }, node] = useBoundingRect({ height: expanded ? null : 0 });
-  const translate = useTranslate();
 
   const slideID = React.useMemo(() => randomID("slideID"), []);
   const labelID = React.useMemo(() => randomID("labelID"), []);
@@ -103,13 +101,7 @@ const Collapse = ({
 
   return (
     <StyledCollapse data-test={dataTest}>
-      <StyledCollapseLabel
-        onClick={handleClick}
-        role="button"
-        aria-expanded={expanded}
-        aria-controls={slideID}
-        id={labelID}
-      >
+      <StyledCollapseLabel onClick={handleClick} role="button" id={labelID}>
         <Stack justify="between" align="center">
           <Heading type="title4">{label}</Heading>
           {/* TODO: dictionary for title */}
@@ -125,7 +117,9 @@ const Collapse = ({
               iconLeft={<AnimatedIcon expanded={expanded} />}
               size="small"
               type="secondary"
-              title={translate("drawer_hide")}
+              ariaLabelledby={labelID}
+              ariaExpanded={expanded}
+              ariaControls={slideID}
             />
           </Stack>
         </Stack>

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.d.ts
@@ -10,6 +10,7 @@ export interface ButtonCommonProps extends Common.Global, Common.Ref, Common.Spa
   readonly asComponent?: Common.Component;
   readonly ariaControls?: string;
   readonly ariaExpanded?: boolean;
+  readonly ariaLabelledby?: string;
   readonly children?: React.ReactNode;
   readonly circled?: boolean;
   readonly disabled?: boolean;

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.js
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.js
@@ -29,6 +29,7 @@ export const StyledButtonPrimitive = styled(
     forwardedRef,
     ariaControls,
     ariaExpanded,
+    ariaLabelledby,
     title,
     className,
     rel,
@@ -61,6 +62,7 @@ export const StyledButtonPrimitive = styled(
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}
         aria-label={title}
+        aria-labelledby={ariaLabelledby}
         type={!isButtonWithHref ? buttonType : undefined}
         className={className}
         disabled={disabled}

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.js.flow
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.js.flow
@@ -17,6 +17,7 @@ export type ButtonCommonProps = {|
   +asComponent?: Component,
   +ariaControls?: string,
   +ariaExpanded?: boolean,
+  +ariaLabelledby?: string,
   +children?: React.Node,
   +circled?: boolean,
   +disabled?: boolean,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3856,7 +3856,7 @@
     resolve-from "^5.0.0"
     ts-dedent "^1.1.1"
 
-"@storybook/theming@^6.0.26":
+"@storybook/theming@6.0.26", "@storybook/theming@^6.0.26":
   version "6.0.26"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.0.26.tgz#e5b545fb2653dfd1b043b567197d490b1c3c0da3"
   integrity sha512-9yon2ofb9a+RT1pdvn8Njydy7XRw0qXcIsMqGsJRKoZecmRRozqB6DxH9Gbdf1vRSbM9gYUUDjbiMDFz7+4RiQ==


### PR DESCRIPTION
- The passed label will now be read by the screen reader
- The screen reader will read collapsed or expanded

This Pull Request meets the following criteria:

- [x] Tests have been added/adjusted for my new feature
- [x] New Components are registered in index.js of my project
<br/><br/><br/><url>LiveURL: https://orbit-tbergq-fix-collapsable-a11y.surge.sh</url>