### PR TITLE
feat(Eslint): add rules for enforcing readOnly types on TS/Flow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
       files: "*.ts",
       extends: ["./config/eslintTS"],
     },
+    // some ESLint rules fail in certain cases, so we're disabling them
     {
       files: ["packages/orbit-components/src/utils/**/*"],
       rules: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,11 @@ module.exports = {
       files: "*.ts",
       extends: ["./config/eslintTS"],
     },
+    {
+      files: ["packages/orbit-components/src/utils/**/*"],
+      rules: {
+        "@typescript-eslint/prefer-readonly-parameter-types": "OFF",
+      },
+    },
   ],
 };

--- a/config/eslintJS.js
+++ b/config/eslintJS.js
@@ -16,6 +16,7 @@ module.exports = {
   rules: {
     "no-console": ["error", { allow: ["warn", "error"] }],
     "prettier/prettier": "error",
+    "flowtype/require-exact-type": "error",
     "import/no-extraneous-dependencies": [
       "error",
       {

--- a/config/eslintTS.js
+++ b/config/eslintTS.js
@@ -6,7 +6,9 @@ module.exports = {
     "prettier/@typescript-eslint",
     "plugin:prettier/recommended",
   ],
+  plugins: ["import", "react"],
   rules: {
+    "@typescript-eslint/prefer-readonly-parameter-types": "error",
     "import/extensions": [
       "error",
       "ignorePackages",
@@ -18,8 +20,8 @@ module.exports = {
       },
     ],
   },
-  plugins: ["import", "react"],
   parserOptions: {
+    project: "./tsconfig.json",
     ecmaVersion: 2018,
     sourceType: "module",
   },

--- a/packages/orbit-components/src/Alert/AlertButton/helpers/getAlertButtonIconForeground.js.flow
+++ b/packages/orbit-components/src/Alert/AlertButton/helpers/getAlertButtonIconForeground.js.flow
@@ -3,9 +3,9 @@ import type { ThemeProps } from "../../../defaultTheme";
 import type { Type } from "../index";
 import type { IconForeground } from "../../../primitives/ButtonPrimitive";
 
-export type GetAlertButtonIconForeground = ({
+export type GetAlertButtonIconForeground = ({|
   type: Type,
   ...ThemeProps,
-}) => IconForeground;
+|}) => IconForeground;
 
 declare export default GetAlertButtonIconForeground;

--- a/packages/orbit-components/src/Alert/AlertButton/helpers/getAlertButtonStyles.js.flow
+++ b/packages/orbit-components/src/Alert/AlertButton/helpers/getAlertButtonStyles.js.flow
@@ -4,11 +4,11 @@ import type { ThemeProps } from "../../../defaultTheme";
 import type { Type } from "../index";
 import type { Background, BoxShadow, Foreground } from "../../../primitives/ButtonPrimitive";
 
-export type GetAlertButtonStyles = ({
+export type GetAlertButtonStyles = ({|
   disabled: boolean,
   type: Type,
   ...ThemeProps,
-}) => {|
+|}) => {|
   ...Background,
   ...Foreground,
   ...BoxShadow,

--- a/packages/orbit-components/src/Alert/index.js
+++ b/packages/orbit-components/src/Alert/index.js
@@ -22,11 +22,11 @@ import media from "../utils/mediaQuery";
 
 import type { Props } from "./index";
 
-type IconProps = {
+type IconProps = {|
   icon: any,
   type: string,
   className: string,
-};
+|};
 
 const getTypeToken = name => ({ theme, type }) => {
   const tokens = {
@@ -99,11 +99,11 @@ const StyledDiv = ({
   className,
   children,
   dataTest,
-}: {
+}: {|
   className: string,
   children: React.Node,
   dataTest: string,
-}) => (
+|}) => (
   <div className={className} data-test={dataTest}>
     {children}
   </div>

--- a/packages/orbit-components/src/Button/helpers/getButtonIconForeground.js.flow
+++ b/packages/orbit-components/src/Button/helpers/getButtonIconForeground.js.flow
@@ -3,9 +3,9 @@ import type { ThemeProps } from "../../defaultTheme";
 import type { Type } from "../index";
 import type { IconForeground } from "../../primitives/ButtonPrimitive";
 
-export type GetButtonIconForeground = ({
+export type GetButtonIconForeground = ({|
   type: Type,
   ...ThemeProps,
-}) => IconForeground;
+|}) => IconForeground;
 
 declare export default GetButtonIconForeground;

--- a/packages/orbit-components/src/Button/helpers/getButtonStyles.js.flow
+++ b/packages/orbit-components/src/Button/helpers/getButtonStyles.js.flow
@@ -4,11 +4,11 @@ import type { ThemeProps } from "../../defaultTheme";
 import type { Type } from "../index";
 import type { Background, BoxShadow, Foreground } from "../../primitives/ButtonPrimitive";
 
-export type GetButtonStyles = ({
+export type GetButtonStyles = ({|
   disabled: boolean,
   type: Type,
   ...ThemeProps,
-}) => {|
+|}) => {|
   ...Background,
   ...Foreground,
   ...BoxShadow,

--- a/packages/orbit-components/src/ButtonLink/helpers/getButtonLinkCommonProps.js.flow
+++ b/packages/orbit-components/src/ButtonLink/helpers/getButtonLinkCommonProps.js.flow
@@ -3,6 +3,6 @@ import type { GetCommonPropsReturn } from "../../primitives/ButtonPrimitive/comm
 import type { Props } from "../index";
 import type { ThemeProps } from "../../defaultTheme";
 
-export type GetButtonLinkCommonProps = ({ ...Props, ...ThemeProps }) => GetCommonPropsReturn;
+export type GetButtonLinkCommonProps = ({| ...Props, ...ThemeProps |}) => GetCommonPropsReturn;
 
 declare export default GetButtonLinkCommonProps;

--- a/packages/orbit-components/src/ButtonLink/helpers/getButtonLinkIconForeground.js.flow
+++ b/packages/orbit-components/src/ButtonLink/helpers/getButtonLinkIconForeground.js.flow
@@ -4,6 +4,6 @@ import type { ThemeProps } from "../../defaultTheme";
 import type { Type } from "../index";
 import type { IconForeground } from "../../primitives/ButtonPrimitive";
 
-export type GetButtonLinkIconForeground = ({ type: Type, ...ThemeProps }) => IconForeground;
+export type GetButtonLinkIconForeground = ({| type: Type, ...ThemeProps |}) => IconForeground;
 
 declare export default GetButtonLinkIconForeground;

--- a/packages/orbit-components/src/ButtonLink/helpers/getButtonLinkStyles.js.flow
+++ b/packages/orbit-components/src/ButtonLink/helpers/getButtonLinkStyles.js.flow
@@ -9,10 +9,10 @@ import type {
   Underlined,
 } from "../../primitives/ButtonPrimitive";
 
-export type GetButtonLinkStyles = ({
+export type GetButtonLinkStyles = ({|
   type: Type,
   ...ThemeProps,
-}) => {|
+|}) => {|
   ...Background,
   ...Foreground,
   ...BoxShadow,

--- a/packages/orbit-components/src/CarrierLogo/index.js.flow
+++ b/packages/orbit-components/src/CarrierLogo/index.js.flow
@@ -6,11 +6,11 @@ import type { ReactComponentStyled } from "styled-components";
 
 import type { Globals } from "../common/common.js.flow";
 
-export type Carrier = {
+export type Carrier = {|
   code: string,
   name: string,
   type?: "airline" | "bus" | "train" | "ferry" | "private_transfer",
-};
+|};
 
 type Size = "small" | "medium" | "large";
 
@@ -20,10 +20,10 @@ export type Props = {|
   ...Globals,
 |};
 
-type styledCarrierLogo = {
+type styledCarrierLogo = {|
   size: Size,
   carriers: Carrier,
-};
+|};
 
 declare export var StyledCarrierLogo: ReactComponentStyled<styledCarrierLogo>;
 

--- a/packages/orbit-components/src/Checkbox/__examples__/REF.js
+++ b/packages/orbit-components/src/Checkbox/__examples__/REF.js
@@ -5,7 +5,7 @@ import Checkbox from "../index";
 
 export default {
   Example: () => {
-    const ref: { current: React$ElementRef<any> } = React.useRef(null);
+    const ref: {| current: React$ElementRef<any> |} = React.useRef(null);
 
     React.useEffect(() => {
       if (ref.current) {

--- a/packages/orbit-components/src/ChoiceGroup/components/FilterWrapper.js.flow
+++ b/packages/orbit-components/src/ChoiceGroup/components/FilterWrapper.js.flow
@@ -7,7 +7,7 @@ type Props = {|
   +children: React$Element<*>,
   +onOnlySelection?: (
     SyntheticEvent<HTMLButtonElement>,
-    { value: string, label: string },
+    {| value: string, label: string |},
   ) => void | Promise<any>,
   +onlySelectionText?: Translation,
 |};

--- a/packages/orbit-components/src/ChoiceGroup/index.d.ts
+++ b/packages/orbit-components/src/ChoiceGroup/index.d.ts
@@ -20,8 +20,9 @@ export interface Props extends Common.Global {
   readonly onlySelectionText?: Common.Translation;
   readonly filter?: boolean;
   readonly onOnlySelection?: (
+    // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
     event: React.SyntheticEvent<HTMLButtonElement>,
-    param2: { value: string; label: string },
+    param2: { readonly value: string; readonly label: string },
   ) => void | Promise<void>;
   // InputEvent
   readonly onChange: Common.Event<React.SyntheticEvent<HTMLInputElement>>;

--- a/packages/orbit-components/src/ChoiceGroup/index.js.flow
+++ b/packages/orbit-components/src/ChoiceGroup/index.js.flow
@@ -8,7 +8,7 @@ type LabelSize = "normal" | "large";
 
 type LabelAs = "h2" | "h3" | "h4" | "h5" | "h6";
 
-export type Filters = { label: string, value: string };
+export type Filters = {| label: string, value: string |};
 export type Props = {|
   ...Globals,
   children: React$Node,
@@ -20,7 +20,7 @@ export type Props = {|
   filter?: boolean,
   onOnlySelection?: (
     SyntheticEvent<HTMLButtonElement>,
-    { value: string, label: string },
+    {| value: string, label: string |},
   ) => void | Promise<any>,
   onChange: (SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
 |};

--- a/packages/orbit-components/src/Collapse/index.d.ts
+++ b/packages/orbit-components/src/Collapse/index.d.ts
@@ -15,6 +15,7 @@ export interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly actions?: React.ReactNode;
   readonly onClick?: (
+    // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
     e: React.SyntheticEvent<HTMLDivElement>,
     state: boolean,
   ) => void | Promise<void>;

--- a/packages/orbit-components/src/CountryFlag/index.js
+++ b/packages/orbit-components/src/CountryFlag/index.js
@@ -73,7 +73,7 @@ StyledShadow.defaultProps = {
   theme: defaultTheme,
 };
 
-export function getCountryProps(code: ?string, name: ?string): { code: string, name: ?string } {
+export function getCountryProps(code: ?string, name: ?string): {| code: string, name: ?string |} {
   const codeNormalized = code ? code.toUpperCase().replace("-", "_") : "ANYWHERE";
   const countryCodeExists = codeNormalized in CODES;
 

--- a/packages/orbit-components/src/Dictionary/index.js.flow
+++ b/packages/orbit-components/src/Dictionary/index.js.flow
@@ -5,10 +5,10 @@ export type Translations = {
   [key: string]: string,
 };
 
-export type Props = {
+export type Props = {|
   +values: Translations,
   +children: React$Node,
-};
+|};
 
 type WithDictionary<A, B> = (a: React.ComponentType<A>) => React.ComponentType<B>;
 

--- a/packages/orbit-components/src/Drawer/helpers/getPosition.js.flow
+++ b/packages/orbit-components/src/Drawer/helpers/getPosition.js.flow
@@ -4,6 +4,6 @@ import { Interpolation } from "styled-components";
 import type { Position } from "../index";
 import type { Theme } from "../../defaultTheme";
 
-export type GetPosition = ({ position: Position, theme: Theme }) => Interpolation;
+export type GetPosition = ({| position: Position, theme: Theme |}) => Interpolation;
 
 declare export default GetPosition;

--- a/packages/orbit-components/src/Drawer/helpers/getTransitionAnimation.js.flow
+++ b/packages/orbit-components/src/Drawer/helpers/getTransitionAnimation.js.flow
@@ -4,11 +4,11 @@ import { Interpolation } from "styled-components";
 import type { Position } from "../index";
 import type { Theme } from "../../defaultTheme";
 
-export type GetTransitionAnimation = ({
+export type GetTransitionAnimation = ({|
   width: string,
   shown: boolean,
   position: Position,
   theme: Theme,
-}) => Interpolation;
+|}) => Interpolation;
 
 declare export default GetTransitionAnimation;

--- a/packages/orbit-components/src/FormLabel/index.js.flow
+++ b/packages/orbit-components/src/FormLabel/index.js.flow
@@ -1,13 +1,13 @@
 // @flow
 import type { Globals } from "../common/common.js.flow";
 
-export type Props = {
+export type Props = {|
   children: React$Node,
   filled?: boolean,
   disabled?: boolean,
   required?: boolean,
   id?: string,
   ...Globals,
-};
+|};
 
 declare export default React$ComponentType<Props>;

--- a/packages/orbit-components/src/Heading/index.js.flow
+++ b/packages/orbit-components/src/Heading/index.js.flow
@@ -22,7 +22,7 @@ export type Props = {|
   +id?: string,
 |};
 
-export type GetHeadingToken = (name: string) => ({ ...ThemeProps, type: Type }) => string;
+export type GetHeadingToken = (name: string) => ({| ...ThemeProps, type: Type |}) => string;
 
 declare export default React$ComponentType<Props>;
 

--- a/packages/orbit-components/src/Icon/helpers/whiteListProps.js.flow
+++ b/packages/orbit-components/src/Icon/helpers/whiteListProps.js.flow
@@ -13,7 +13,7 @@ type Return = {|
   +ariaLabel?: string,
 |};
 
-type Props = { ...Return };
+type Props = {| ...Return |};
 
 export type WhiteListProps = (props: Props) => any;
 

--- a/packages/orbit-components/src/Icon/index.js.flow
+++ b/packages/orbit-components/src/Icon/index.js.flow
@@ -26,14 +26,14 @@ export type Props = {|
   +ariaLabel?: string,
 |};
 
-export type FactoryProps = {
+export type FactoryProps = {|
   +viewBox: string,
   +children: React.Node,
   ...Props,
-};
+|};
 
 declare export default React.ComponentType<FactoryProps>;
 
-export type GetSize = (size: Size) => ({ theme: typeof defaultTheme }) => string;
+export type GetSize = (size: Size) => ({| theme: typeof defaultTheme |}) => string;
 
 declare export var getSize: GetSize;

--- a/packages/orbit-components/src/InputField/index.js
+++ b/packages/orbit-components/src/InputField/index.js
@@ -281,11 +281,11 @@ const FormLabel = ({
   label,
   isFilled,
   required,
-}: {
+}: {|
   label: Translation,
   isFilled: boolean,
   required?: boolean,
-}) => (
+|}) => (
   <DefaultFormLabel filled={isFilled} required={required}>
     {label}
   </DefaultFormLabel>

--- a/packages/orbit-components/src/InputFile/__examples__/REF.js
+++ b/packages/orbit-components/src/InputFile/__examples__/REF.js
@@ -7,7 +7,7 @@ export default {
   Example: () => {
     const [fileName, setFileName] = React.useState("");
     const fileTypes = ".png,.jpg,.jpeg,.webp";
-    const ref: { current: React$ElementRef<any> } = React.useRef(null);
+    const ref: {| current: React$ElementRef<any> |} = React.useRef(null);
 
     React.useEffect(() => {
       if (ref.current) {

--- a/packages/orbit-components/src/InputStepper/__examples__/REF.js
+++ b/packages/orbit-components/src/InputStepper/__examples__/REF.js
@@ -5,7 +5,7 @@ import InputStepper from "../index";
 
 export default {
   Example: () => {
-    const ref: { current: React$ElementRef<any> } = React.useRef(null);
+    const ref: {| current: React$ElementRef<any> |} = React.useRef(null);
 
     React.useEffect(() => {
       if (ref.current) {

--- a/packages/orbit-components/src/InputStepper/index.d.ts
+++ b/packages/orbit-components/src/InputStepper/index.d.ts
@@ -8,7 +8,7 @@ import * as Common from "../common/common";
 
 declare module "@kiwicom/orbit-components/lib/InputStepper";
 
-type Title = string | ((...params: any[]) => string);
+type Title = string | ((...params: readonly any[]) => string);
 // InputEvent
 export type Event = Common.Event<React.SyntheticEvent<HTMLInputElement>>;
 

--- a/packages/orbit-components/src/List/ListItem/index.js.flow
+++ b/packages/orbit-components/src/List/ListItem/index.js.flow
@@ -17,6 +17,6 @@ declare export default React$ComponentType<Props>;
 declare export var Item: ReactComponentStyled<any>;
 declare export var IconContainer: ReactComponentStyled<any>;
 
-export type GetLineHeightToken = ({ theme: Theme, size: Size }) => string;
+export type GetLineHeightToken = ({| theme: Theme, size: Size |}) => string;
 
 declare export var getLineHeightToken: GetLineHeightToken;

--- a/packages/orbit-components/src/Modal/ModalContext.d.ts
+++ b/packages/orbit-components/src/Modal/ModalContext.d.ts
@@ -21,5 +21,6 @@ export interface Props {
 export const ModalContext: React.Context<Props>;
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type WithModalContextType = <Config extends {}>(
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
   arg0: React.Component<Config>,
 ) => React.Component<Config>;

--- a/packages/orbit-components/src/Modal/ModalContext.js.flow
+++ b/packages/orbit-components/src/Modal/ModalContext.js.flow
@@ -13,7 +13,7 @@ export type ModalContextProps = {|
 
 export type ModalContextType = React.Context<ModalContextProps>;
 
-export type WithModalContextType = <Config: {}>(
+export type WithModalContextType = <Config: {||}>(
   React.AbstractComponent<Config>,
 ) => React.AbstractComponent<Config>;
 

--- a/packages/orbit-components/src/Modal/__examples__/SCROLL_POSITION.js
+++ b/packages/orbit-components/src/Modal/__examples__/SCROLL_POSITION.js
@@ -10,7 +10,7 @@ import ModalHeader from "../ModalHeader";
 export default {
   Example: () => {
     const [showModal, setShowModal] = React.useState(true);
-    const modalRef: { current: React$ElementRef<any> } = React.useRef(null);
+    const modalRef: {| current: React$ElementRef<any> |} = React.useRef(null);
 
     const setScroll = () => {
       if (modalRef.current) {

--- a/packages/orbit-components/src/Modal/index.js
+++ b/packages/orbit-components/src/Modal/index.js
@@ -348,9 +348,9 @@ export class PureModal extends React.PureComponent<Props & ThemeProps, State> {
     hasModalSection: false,
   };
 
-  modalContent: { current: any | HTMLElement } = React.createRef();
+  modalContent: {| current: any | HTMLElement |} = React.createRef();
 
-  modalBody: { current: any | HTMLElement } = React.createRef();
+  modalBody: {| current: any | HTMLElement |} = React.createRef();
 
   offset = 40;
 

--- a/packages/orbit-components/src/PictureCard/index.js
+++ b/packages/orbit-components/src/PictureCard/index.js
@@ -214,7 +214,7 @@ const PictureCard = ({
   width,
   dataTest,
 }: Props) => {
-  const ref: { current: any | HTMLDivElement } = React.useRef(null);
+  const ref: {| current: any | HTMLDivElement |} = React.useRef(null);
   const [contentHeight, setContentHeight] = React.useState(0);
 
   React.useEffect(() => {

--- a/packages/orbit-components/src/Popover/components/ContentWrapper.js
+++ b/packages/orbit-components/src/Popover/components/ContentWrapper.js
@@ -178,8 +178,8 @@ const PopoverContentWrapper = ({
   actions,
 }: Props) => {
   const { isInsideModal } = useContext(ModalContext);
-  const popover: { current: React$ElementRef<*> } = useRef(null);
-  const content: { current: React$ElementRef<*> } = useRef(null);
+  const popover: {| current: React$ElementRef<*> |} = useRef(null);
+  const content: {| current: React$ElementRef<*> |} = useRef(null);
   const intervalRef = useRef(null);
   const position = calculatePopoverPosition(preferredPosition, preferredAlign);
   const scrollableParent = useMemo(() => getScrollableParent(containerRef.current), [containerRef]);

--- a/packages/orbit-components/src/Popover/index.js
+++ b/packages/orbit-components/src/Popover/index.js
@@ -43,7 +43,7 @@ const Popover = ({
     setRenderWithTimeout,
     clearRenderTimeout,
   ] = useStateWithTimeout<boolean>(false, transitionLength);
-  const container: { current: React$ElementRef<*> } = useRef(null);
+  const container: {| current: React$ElementRef<*> |} = useRef(null);
 
   const resolveCallback = useCallback(
     state => {

--- a/packages/orbit-components/src/Radio/__examples__/REF.js
+++ b/packages/orbit-components/src/Radio/__examples__/REF.js
@@ -5,7 +5,7 @@ import Radio from "../index";
 
 export default {
   Example: () => {
-    const ref: { current: React$ElementRef<any> } = React.useRef(null);
+    const ref: {| current: React$ElementRef<any> |} = React.useRef(null);
 
     React.useEffect(() => {
       if (ref.current) {

--- a/packages/orbit-components/src/RatingStars/index.js.flow
+++ b/packages/orbit-components/src/RatingStars/index.js.flow
@@ -5,12 +5,12 @@
 import type { Globals } from "../common/common.js.flow";
 import type { Size } from "../Icon";
 
-export type Props = {
+export type Props = {|
   +rating: number,
   +size?: Size,
   +color?: "primary" | "secondary",
   +showEmpty?: boolean,
   ...Globals,
-};
+|};
 
 declare export default React$ComponentType<Props>;

--- a/packages/orbit-components/src/Select/__examples__/REF.js
+++ b/packages/orbit-components/src/Select/__examples__/REF.js
@@ -5,7 +5,7 @@ import Select from "../index";
 
 export default {
   Example: () => {
-    const ref: { current: React$ElementRef<any> } = React.useRef(null);
+    const ref: {| current: React$ElementRef<any> |} = React.useRef(null);
 
     React.useEffect(() => {
       if (ref.current) {

--- a/packages/orbit-components/src/SkipLink/index.js.flow
+++ b/packages/orbit-components/src/SkipLink/index.js.flow
@@ -6,7 +6,7 @@
 type Actions = {|
   +name: string,
   +href?: string,
-  +onClick?: () => {} | void | Promise<any>,
+  +onClick?: () => {||} | void | Promise<any>,
 |};
 
 export type MappedOptions = {|

--- a/packages/orbit-components/src/SkipNavigation/index.js.flow
+++ b/packages/orbit-components/src/SkipNavigation/index.js.flow
@@ -6,7 +6,7 @@
 type Actions = {|
   +name?: string,
   +link?: string,
-  +onClick?: () => {} | void | Promise<any>,
+  +onClick?: () => {||} | void | Promise<any>,
 |};
 
 export type MappedOptions = {|

--- a/packages/orbit-components/src/Slider/components/Bar/index.js.flow
+++ b/packages/orbit-components/src/Slider/components/Bar/index.js.flow
@@ -19,6 +19,6 @@ export type CalculateBarPosition = (
   max: number,
   min: number,
   hasHistogram: boolean,
-) => { left: number, width: number };
+) => {| left: number, width: number |};
 
 declare export var calculateBarPosition: CalculateBarPosition;

--- a/packages/orbit-components/src/SocialButton/helpers/getSocialButtonIconForeground.js.flow
+++ b/packages/orbit-components/src/SocialButton/helpers/getSocialButtonIconForeground.js.flow
@@ -3,6 +3,6 @@ import type { Type } from "../index";
 import type { ThemeProps } from "../../defaultTheme";
 import type { IconForeground } from "../../primitives/ButtonPrimitive";
 
-export type GetSocialButtonIconForeground = ({ type: Type, ...ThemeProps }) => IconForeground;
+export type GetSocialButtonIconForeground = ({| type: Type, ...ThemeProps |}) => IconForeground;
 
 declare export default GetSocialButtonIconForeground;

--- a/packages/orbit-components/src/SocialButton/helpers/getSocialButtonStyles.js.flow
+++ b/packages/orbit-components/src/SocialButton/helpers/getSocialButtonStyles.js.flow
@@ -3,7 +3,7 @@ import type { Type } from "../index";
 import type { ThemeProps } from "../../defaultTheme";
 import type { Background, BoxShadow, Foreground } from "../../primitives/ButtonPrimitive";
 
-export type GetSocialButtonStyles = ({ type: Type, disabled: boolean, ...ThemeProps }) => {|
+export type GetSocialButtonStyles = ({| type: Type, disabled: boolean, ...ThemeProps |}) => {|
   ...Background,
   ...Foreground,
   ...BoxShadow,

--- a/packages/orbit-components/src/SocialButton/index.js.flow
+++ b/packages/orbit-components/src/SocialButton/index.js.flow
@@ -12,7 +12,7 @@ export type Props = {|
   +type?: Type,
   ...$Diff<
     ButtonCommonProps,
-    { +iconLeft?: React.Node, +iconRight?: React.Node, +circled?: boolean },
+    {| +iconLeft?: React.Node, +iconRight?: React.Node, +circled?: boolean |},
   >,
 |};
 

--- a/packages/orbit-components/src/Stack/helpers/getChildrenMargin.js.flow
+++ b/packages/orbit-components/src/Stack/helpers/getChildrenMargin.js.flow
@@ -8,6 +8,6 @@ export type GetChildrenMargin = ({|
   viewport: Devices,
   index: number,
   devices: Devices[],
-|}) => ({ ...Props, ...SmallMobile }) => Interpolation | boolean;
+|}) => ({| ...Props, ...SmallMobile |}) => Interpolation | boolean;
 
 declare export default GetChildrenMargin;

--- a/packages/orbit-components/src/Stack/helpers/getProperty.js.flow
+++ b/packages/orbit-components/src/Stack/helpers/getProperty.js.flow
@@ -5,7 +5,7 @@ import type { Devices } from "../../utils/mediaQuery/consts";
 export type GetProperty = (
   property: "spacing" | "direction",
   {| index: number, devices: Devices[] |},
-  { ...Props, ...SmallMobile },
+  {| ...Props, ...SmallMobile |},
 ) => ?Direction | ?Spacing;
 
 declare export default GetProperty;

--- a/packages/orbit-components/src/Sticky/index.js
+++ b/packages/orbit-components/src/Sticky/index.js
@@ -32,13 +32,13 @@ class Sticky extends React.Component<Props, State> {
     width: 0,
   };
 
-  content: {
+  content: {|
     current: any | HTMLDivElement,
-  } = React.createRef();
+  |} = React.createRef();
 
-  sticky: {
+  sticky: {|
     current: any | HTMLDivElement,
-  } = React.createRef();
+  |} = React.createRef();
 
   componentDidMount() {
     this.handleTop();

--- a/packages/orbit-components/src/Table/index.js
+++ b/packages/orbit-components/src/Table/index.js
@@ -106,9 +106,9 @@ const Table = ({
   const [right, setRight] = React.useState(false);
   const [left, setLeft] = React.useState(false);
 
-  const outer: { current: any | HTMLElement } = React.useRef(null);
-  const inner: { current: any | HTMLElement } = React.useRef(null);
-  const table: { current: any | HTMLElement } = React.useRef(null);
+  const outer: {| current: any | HTMLElement |} = React.useRef(null);
+  const inner: {| current: any | HTMLElement |} = React.useRef(null);
+  const table: {| current: any | HTMLElement |} = React.useRef(null);
 
   const handleScroll = () => {
     if (shadows && inner && table && outer) {

--- a/packages/orbit-components/src/TextLink/index.js.flow
+++ b/packages/orbit-components/src/TextLink/index.js.flow
@@ -32,11 +32,11 @@ export type Props = {|
   ...Globals,
 |};
 
-export type GetLinkStyleProps = {
+export type GetLinkStyleProps = {|
   type: Type,
   noUnderline?: boolean,
   ...ThemeProps,
-};
+|};
 
 export type GetLinkStyle = GetLinkStyleProps => Interpolation[];
 

--- a/packages/orbit-components/src/Textarea/__examples__/REF.js
+++ b/packages/orbit-components/src/Textarea/__examples__/REF.js
@@ -5,7 +5,7 @@ import Textarea from "../index";
 
 export default {
   Example: () => {
-    const ref: { current: React$ElementRef<any> } = React.useRef(null);
+    const ref: {| current: React$ElementRef<any> |} = React.useRef(null);
 
     React.useEffect(() => {
       if (ref.current) {

--- a/packages/orbit-components/src/ThemeProvider/ThemeProvider.stories.js
+++ b/packages/orbit-components/src/ThemeProvider/ThemeProvider.stories.js
@@ -72,7 +72,7 @@ storiesOf("ThemeProvider", module)
       });
       const customTheme = object("customTheme", { black: "#000" });
       return (
-        <ThemeProvider theme={{ orbit: getTokens(orbitTheme), customTheme }}>
+        <ThemeProvider theme={{ orbit: { ...getTokens(orbitTheme), ...customTheme } }}>
           <Button onClick={action("onClick")}>Hello World!</Button>
         </ThemeProvider>
       );

--- a/packages/orbit-components/src/ThemeProvider/index.js.flow
+++ b/packages/orbit-components/src/ThemeProvider/index.js.flow
@@ -7,7 +7,7 @@ import type { Translations } from "../Dictionary";
 import type { Theme } from "../defaultTheme";
 
 export type Props = {|
-  +theme: { ...Theme }, // allow other sub objects with spread
+  +theme: {| ...Theme |}, // allow other sub objects with spread
   +dictionary?: Translations,
   +children: React$Node,
 |};

--- a/packages/orbit-components/src/Timeline/TimelineContext.js
+++ b/packages/orbit-components/src/Timeline/TimelineContext.js
@@ -13,7 +13,7 @@ export const TimelineStepContext: React.Context<StepContext> = React.createConte
   last: false,
 });
 
-export const TimelineStatusProvider = ({ children }: { children: React.Node }) => {
+export const TimelineStatusProvider = ({ children }: {| children: React.Node |}) => {
   const [types, setTypes] = React.useState({});
 
   return (

--- a/packages/orbit-components/src/Timeline/TimelineContext.js.flow
+++ b/packages/orbit-components/src/Timeline/TimelineContext.js.flow
@@ -15,7 +15,7 @@ export type StepContext = {|
   +last: boolean,
 |};
 
-declare export var TimelineStatusProvider: React.ComponentType<{ children: React.Node }>;
+declare export var TimelineStatusProvider: React.ComponentType<{| children: React.Node |}>;
 declare export var TimelineStepContext: React.Context<StepContext>;
 declare export function useStatuses(): Context;
 declare export function useStep(): StepContext;

--- a/packages/orbit-components/src/Translate/index.js.flow
+++ b/packages/orbit-components/src/Translate/index.js.flow
@@ -15,9 +15,9 @@ export type Props = {|
 
 export type PureTranslate = (dictionary: Translations, key: Key, values?: Values) => string;
 
-export type Translate = {
+export type Translate = {|
   translate: (tKey: string, values?: Values) => string,
-};
+|};
 
 declare export default React$ComponentType<Props>;
 

--- a/packages/orbit-components/src/common/common.js.flow
+++ b/packages/orbit-components/src/common/common.js.flow
@@ -1,3 +1,5 @@
+/* eslint-disable flowtype/require-exact-type  */
+/* we disable it because the RefType does not need to be exact or is incompatible with the React ref */
 // @flow
 
 export type Globals = {|

--- a/packages/orbit-components/src/deprecated/DestinationCard/index.js
+++ b/packages/orbit-components/src/deprecated/DestinationCard/index.js
@@ -175,7 +175,7 @@ class DestinationCard extends React.PureComponent<Props, State> {
     hiddenContentHeight: 0,
   };
 
-  hiddenContent: { current: any | HTMLDivElement } = React.createRef();
+  hiddenContent: {| current: any | HTMLDivElement |} = React.createRef();
 
   cardID: string = randomID("destinationCardID");
 

--- a/packages/orbit-components/src/deprecated/Tile/TileExpandable/index.js
+++ b/packages/orbit-components/src/deprecated/Tile/TileExpandable/index.js
@@ -33,7 +33,7 @@ StyledTileExpandable.defaultProps = {
 class TileExpandable extends React.PureComponent<Props, State> {
   timeout: TimeoutID;
 
-  node: { current: any | HTMLDivElement };
+  node: {| current: any | HTMLDivElement |};
 
   constructor(props: Props) {
     super(props);

--- a/packages/orbit-components/src/deprecated/Tile/TileExpandable/index.js.flow
+++ b/packages/orbit-components/src/deprecated/Tile/TileExpandable/index.js.flow
@@ -4,10 +4,10 @@ export type State = {|
   contentHeight: number,
 |};
 
-export type Props = {
+export type Props = {|
   +expanded?: boolean,
   +initialExpanded?: boolean,
   +children: React$Node,
-};
+|};
 
 declare export default React$ComponentType<Props>;

--- a/packages/orbit-components/src/deprecated/Tile/TileHeader/index.js.flow
+++ b/packages/orbit-components/src/deprecated/Tile/TileHeader/index.js.flow
@@ -2,7 +2,7 @@
 
 import type { ReactComponentStyled } from "styled-components";
 
-export type Props = {
+export type Props = {|
   +icon?: React$Node,
   +title?: React$Node,
   +description?: React$Node,
@@ -10,13 +10,13 @@ export type Props = {
   +onClick?: (ev: SyntheticEvent<HTMLDivElement>) => void,
   +isExpandable?: boolean,
   +isExpanded?: boolean,
-};
+|};
 
-export type IconRightProps = {
+export type IconRightProps = {|
   external?: boolean,
   isExpandable?: boolean,
   isExpanded?: boolean,
-};
+|};
 
 declare export var StyledIconRight: ReactComponentStyled<IconRightProps>;
 

--- a/packages/orbit-components/src/deprecated/Tile/index.js.flow
+++ b/packages/orbit-components/src/deprecated/Tile/index.js.flow
@@ -4,10 +4,10 @@
 */
 import type { Globals } from "../../common/common.js.flow";
 
-export type State = {
+export type State = {|
   expanded?: boolean,
   initialExpanded?: boolean,
-};
+|};
 
 export type Props = {|
   +title?: React$Node,

--- a/packages/orbit-components/src/hooks/useBoundingRect/index.js.flow
+++ b/packages/orbit-components/src/hooks/useBoundingRect/index.js.flow
@@ -1,5 +1,5 @@
 // @flow
-export type Dimensions = {
+export type Dimensions = {|
   x: ?number,
   y: ?number,
   width: ?number,
@@ -8,10 +8,10 @@ export type Dimensions = {
   right: ?number,
   bottom: ?number,
   left: ?number,
-};
+|};
 
 export type UseBoundingRect = (
   initialValue: ?$Shape<Dimensions>,
-) => [Dimensions, { current: ?HTMLElement }];
+) => [Dimensions, {| current: ?HTMLElement |}];
 
 declare export default UseBoundingRect;

--- a/packages/orbit-components/src/hooks/useClickOutside/index.d.ts
+++ b/packages/orbit-components/src/hooks/useClickOutside/index.d.ts
@@ -1,8 +1,8 @@
 // @flow
-import * as Common from "../../common/common";
 
 declare const UseClickOutside: (
-  ref: { current: HTMLElement | null | undefined },
+  ref: { readonly current: HTMLElement | null | undefined },
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
   handler: (ev: React.SyntheticEvent<HTMLLinkElement>) => void,
 ) => void;
 

--- a/packages/orbit-components/src/hooks/useClickOutside/index.js.flow
+++ b/packages/orbit-components/src/hooks/useClickOutside/index.js.flow
@@ -1,6 +1,6 @@
 // @flow
 export type UseClickOutside = (
-  ref: { current: ?HTMLElement },
+  ref: {| current: ?HTMLElement |},
   handler: (ev: SyntheticEvent<HTMLElement>) => void,
 ) => void;
 

--- a/packages/orbit-components/src/hooks/useFocusTrap/index.d.ts
+++ b/packages/orbit-components/src/hooks/useFocusTrap/index.d.ts
@@ -1,3 +1,3 @@
-declare const useFocusTrap: (ref: { current: HTMLElement | undefined | null }) => void;
+declare const useFocusTrap: (ref: { readonly current: HTMLElement | undefined | null }) => void;
 
 export { useFocusTrap, useFocusTrap as default };

--- a/packages/orbit-components/src/hooks/useFocusTrap/index.js.flow
+++ b/packages/orbit-components/src/hooks/useFocusTrap/index.js.flow
@@ -1,4 +1,4 @@
 // @flow
-export type UseFocusTrap = (ref: { current: ?HTMLElement }) => void;
+export type UseFocusTrap = (ref: {| current: ?HTMLElement |}) => void;
 
 declare export default UseFocusTrap;

--- a/packages/orbit-components/src/hooks/useIntersect/index.js.flow
+++ b/packages/orbit-components/src/hooks/useIntersect/index.js.flow
@@ -4,6 +4,6 @@ type SetAction<S> = S | ((prevState: S) => S);
 
 export type useIntersect = (
   intersect?: IntersectionObserverOptions,
-) => { ref: Dispatch<SetAction<null | Element>> | null, entry: IntersectionObserverEntry | null };
+) => {| ref: Dispatch<SetAction<null | Element>> | null, entry: IntersectionObserverEntry | null |};
 
 declare export default useIntersect;

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/common/createRel.js.flow
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/common/createRel.js.flow
@@ -1,8 +1,8 @@
 // @flow
-export type CreateRel = ({
+export type CreateRel = ({|
   +href?: string,
   +rel?: string,
   +external?: boolean,
-}) => ?string;
+|}) => ?string;
 
 declare export default CreateRel;

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/common/getCommonProps.js.flow
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/common/getCommonProps.js.flow
@@ -1,3 +1,5 @@
+/* eslint-disable flowtype/require-exact-type */
+
 // @flow
 import * as React from "react";
 

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/common/getIconContainer.js.flow
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/common/getIconContainer.js.flow
@@ -1,3 +1,4 @@
+/* eslint-disable flowtype/require-exact-type */
 // @flow
 import * as React from "react";
 

--- a/packages/orbit-components/src/primitives/IllustrationPrimitive/IllustrationPrimitiveList.js
+++ b/packages/orbit-components/src/primitives/IllustrationPrimitive/IllustrationPrimitiveList.js
@@ -60,7 +60,7 @@ IllustrationJSX.defaultProps = {
   theme: defaultTheme,
 };
 
-const IllustrationPrimitiveList = (props: { images: Array<string>, nameOfComponent: string }) => {
+const IllustrationPrimitiveList = (props: {| images: Array<string>, nameOfComponent: string |}) => {
   return (
     <List>
       {props.images.map(illustration => {

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/resolveContainerAlign.js.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/resolveContainerAlign.js.flow
@@ -3,11 +3,11 @@ import type { Interpolation } from "styled-components";
 
 import type { Align, Dimensions, Position } from "../index";
 
-export type Props = {
+export type Props = {|
   ...Dimensions,
   ...Align,
   ...Position,
-};
+|};
 
 type ResolveContainerAlign = Props => Interpolation[] | null;
 

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/resolveContainerPosition.js.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/resolveContainerPosition.js.flow
@@ -4,11 +4,11 @@ import type { Interpolation } from "styled-components";
 import type { Dimensions, Position } from "../index";
 import type { ThemeProps } from "../../../defaultTheme";
 
-export type Props = {
+export type Props = {|
   ...Dimensions,
   ...Position,
   ...ThemeProps,
-};
+|};
 
 type ResolveContainerPosition = Props => Interpolation[] | null;
 

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/resolveTooltipArrowAlign.js.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/resolveTooltipArrowAlign.js.flow
@@ -3,11 +3,11 @@ import type { Interpolation } from "styled-components";
 
 import type { Align, Dimensions, Position } from "../index";
 
-export type Props = {
+export type Props = {|
   ...Dimensions,
   ...Align,
   ...Position,
-};
+|};
 
 type ResolveTooltipArrowAlign = Props => Interpolation[] | null;
 

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/resolveTooltipArrowPosition.js.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/resolveTooltipArrowPosition.js.flow
@@ -3,9 +3,9 @@ import type { Interpolation } from "styled-components";
 
 import type { Position } from "../index";
 
-export type Props = {
+export type Props = {|
   ...Position,
-};
+|};
 
 type ResolveTooltipArrowPosition = Props => Interpolation[];
 

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/tooltipArrowStyle.js.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/tooltipArrowStyle.js.flow
@@ -4,10 +4,10 @@ import type { Interpolation } from "styled-components";
 import type { Position } from "../index";
 import type { ThemeProps } from "../../../defaultTheme";
 
-export type Props = {
+export type Props = {|
   ...Position,
   ...ThemeProps,
-};
+|};
 
 type TooltipArrowStyle = Props => Interpolation[];
 

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/tooltipPadding.js.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/tooltipPadding.js.flow
@@ -2,10 +2,10 @@
 import type { ThemeProps } from "../../../defaultTheme";
 import type { Dimensions } from "../index";
 
-export type Props = {
+export type Props = {|
   ...Dimensions,
   ...ThemeProps,
-};
+|};
 
 type TooltipPadding = Props => string;
 

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/tooltipSize.js.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/tooltipSize.js.flow
@@ -2,9 +2,9 @@
 
 import type { Size } from "../index";
 
-export type Props = {
+export type Props = {|
   ...Size,
-};
+|};
 
 type TooltipSize = Props => string;
 

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/hooks/useDimensions.js.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/hooks/useDimensions.js.flow
@@ -4,11 +4,11 @@ import * as React from "react";
 import type { Dimensions } from "../index";
 
 export type UseDimensions = (
-  {
+  {|
     containerRef: ?React.ElementRef<*>,
     tooltip: ?React.ElementRef<*>,
     content: ?React.ElementRef<*>,
-  },
+  |},
   children: React.Node,
   parent: ?React.Node,
 ) => Dimensions;

--- a/packages/orbit-components/src/utils/Grid/helpers/getProperty.js.flow
+++ b/packages/orbit-components/src/utils/Grid/helpers/getProperty.js.flow
@@ -5,7 +5,7 @@ import type { Devices } from "../../mediaQuery/consts";
 export type GetProperty = (
   property: "rows" | "columns" | "gap" | "rowGap" | "columnGap",
   {| index: number, devices: Devices[] |},
-  { ...Props, ...SmallMobile },
+  {| ...Props, ...SmallMobile |},
 ) => ?string;
 
 declare export default GetProperty;

--- a/packages/orbit-components/src/utils/Grid/helpers/getViewportGridStyles.js.flow
+++ b/packages/orbit-components/src/utils/Grid/helpers/getViewportGridStyles.js.flow
@@ -4,9 +4,13 @@ import type { Interpolation } from "styled-components";
 import type { Devices } from "../../mediaQuery/consts";
 import type { Props, SmallMobile } from "../index";
 
-export type GetViewportGridStyles = ({ viewport: Devices, index: number, devices: Devices[] }) => ({
+export type GetViewportGridStyles = ({|
+  viewport: Devices,
+  index: number,
+  devices: Devices[],
+|}) => ({|
   ...Props,
   ...SmallMobile,
-}) => Interpolation[] | boolean;
+|}) => Interpolation[] | boolean;
 
 declare export default GetViewportGridStyles;

--- a/packages/orbit-components/src/utils/Grid/helpers/getViewportIEGridStyles.js.flow
+++ b/packages/orbit-components/src/utils/Grid/helpers/getViewportIEGridStyles.js.flow
@@ -7,8 +7,8 @@ import type { Props, SmallMobile, BasicProps } from "../index";
 export type GetViewportIEGridStyles = (
   mediaQuery: BasicProps,
   childrenCount: number,
-  { index: number, devices: Devices[] },
-  { ...Props, ...SmallMobile },
+  {| index: number, devices: Devices[] |},
+  {| ...Props, ...SmallMobile |},
 ) => Interpolation[] | boolean;
 
 declare export default GetViewportIEGridStyles;

--- a/packages/orbit-components/src/utils/Grid/index.js.flow
+++ b/packages/orbit-components/src/utils/Grid/index.js.flow
@@ -17,7 +17,7 @@ export type MediaQuery = {|
   ...BasicProps,
 |};
 
-export type Props = {
+export type Props = {|
   ...BasicProps,
   ...Globals,
   +as?: string,
@@ -27,7 +27,7 @@ export type Props = {
   +desktop?: MediaQuery,
   +largeDesktop?: MediaQuery,
   +children: React$Node,
-};
+|};
 
 export type SmallMobile = {|
   +smallMobile: MediaQuery,

--- a/packages/orbit-components/src/utils/boundingClientRect/index.js.flow
+++ b/packages/orbit-components/src/utils/boundingClientRect/index.js.flow
@@ -12,6 +12,6 @@ type Dimensions = {|
   pureBottom: number,
 |};
 
-export type BoundingClientRect = (ref: ?{ current: ?HTMLElement }) => ?Dimensions;
+export type BoundingClientRect = (ref: ?{| current: ?HTMLElement |}) => ?Dimensions;
 
 declare export default BoundingClientRect;

--- a/packages/orbit-components/src/utils/mediaQuery/consts.js.flow
+++ b/packages/orbit-components/src/utils/mediaQuery/consts.js.flow
@@ -9,10 +9,10 @@ export type Devices =
 
 declare export var DEVICES: Devices[];
 
-declare export var QUERIES: {
+declare export var QUERIES: {|
   LARGEDESKTOP: "largeDesktop",
   DESKTOP: "desktop",
   TABLET: "tablet",
   LARGEMOBILE: "largeMobile",
   MEDIUMMOBILE: "mediumMobile",
-};
+|};

--- a/packages/orbit-components/src/utils/rtl/index.js.flow
+++ b/packages/orbit-components/src/utils/rtl/index.js.flow
@@ -1,15 +1,15 @@
 // @flow
 import type { ThemeProps } from "../../defaultTheme";
 
-export type LeftToRight = <T1, T2>(left: T1, right: T2) => ({ ...ThemeProps }) => T1 | T2;
+export type LeftToRight = <T1, T2>(left: T1, right: T2) => ({| ...ThemeProps |}) => T1 | T2;
 
-export type RtlSpacing = (value: string) => ({ ...ThemeProps }) => string;
+export type RtlSpacing = (value: string) => ({| ...ThemeProps |}) => string;
 
-export type BorderRadius = (value: string) => ({ ...ThemeProps }) => string;
+export type BorderRadius = (value: string) => ({| ...ThemeProps |}) => string;
 
-export type TextAlign = (value: "left" | "right") => ({ ...ThemeProps }) => string | LeftToRight;
+export type TextAlign = (value: "left" | "right") => ({| ...ThemeProps |}) => string | LeftToRight;
 
-export type Translate3d = (value: string) => ({ ...ThemeProps }) => string;
+export type Translate3d = (value: string) => ({| ...ThemeProps |}) => string;
 
 declare export var rtlSpacing: RtlSpacing;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1977,6 +1977,22 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@eslint/eslintrc@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.3.tgz#7d1a2b2358552cc04834c0979bd4275362e37085"
+  integrity sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    lodash "^4.17.19"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"
@@ -4547,10 +4563,15 @@ acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.1.1, acorn@^7.3.1:
+acorn@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
+
+acorn@^7.4.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
@@ -6106,7 +6127,6 @@ chokidar@^3.4.0:
 
 "chokidarAt2@https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz":
   version "2.1.8"
-  uid "804b3a7b6a99358c3c5c61e71d8728f041cff917"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   dependencies:
     anymatch "^2.0.0"
@@ -8143,12 +8163,20 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.0.0, eslint-scope@^5.1.0:
+eslint-scope@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
   integrity sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
   dependencies:
     esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
 eslint-utils@^2.0.0, eslint-utils@^2.1.0:
@@ -8169,21 +8197,22 @@ eslint-visitor-keys@^2.0.0:
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.7.0.tgz#18beba51411927c4b64da0a8ceadefe4030d6073"
-  integrity sha512-1KUxLzos0ZVsyL81PnRN335nDtQ8/vZUD6uMtWbF+5zDtjKcsklIi78XoE0MVL93QvWTu+E5y44VyyCsOMBrIg==
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.11.0.tgz#aaf2d23a0b5f1d652a08edacea0c19f7fadc0b3b"
+  integrity sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
+    "@eslint/eslintrc" "^0.1.3"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
     debug "^4.0.1"
     doctrine "^3.0.0"
     enquirer "^2.3.5"
-    eslint-scope "^5.1.0"
+    eslint-scope "^5.1.1"
     eslint-utils "^2.1.0"
-    eslint-visitor-keys "^1.3.0"
-    espree "^7.2.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.0"
     esquery "^1.2.0"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
@@ -8210,12 +8239,12 @@ eslint@^7.7.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.2.0.tgz#1c263d5b513dbad0ac30c4991b93ac354e948d69"
-  integrity sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==
+espree@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.0.tgz#dc30437cf67947cf576121ebd780f15eeac72348"
+  integrity sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==
   dependencies:
-    acorn "^7.3.1"
+    acorn "^7.4.0"
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.3.0"
 
@@ -8238,6 +8267,13 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+  dependencies:
+    estraverse "^5.2.0"
+
 estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
@@ -8247,6 +8283,11 @@ estraverse@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
   integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+
+estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -15945,7 +15986,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^3.1.0:
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==


### PR DESCRIPTION
Adds rules for enforcing `readonly` and `exact` types on Typescript and Flow

`prefer-readonly-parameter-types` throws a `Maximum Call Stack Exceeded` error on `MediaQuery.d.ts` ... this has been reported previously on https://github.com/typescript-eslint/typescript-eslint/issues/1665 but was fixed.. something wrong happening with the version

We are not using that many parameters anyways... Also, they were some weird interactions with some third party library types (styled-components, react...) and some of our types, so had to disable some flow rule in a couple of files