### PR TITLE
feat(Grid): add width property

### DIFF
--- a/packages/orbit-components/src/utils/Grid/Grid.stories.js
+++ b/packages/orbit-components/src/utils/Grid/Grid.stories.js
@@ -13,6 +13,7 @@ const CustomDiv = styled.div`
 storiesOf("Grid", module).add("Playground", () => {
   const inline = boolean("inline", false);
   const maxWidth = text("maxWidth", "1440px");
+  const width = text("width", "100%");
   const columns = text("columns", undefined);
   const rows = text("rows", "repeat(8, 40px)");
   const gap = text("gap", null);
@@ -45,6 +46,7 @@ storiesOf("Grid", module).add("Playground", () => {
     <Grid
       inline={inline}
       maxWidth={maxWidth}
+      width={width}
       columns={columns}
       rows={rows}
       gap={gap}

--- a/packages/orbit-components/src/utils/Grid/README.md
+++ b/packages/orbit-components/src/utils/Grid/README.md
@@ -40,6 +40,7 @@ The table below contains all of the props available in the Grid component.
 | mediumMobile | [`Object`](#media-queries) |         | Object for setting up properties for mediumMobile viewports. [See Media queries](#media-queries)  |
 | rows         | `string`                   | `"1fr"` | Property alias for `grid-template-rows`, [see known limitations](#known-template-limitations).    |
 | rowGap       | `string`                   |         | The gap size for `rows`.                                                                          |
+| width        | `string`                   |         | Alias for the `width` property of the Grid component.                                             |
 
 ### Media Queries
 
@@ -56,6 +57,7 @@ All of the object for these properties have the same properties and none is requ
 | maxWidth  | `string`  |          | Alias for the `max-width` property of the Grid component.                                         |
 | rows      | `string`  | `"none"` | Property alias for `grid-template-rows`, [see known limitations](#known-template-limitations).    |
 | rowGap    | `string`  |          | Gap size for `rows`.                                                                              |
+| width     | `string`  |          | Alias for the `width` property of the Grid component.                                             |
 
 ## Why you should use this component
 

--- a/packages/orbit-components/src/utils/Grid/__tests__/index.test.js
+++ b/packages/orbit-components/src/utils/Grid/__tests__/index.test.js
@@ -10,6 +10,7 @@ import Grid from "..";
 describe("Grid with basic props", () => {
   const inline = true;
   const maxWidth = "1440px";
+  const width = "100%";
   const columns = "repeat(2, 1fr)";
   const columnGap = "10px";
   const rows = "repeat(2, minmax(30px, 100px))";
@@ -19,6 +20,7 @@ describe("Grid with basic props", () => {
     <Grid
       inline={inline}
       maxWidth={maxWidth}
+      width={width}
       columns={columns}
       columnGap={columnGap}
       rows={rows}
@@ -45,6 +47,7 @@ describe("Grid with basic props", () => {
      */
     expect(grid).toHaveStyleRule("display", "-ms-inline-grid");
     expect(grid).toHaveStyleRule("max-width", "1440px");
+    expect(grid).toHaveStyleRule("width", "100%");
     expect(grid).toHaveStyleRule("grid-template-columns", "repeat(2,1fr)");
     expect(grid).toHaveStyleRule("grid-template-rows", "repeat(2,minmax(30px,100px))");
     expect(grid).toHaveStyleRule("grid-row-gap", "20px");
@@ -94,6 +97,7 @@ describe("Grid with mediaQueries", () => {
     columns: "1fr 1fr",
     rows: "1fr 1fr",
     columnGap: "20px",
+    width: "100%",
   };
   const tablet = {
     gap: "20px",
@@ -221,6 +225,9 @@ describe("Grid with mediaQueries", () => {
       media: getBreakpointWidth(QUERIES.LARGEMOBILE, theme),
     });
     expect(grid).toHaveStyleRule("-ms-grid-rows", "1fr 1fr", {
+      media: getBreakpointWidth(QUERIES.LARGEMOBILE, theme),
+    });
+    expect(grid).toHaveStyleRule("width", "100%", {
       media: getBreakpointWidth(QUERIES.LARGEMOBILE, theme),
     });
   });

--- a/packages/orbit-components/src/utils/Grid/helpers/getViewportGridStyles.js
+++ b/packages/orbit-components/src/utils/Grid/helpers/getViewportGridStyles.js
@@ -12,7 +12,7 @@ import type { GetViewportGridStyles } from "./getViewportGridStyles";
  */
 const getViewportGridStyles: GetViewportGridStyles = ({ viewport, index, devices }) => props => {
   if (props[viewport]) {
-    const { inline, maxWidth, gap, columnGap, rowGap, rows, columns } = props[viewport];
+    const { inline, maxWidth, gap, columnGap, rowGap, rows, columns, width } = props[viewport];
     const compatibleIE = getViewportIEGridStyles(
       props[viewport],
       React.Children.count(props.children),
@@ -22,6 +22,7 @@ const getViewportGridStyles: GetViewportGridStyles = ({ viewport, index, devices
     return css`
       ${getDisplay(inline, viewport === "smallMobile")};
       max-width: ${maxWidth};
+      width: ${width};
       grid-template-columns: ${columns};
       grid-template-rows: ${rows};
       grid-column-gap: ${columnGap};

--- a/packages/orbit-components/src/utils/Grid/index.d.ts
+++ b/packages/orbit-components/src/utils/Grid/index.d.ts
@@ -16,6 +16,7 @@ export type BasicProps = {
   readonly rowGap?: string;
   readonly columnGap?: string;
   readonly maxWidth?: string;
+  readonly width?: string;
 };
 
 interface Props extends Common.Global, BasicProps {

--- a/packages/orbit-components/src/utils/Grid/index.js
+++ b/packages/orbit-components/src/utils/Grid/index.js
@@ -48,12 +48,13 @@ const Grid = ({
   rowGap,
   columnGap,
   maxWidth,
+  width,
   children,
   dataTest,
   as = "div",
   ...props
 }: Props) => {
-  const smallMobile = { inline, rows, columns, gap, rowGap, columnGap, maxWidth };
+  const smallMobile = { inline, rows, columns, gap, rowGap, columnGap, maxWidth, width };
   return (
     <StyledGrid {...props} smallMobile={smallMobile} data-test={dataTest} as={as}>
       {children}

--- a/packages/orbit-components/src/utils/Grid/index.js.flow
+++ b/packages/orbit-components/src/utils/Grid/index.js.flow
@@ -10,6 +10,7 @@ export type BasicProps = {|
   +rowGap?: string,
   +columnGap?: string,
   +maxWidth?: string,
+  +width?: string,
 |};
 
 export type MediaQuery = {|


### PR DESCRIPTION
Added `width` property so developers can provide the container needed width in their use case. This property was also added to MediaQuery object.<br/><br/><br/><url>LiveURL: https://orbit-feat-grid-width.surge.sh</url>