### PR TITLE
fix: fix InputGroup/LayoutColumn TS typing

### DIFF
--- a/packages/orbit-components/src/InputGroup/index.d.ts
+++ b/packages/orbit-components/src/InputGroup/index.d.ts
@@ -23,5 +23,5 @@ interface Props extends Common.Global, Common.SpaceAfter {
   readonly onBlur?: Event;
 }
 
-declare class InputGroup extends React.FC<Props> {}
+declare const InputGroup: React.FC<Props>;
 export { InputGroup, InputGroup as default };

--- a/packages/orbit-components/src/Layout/LayoutColumn/index.d.ts
+++ b/packages/orbit-components/src/Layout/LayoutColumn/index.d.ts
@@ -5,7 +5,7 @@
 import * as React from "react";
 
 import * as Common from "../../common/common";
-import { Devices } from "../../utils/mediaQuery/index";
+import { Devices } from "../../utils/mediaQuery/consts";
 
 declare module "@kiwicom/orbit-components/lib/LayoutColumn";
 


### PR DESCRIPTION
It seems that you don't have any `tsc --noEmit` job on CI nor on your
local development environment; I realise this is because there are some
issues with `@types/styled-components` depending on `@types/react-native`
and other things.

I would suggest to still run `tsc --noEmit` on your local machine
for some sanity check, to ensure no broken types are shipped.

This Pull Request meets the following criteria:

- [x] Tests have been added/adjusted for my new feature
- [x] New Components are registered in index.js of my project
<br/><br/><br/><url>LiveURL: https://orbit-rcsl-fix-types.surge.sh</url>