### PR TITLE
feat(orbit): transitions defaults to on

### DIFF
--- a/packages/orbit-components/src/utils/transition/__tests__/index.test.js
+++ b/packages/orbit-components/src/utils/transition/__tests__/index.test.js
@@ -19,4 +19,33 @@ describe("transition", () => {
       `top ${defaultTheme.orbit.durationSlow} ease-in-out,box-shadow ${defaultTheme.orbit.durationSlow} ease-in-out`,
     );
   });
+  it("returns transition when transitions is undefined or null", () => {
+    const theme2 = {
+      theme: {
+        ...defaultTheme,
+        rtl: false,
+        transitions: undefined,
+      },
+    };
+
+    // $FlowExpectedError[incompatible-call]: Intentionally testing with undefined value
+    expect(transition(["top", "box-shadow"], "slow", "ease-in-out")(theme2)).toMatch(
+      `top ${defaultTheme.orbit.durationSlow} ease-in-out,box-shadow ${defaultTheme.orbit.durationSlow} ease-in-out`,
+    );
+    theme2.theme.transitions = null;
+    expect(transition(["top", "box-shadow"], "slow", "ease-in-out")(theme2)).toMatch(
+      `top ${defaultTheme.orbit.durationSlow} ease-in-out,box-shadow ${defaultTheme.orbit.durationSlow} ease-in-out`,
+    );
+  });
+
+  it("returns null when transitions is set to false", () => {
+    const theme2 = {
+      theme: {
+        ...defaultTheme,
+        rtl: false,
+        transitions: false,
+      },
+    };
+    expect(transition(["top", "box-shadow"], "slow", "ease-in-out")(theme2)).toBeNull();
+  });
 });

--- a/packages/orbit-components/src/utils/transition/index.js
+++ b/packages/orbit-components/src/utils/transition/index.js
@@ -8,7 +8,9 @@ const DURATIONS = {
 };
 
 const transition: Transition = (properties, duration, timingFunction) => ({ theme }) => {
-  if (!theme.transitions) return null;
+  if (theme.transitions === false) {
+    return null;
+  }
   const tokens = {
     [DURATIONS.SLOW]: theme.orbit.durationSlow,
     [DURATIONS.NORMAL]: theme.orbit.durationNormal,


### PR DESCRIPTION
- Transitions can be deactivated by explicitly setting theme.transitions to false

This Pull Request meets the following criteria:

- [x] Tests have been added/adjusted for my new feature
- [x] New Components are registered in index.js of my project
<br/><br/><br/><url>LiveURL: https://orbit-animations-default-on.surge.sh</url>