### PR TITLE
feat(Types): expose enum types from ts/flow definitions of components

### DIFF
--- a/packages/orbit-components/src/Alert/README.md
+++ b/packages/orbit-components/src/Alert/README.md
@@ -37,6 +37,15 @@ The table below contains all types of the props available in Alert component.
 | `"warning"`  |
 | `"critical"` |
 
+### Types
+
+You can import the `Type` `enum` as a type from the component definition
+
+```js
+import type { Type } from "@kiwicom/orbit-components/lib/Alert"; // Flow
+import { Type } from "@kiwicom/orbit-components/lib/Alert"; // TS
+```
+
 ## Functional specs
 
 - By passing the `closable` prop into Alert, you will be able to handle `onClose` function and Close icon will be displayed. Also, if you want to select the Close Button element for testing purposes, use [data-test="AlertCloseButton"] selector.

--- a/packages/orbit-components/src/Alert/index.d.ts
+++ b/packages/orbit-components/src/Alert/index.d.ts
@@ -7,9 +7,9 @@ import * as React from "react";
 import * as Common from "../common/common";
 import AlertButton from "./AlertButton";
 
-type Type = "info" | "success" | "warning" | "critical";
-
 declare module "@kiwicom/orbit-components/lib/Alert";
+
+export type Type = "info" | "success" | "warning" | "critical";
 
 export interface Props extends Common.Global, Common.SpaceAfter {
   readonly type?: Type;

--- a/packages/orbit-components/src/Alert/index.js.flow
+++ b/packages/orbit-components/src/Alert/index.js.flow
@@ -8,7 +8,7 @@ import type { spaceAfter } from "../common/getSpacingToken/index";
 import type { Globals, Translation } from "../common/common.js.flow";
 import type { Props as AlertButtonProps } from "./AlertButton";
 
-type Type = "info" | "success" | "warning" | "critical";
+export type Type = "info" | "success" | "warning" | "critical";
 
 export type Props = {|
   +type?: Type,

--- a/packages/orbit-components/src/Badge/README.md
+++ b/packages/orbit-components/src/Badge/README.md
@@ -39,6 +39,15 @@ Table below contains all types of the props available in Badge component.
 | `"successInverted"`  |
 | `"warningInverted"`  |
 
+### Types
+
+You can import the `Type` `enum` as a type from the component definition
+
+```js
+import type { Type } from "@kiwicom/orbit-components/lib/Badge"; // Flow
+import { Type } from "@kiwicom/orbit-components/lib/Badge"; // TS
+```
+
 ## Functional specs
 
 - If you want to use `circled` badge, please take a look on **NotificationBadge**.

--- a/packages/orbit-components/src/Button/README.md
+++ b/packages/orbit-components/src/Button/README.md
@@ -54,6 +54,15 @@ Table below contains all types of the props available in Button component.
 | `"primarySubtle"`  |            |
 | `"criticalSubtle"` |            |
 
+### Types
+
+You can import the `Type` `enum` as types from the component definition
+
+```js
+import type { Type } from "@kiwicom/orbit-components/lib/Button"; // Flow
+import { Type } from "@kiwicom/orbit-components/lib/Button"; // TS
+```
+
 ## Functional specs
 
 - When the `external` is specified, `noopener` and `noreferrer` values will automatically added to attribute `rel` for security reason.

--- a/packages/orbit-components/src/Button/index.d.ts
+++ b/packages/orbit-components/src/Button/index.d.ts
@@ -8,7 +8,13 @@ import { ButtonCommonProps } from "../primitives/ButtonPrimitive/index";
 
 declare module "@kiwicom/orbit-components/lib/Button";
 
-type Type = "primary" | "secondary" | "critical" | "primarySubtle" | "criticalSubtle" | "white";
+export type Type =
+  | "primary"
+  | "secondary"
+  | "critical"
+  | "primarySubtle"
+  | "criticalSubtle"
+  | "white";
 
 export interface Props extends ButtonCommonProps {
   readonly type?: Type;

--- a/packages/orbit-components/src/ButtonLink/README.md
+++ b/packages/orbit-components/src/ButtonLink/README.md
@@ -52,6 +52,15 @@ Table below contains all types of the props available in ButtonLink component.
 | `"critical"`  | `"large"`  |
 | `"inline"`    |            |
 
+### Types
+
+You can import the `Type` `enum` as a type from the component definition
+
+```js
+import type { Type } from "@kiwicom/orbit-components/lib/ButtonLink"; // Flow
+import { Type } from "@kiwicom/orbit-components/lib/ButtonLink"; // TS
+```
+
 ## Functional specs
 
 - When the `external` is specified, `noopener` and `noreferrer` values will automatically added to attribute `rel` for security reason.

--- a/packages/orbit-components/src/ButtonLink/index.d.ts
+++ b/packages/orbit-components/src/ButtonLink/index.d.ts
@@ -9,7 +9,7 @@ import { ButtonCommonProps } from "../primitives/ButtonPrimitive/index";
 
 declare module "@kiwicom/orbit-components/lib/ButtonLink";
 
-type Type = "primary" | "secondary" | "critical" | "inline";
+export type Type = "primary" | "secondary" | "critical" | "inline";
 
 export interface Props extends Common.Global, Common.Ref, Common.SpaceAfter, ButtonCommonProps {
   readonly compact?: boolean;

--- a/packages/orbit-components/src/Illustration/FLOW_TEMPLATE.flow
+++ b/packages/orbit-components/src/Illustration/FLOW_TEMPLATE.flow
@@ -5,7 +5,7 @@
 import type { Globals } from "../common/common.js.flow";
 import type { spaceAfter } from "../common/getSpacingToken/index";
 
-type Name =%NAMES%
+export type Name =%NAMES%
 
 export type Props = {|
   +size?: "extraSmall" | "small" | "medium" | "large" | "display",

--- a/packages/orbit-components/src/Illustration/README.md
+++ b/packages/orbit-components/src/Illustration/README.md
@@ -102,3 +102,12 @@ Table below contains all types of the props available in Illustration component.
 | `"TransportBus"`                |
 | `"TransportTaxi"`               |
 | `"WomanWithPhone"`              |
+
+### Types
+
+You can import the `Name` `enum` as a type from the component definition
+
+```js
+import type { Name } from "@kiwicom/orbit-components/lib/Illustration"; // Flow
+import { Name } from "@kiwicom/orbit-components/lib/Illustration"; // TS
+```

--- a/packages/orbit-components/src/Illustration/TYPESCRIPT_TEMPLATE.template
+++ b/packages/orbit-components/src/Illustration/TYPESCRIPT_TEMPLATE.template
@@ -8,7 +8,7 @@ import * as React from "react";
 import * as Common from "../common/common";
 
 declare module "@kiwicom/orbit-components/lib/Illustration";
-type Name =%NAMES%
+export type Name =%NAMES%
 
 export interface Props extends Common.Global, Common.SpaceAfter {
   readonly size?: "extraSmall" | "small" | "medium" | "large" | "display";

--- a/packages/orbit-components/src/Popover/README.MD
+++ b/packages/orbit-components/src/Popover/README.MD
@@ -28,19 +28,28 @@ Table below contains all types of the props available in the Popover component.
 | noPadding         | `boolean`               | `true`     | Adds or removes padding around popover's content.                                                            |
 | opened            | `boolean`               |            | Prop for programmatically controlling Popover inner state. If `opened` is present open triggers are ignored. |
 | preferredAlign    | [`enum`](#enum)         | `"start"`  | The preferred position to choose [See Functional specs](#functional-specs).                                  |
-| preferredPosition | [`enum`](#enum)         | `"bottom"` | The preferred align to choose [See Functional specs](#functional-specs).                                  |
+| preferredPosition | [`enum`](#enum)         | `"bottom"` | The preferred align to choose [See Functional specs](#functional-specs).                                     |
 | overlapped        | `boolean`               | `false`    | If `true`, the content of Popover will overlap the trigger children.                                         |
 | width             | `string`                |            | Width of popover, if not set the with is set to `auto`.                                                      |
 | onClose           | `() => void \| Promise` |            | Function for handling onClose.                                                                               |
 | onOpen            | `() => void \| Promise` |            | Function for handling onOpen.                                                                                |
 
-## enum
+### enum
 
 | position   | Align      |
 | :--------- | :--------- |
 | `"bottom"` | `"start"`  |
 | `"top"`    | `"end"`    |
-|     | `"center"`    |
+|            | `"center"` |
+
+### Types
+
+You can import the `AlignsCore` and `Position` `enums` as types from the component definition
+
+```js
+import type { AlignsCore, Position } from "@kiwicom/orbit-components/lib/Popover"; // Flow
+import { AlignsCore, Position } from "@kiwicom/orbit-components/lib/Popover"; // TS
+```
 
 ## Functional specs
 

--- a/packages/orbit-components/src/Popover/index.d.ts
+++ b/packages/orbit-components/src/Popover/index.d.ts
@@ -8,14 +8,14 @@ import * as Common from "../common/common";
 
 declare module "@kiwicom/orbit-components/lib/Popover";
 
-type Position = "top" | "bottom";
-type Aligns = "start" | "end" | "center";
+export type Position = "top" | "bottom";
+export type AlignsCore = "start" | "end" | "center";
 
 export interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly content: React.ReactNode;
   readonly preferredPosition?: Position;
-  readonly preferredAlign?: Aligns;
+  readonly preferredAlign?: AlignsCore;
   readonly opened?: boolean;
   readonly width?: string;
   readonly noPadding?: boolean;

--- a/packages/orbit-components/src/Text/README.md
+++ b/packages/orbit-components/src/Text/README.md
@@ -41,3 +41,12 @@ Table below contains all types of the props available in the Text component.
 | `"warning"`   |            |          |            |            |
 | `"critical"`  |            |          |            |            |
 | `"white"`     |            |          |            |            |
+
+### Types
+
+You can import the `Type, As, Align, Weight `enums` as types from the component definition
+
+```js
+import type { Type, As, Align, Weight } from "@kiwicom/orbit-components/lib/Text"; // Flow
+import { Type, As, Align, Weight } from "@kiwicom/orbit-components/lib/Text"; // TS
+```

--- a/packages/orbit-components/src/Text/index.d.ts
+++ b/packages/orbit-components/src/Text/index.d.ts
@@ -8,9 +8,9 @@ import * as Common from "../common/common";
 
 declare module "@kiwicom/orbit-components/lib/Text";
 
-type Align = "left" | "center" | "right";
-type As = "p" | "span" | "div";
-type Type =
+export type Align = "left" | "center" | "right";
+export type As = "p" | "span" | "div";
+export type Type =
   | "primary"
   | "secondary"
   | "attention"
@@ -19,7 +19,7 @@ type Type =
   | "warning"
   | "critical"
   | "white";
-type Weight = "normal" | "bold";
+export type Weight = "normal" | "bold";
 
 export interface Props extends Common.Global, Common.SpaceAfter {
   readonly type?: Type;

--- a/packages/orbit-components/src/Text/index.js.flow
+++ b/packages/orbit-components/src/Text/index.js.flow
@@ -9,9 +9,10 @@ import type { Globals } from "../common/common.js.flow";
 
 type Align = "left" | "center" | "right";
 type As = "p" | "span" | "div";
-type Type = "primary" | "secondary" | "info" | "success" | "warning" | "critical" | "white";
 type Size = "large" | "normal" | "small";
-type Weight = "normal" | "bold";
+
+export type Type = "primary" | "secondary" | "info" | "success" | "warning" | "critical" | "white";
+export type Weight = "normal" | "bold";
 
 export type Props = {|
   +type?: Type,

--- a/packages/orbit-components/src/TextLink/index.js.flow
+++ b/packages/orbit-components/src/TextLink/index.js.flow
@@ -8,8 +8,7 @@ import type { Globals, Component } from "../common/common.js.flow";
 import type { ThemeProps } from "../defaultTheme";
 
 export type Type = "primary" | "secondary";
-
-type Size = "large" | "normal" | "small";
+export type Size = "large" | "normal" | "small";
 
 export type Props = {|
   +ariaCurrent?: string,


### PR DESCRIPTION
Expose `ts/flow` enum types from components:

- `Text`: Weight, Type, As, Align
- `Illustration`: Name
- `Alert`: Type
- `Button`: Type
- `ButtonLink`: Type
- `Popover`: AlignsCore (used for preferredAlign) and Position
- `Badge`: Type
- `TextLink`: Type