### PR TITLE
fix(TextLink): ariaCurrent should in optional in TS definition

### DIFF
--- a/packages/orbit-components/src/TextLink/index.d.ts
+++ b/packages/orbit-components/src/TextLink/index.d.ts
@@ -11,7 +11,7 @@ declare module "@kiwicom/orbit-components/lib/TextLink";
 export type Type = "primary" | "secondary";
 
 export interface Props extends Common.Global {
-  readonly ariaCurrent: string;
+  readonly ariaCurrent?: string;
   readonly children: React.ReactNode;
   readonly href?: string;
   readonly icon?: React.ReactNode;


### PR DESCRIPTION
Fixed `ariaCurrent` property that was marked as optional in Flow definition, but not in the TS definition.<br/><br/><br/><url>LiveURL: https://orbit-fix-textlink-aria-def.surge.sh</url>