### PR TITLE
feat(Loki): skip code blocks

### DIFF
--- a/packages/orbit-components/.storybook/orbitDecorator.js
+++ b/packages/orbit-components/.storybook/orbitDecorator.js
@@ -18,7 +18,7 @@ const orbitDecorator = (storyFn, context) => {
     <div style={{ padding: "20px" }}>
       <Heading spaceAfter="medium">{context.kind}</Heading>
       <Text spaceAfter="largest">{context.parameters?.info}</Text>
-      {children}
+      <div id="component_preview">{children}</div>
       <div style={{ marginTop: 20 }}>
         <>
           <Code code={jsxToString(children, options)} language="jsx" format={false} />

--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -58,6 +58,7 @@
     "yarn.lock"
   ],
   "loki": {
+    "chromeSelector": "#component_preview > *",
     "configurations": {
       "chrome.laptop": {
         "target": "chrome.docker",


### PR DESCRIPTION
closes #2346

The idea is that we add a wrapping `<div>` with a specific ID to the decorator that adds the source code at the bottom. This way we can tell Loki to only take a screenshot of that `<div>` and not the whole page, therefore skipping story-code changes.

The area of the screenshot to be taken by Loki:

<img width="1067" alt="Screenshot 2020-10-21 at 19 38 42" src="https://user-images.githubusercontent.com/524272/96757086-41554080-13d5-11eb-9bc1-8496181a59de.png">


### TODO

Before merging:
* Help me run the visual regression tests (I don't have docker locally, the documentation is "coming soon", and it's getting late) cc @silvenon ,
* Make sure that absolutely positioned elements are captured correctly (that is the only caveat of this wrapper `<div>` solution.

---------------------------------

This Pull Request meets the following criteria:

- [x] Tests have been added/adjusted for my new feature
- [x] New Components are registered in index.js of my project
<br/><br/><br/><url>LiveURL: https://orbit-sampi-fix-2346.surge.sh</url>