### PR TITLE
improve(Commitlint): add the improve type to commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,5 +3,23 @@ module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
     "scope-case": [2, "always", "pascal-case"],
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+        "improve",
+      ],
+    ],
   },
 };


### PR DESCRIPTION
Adds the `improve` type to the commitlint configuration, so now you can do commits with the `improve` type. This is useful for huge tooling and platform changes, like the commit of this MR of course 😂

e.g. of usage (also in the commit)

```
improve(Something): adds a lot of awesome changes
```
