### PR TITLE
Fix TypeScript checking and include it in CI

### DIFF
--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "**/node_modules"
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock', '.yarnclean') }}
 
       - name: Install dependencies
         run: yarn install && yarn bootstrap

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "**/node_modules"
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock', '.yarnclean') }}
 
       - name: Install dependencies
         run: yarn install && yarn bootstrap
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "**/node_modules"
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock', '.yarnclean') }}
 
       - name: Install dependencies
         run: yarn install && yarn bootstrap
@@ -62,5 +62,3 @@ jobs:
 
       - name: Update PR description
         run: yarn orbit-components deploy:updateURL ${BRANCH_NAME} https://orbit-${BRANCH_URL}.surge.sh ${{ secrets.OCTO_TOKEN }}
-
-

--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,3 @@
+# prevent type clashing between react-native and dom types
+# https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311#issuecomment-494477593
+@types/react-native

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eslint:check": "eslint . --report-unused-disable-directives",
     "flow:check": "flow check",
     "test": "jest --config=jest.json",
-    "test-ci": "yarn orbit-components check:icons && yarn orbit-components build && yarn flow:check && yarn eslint:check && yarn test --ci --maxWorkers=2 && yarn workspace @kiwicom/babel-plugin-orbit-components test && yarn prettier:test",
+    "test-ci": "yarn orbit-components check:icons && yarn orbit-components build && yarn flow:check && yarn tsc && yarn eslint:check && yarn test --ci --maxWorkers=2 && yarn workspace @kiwicom/babel-plugin-orbit-components test && yarn prettier:test",
     "update-supported-browsers": "markdown --path .github/contribution/testing-conventions.md && git add .github/contribution/testing-conventions.md",
     "release": "lerna version --conventional-commits --no-push"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,11 @@
 {
   "compilerOptions": {
+    "noEmit": true,
     "lib": ["esnext", "dom"],
     "strict": true,
-    "noImplicitAny": false,
-    "moduleResolution": "node",
-    "jsx": "preserve",
-    "baseUrl": "./"
+    "noImplicitAny": false
   },
   "include": [
-    "packages/*/src"
-  ],
-  "exclude": [
-    "**/node_modules",
-    "packages/*/{es,lib,umd}"
+    "packages/orbit-components/**/*"
   ]
 }


### PR DESCRIPTION
- chore: fix clashing types in TypeScript
- chore: simplify TypeScript configuration
- ci: start type checking with TypeScript
<br/><br/><br/><url>LiveURL: https://orbit-test-typescript.surge.sh</url>