### PR TITLE
fix: remove //flow from *.d.ts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,3 +2,4 @@ This Pull Request meets the following criteria:
 
 - [ ] Tests have been added/adjusted for my new feature
 - [ ] New Components are registered in index.js of my project
+- [ ] New Components has both `.flow` and `d.ts` files and are exprorted in `index.js.flow` and `index.d.ts`

--- a/packages/orbit-components/src/Accordion/AccordionSection/index.d.ts
+++ b/packages/orbit-components/src/Accordion/AccordionSection/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Accordion/index.d.ts
+++ b/packages/orbit-components/src/Accordion/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Alert/AlertButton/index.d.ts
+++ b/packages/orbit-components/src/Alert/AlertButton/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Alert/index.d.ts
+++ b/packages/orbit-components/src/Alert/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Badge/index.d.ts
+++ b/packages/orbit-components/src/Badge/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Breadcrumbs/BreadcrumbsItem/index.d.ts
+++ b/packages/orbit-components/src/Breadcrumbs/BreadcrumbsItem/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Breadcrumbs/index.d.ts
+++ b/packages/orbit-components/src/Breadcrumbs/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Button/index.d.ts
+++ b/packages/orbit-components/src/Button/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/ButtonGroup/index.d.ts
+++ b/packages/orbit-components/src/ButtonGroup/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/ButtonLink/index.d.ts
+++ b/packages/orbit-components/src/ButtonLink/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/CallOutBanner/index.d.ts
+++ b/packages/orbit-components/src/CallOutBanner/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Card/CardSection/index.d.ts
+++ b/packages/orbit-components/src/Card/CardSection/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Card/index.d.ts
+++ b/packages/orbit-components/src/Card/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/CarrierLogo/index.d.ts
+++ b/packages/orbit-components/src/CarrierLogo/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Checkbox/index.d.ts
+++ b/packages/orbit-components/src/Checkbox/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/ChoiceGroup/index.d.ts
+++ b/packages/orbit-components/src/ChoiceGroup/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/ClickOutside/index.d.ts
+++ b/packages/orbit-components/src/ClickOutside/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Collapse/index.d.ts
+++ b/packages/orbit-components/src/Collapse/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/CountryFlag/index.d.ts
+++ b/packages/orbit-components/src/CountryFlag/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Coupon/index.d.ts
+++ b/packages/orbit-components/src/Coupon/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Desktop/index.d.ts
+++ b/packages/orbit-components/src/Desktop/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Dialog/index.d.ts
+++ b/packages/orbit-components/src/Dialog/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Dictionary/index.d.ts
+++ b/packages/orbit-components/src/Dictionary/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Drawer/components/DrawerClose.d.ts
+++ b/packages/orbit-components/src/Drawer/components/DrawerClose.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Drawer/index.d.ts
+++ b/packages/orbit-components/src/Drawer/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/FormFeedback/index.d.ts
+++ b/packages/orbit-components/src/FormFeedback/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/FormLabel/index.d.ts
+++ b/packages/orbit-components/src/FormLabel/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Heading/index.d.ts
+++ b/packages/orbit-components/src/Heading/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Hide/index.d.ts
+++ b/packages/orbit-components/src/Hide/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Icon/index.d.ts
+++ b/packages/orbit-components/src/Icon/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/InputField/index.d.ts
+++ b/packages/orbit-components/src/InputField/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/InputFile/index.d.ts
+++ b/packages/orbit-components/src/InputFile/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/InputGroup/index.d.ts
+++ b/packages/orbit-components/src/InputGroup/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/InputStepper/InputStepperStateless/index.d.ts
+++ b/packages/orbit-components/src/InputStepper/InputStepperStateless/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/InputStepper/index.d.ts
+++ b/packages/orbit-components/src/InputStepper/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Layout/LayoutColumn/index.d.ts
+++ b/packages/orbit-components/src/Layout/LayoutColumn/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Layout/index.d.ts
+++ b/packages/orbit-components/src/Layout/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/LazyImage/index.d.ts
+++ b/packages/orbit-components/src/LazyImage/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/LinkList/index.d.ts
+++ b/packages/orbit-components/src/LinkList/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/List/ListItem/index.d.ts
+++ b/packages/orbit-components/src/List/ListItem/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/List/index.d.ts
+++ b/packages/orbit-components/src/List/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/ListChoice/index.d.ts
+++ b/packages/orbit-components/src/ListChoice/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Loading/index.d.ts
+++ b/packages/orbit-components/src/Loading/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Mobile/index.d.ts
+++ b/packages/orbit-components/src/Mobile/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Modal/ModalContext.d.ts
+++ b/packages/orbit-components/src/Modal/ModalContext.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Modal/ModalFooter/index.d.ts
+++ b/packages/orbit-components/src/Modal/ModalFooter/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 import * as React from "react";

--- a/packages/orbit-components/src/Modal/ModalHeader/index.d.ts
+++ b/packages/orbit-components/src/Modal/ModalHeader/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 import * as React from "react";

--- a/packages/orbit-components/src/Modal/ModalSection/index.d.ts
+++ b/packages/orbit-components/src/Modal/ModalSection/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 import * as React from "react";

--- a/packages/orbit-components/src/Modal/index.d.ts
+++ b/packages/orbit-components/src/Modal/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/NavigationBar/index.d.ts
+++ b/packages/orbit-components/src/NavigationBar/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 import * as React from "react";

--- a/packages/orbit-components/src/NotificationBadge/index.d.ts
+++ b/packages/orbit-components/src/NotificationBadge/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Pagination/index.d.ts
+++ b/packages/orbit-components/src/Pagination/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/PictureCard/index.d.ts
+++ b/packages/orbit-components/src/PictureCard/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Popover/index.d.ts
+++ b/packages/orbit-components/src/Popover/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Portal/index.d.ts
+++ b/packages/orbit-components/src/Portal/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/PricingTable/PricingTableItem/index.d.ts
+++ b/packages/orbit-components/src/PricingTable/PricingTableItem/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/PricingTable/index.d.ts
+++ b/packages/orbit-components/src/PricingTable/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Radio/index.d.ts
+++ b/packages/orbit-components/src/Radio/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/RatingStars/index.d.ts
+++ b/packages/orbit-components/src/RatingStars/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Seat/index.d.ts
+++ b/packages/orbit-components/src/Seat/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Select/index.d.ts
+++ b/packages/orbit-components/src/Select/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Separator/index.d.ts
+++ b/packages/orbit-components/src/Separator/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/SkipLink/index.d.ts
+++ b/packages/orbit-components/src/SkipLink/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/SkipNavigation/index.d.ts
+++ b/packages/orbit-components/src/SkipNavigation/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Slider/index.d.ts
+++ b/packages/orbit-components/src/Slider/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/SocialButton/index.d.ts
+++ b/packages/orbit-components/src/SocialButton/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Stack/index.d.ts
+++ b/packages/orbit-components/src/Stack/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Stepper/StepperStateless/index.d.ts
+++ b/packages/orbit-components/src/Stepper/StepperStateless/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Stepper/index.d.ts
+++ b/packages/orbit-components/src/Stepper/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Sticky/index.d.ts
+++ b/packages/orbit-components/src/Sticky/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/StopoverArrow/index.d.ts
+++ b/packages/orbit-components/src/StopoverArrow/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Table/TableBody/index.d.ts
+++ b/packages/orbit-components/src/Table/TableBody/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Table/TableCell/index.d.ts
+++ b/packages/orbit-components/src/Table/TableCell/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Table/TableFooter/index.d.ts
+++ b/packages/orbit-components/src/Table/TableFooter/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Table/TableHead/index.d.ts
+++ b/packages/orbit-components/src/Table/TableHead/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Table/TableRow/index.d.ts
+++ b/packages/orbit-components/src/Table/TableRow/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Table/index.d.ts
+++ b/packages/orbit-components/src/Table/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Tag/index.d.ts
+++ b/packages/orbit-components/src/Tag/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Text/index.d.ts
+++ b/packages/orbit-components/src/Text/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/TextLink/index.d.ts
+++ b/packages/orbit-components/src/TextLink/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Textarea/index.d.ts
+++ b/packages/orbit-components/src/Textarea/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/ThemeProvider/QueryContext/index.d.ts
+++ b/packages/orbit-components/src/ThemeProvider/QueryContext/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/ThemeProvider/index.d.ts
+++ b/packages/orbit-components/src/ThemeProvider/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Tile/index.d.ts
+++ b/packages/orbit-components/src/Tile/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/TileGroup/index.d.ts
+++ b/packages/orbit-components/src/TileGroup/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Tooltip/index.d.ts
+++ b/packages/orbit-components/src/Tooltip/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Translate/index.d.ts
+++ b/packages/orbit-components/src/Translate/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/Truncate/index.d.ts
+++ b/packages/orbit-components/src/Truncate/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/common/common.d.ts
+++ b/packages/orbit-components/src/common/common.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/defaultTheme.d.ts
+++ b/packages/orbit-components/src/defaultTheme.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/Card/CardHeader/index.d.ts
+++ b/packages/orbit-components/src/deprecated/Card/CardHeader/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/Card/CardSection/index.d.ts
+++ b/packages/orbit-components/src/deprecated/Card/CardSection/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/Card/index.d.ts
+++ b/packages/orbit-components/src/deprecated/Card/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/DestinationCard/index.d.ts
+++ b/packages/orbit-components/src/deprecated/DestinationCard/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/DestinationHeader/index.d.ts
+++ b/packages/orbit-components/src/deprecated/DestinationHeader/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/Tile/TileExpandable/index.d.ts
+++ b/packages/orbit-components/src/deprecated/Tile/TileExpandable/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/Tile/TileHeader/index.d.ts
+++ b/packages/orbit-components/src/deprecated/Tile/TileHeader/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/Tile/index.d.ts
+++ b/packages/orbit-components/src/deprecated/Tile/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/TripSector/TripDate/index.d.ts
+++ b/packages/orbit-components/src/deprecated/TripSector/TripDate/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/TripSector/TripLayover/index.d.ts
+++ b/packages/orbit-components/src/deprecated/TripSector/TripLayover/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/TripSector/index.d.ts
+++ b/packages/orbit-components/src/deprecated/TripSector/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/deprecated/TripSegment/index.d.ts
+++ b/packages/orbit-components/src/deprecated/TripSegment/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/hooks/useBoundingRect/index.d.ts
+++ b/packages/orbit-components/src/hooks/useBoundingRect/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 type inexactNumber = number | undefined | null;
 
 type Dimensions = {

--- a/packages/orbit-components/src/hooks/useClickOutside/index.d.ts
+++ b/packages/orbit-components/src/hooks/useClickOutside/index.d.ts
@@ -1,5 +1,3 @@
-// @flow
-
 declare const UseClickOutside: (
   ref: { readonly current: HTMLElement | null | undefined },
   // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types

--- a/packages/orbit-components/src/hooks/useDictionary/index.d.ts
+++ b/packages/orbit-components/src/hooks/useDictionary/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 import Translations from "../../Dictionary/index";
 
 declare const useDictionary: () => typeof Translations;

--- a/packages/orbit-components/src/hooks/useMediaQuery/index.d.ts
+++ b/packages/orbit-components/src/hooks/useMediaQuery/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 import { Props as Media } from "../../ThemeProvider/QueryContext/index";
 
 declare const UseMediaQuery: () => Media;

--- a/packages/orbit-components/src/hooks/useStateWithCallback/index.d.ts
+++ b/packages/orbit-components/src/hooks/useStateWithCallback/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 export type Return<S> = [S, (arg0: S) => void];
 
 export default function useStateWithCallback<S>(

--- a/packages/orbit-components/src/hooks/useStateWithTimeout/index.d.ts
+++ b/packages/orbit-components/src/hooks/useStateWithTimeout/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 export type Return<S> = [S, (arg0: S) => void, (arg0: S) => void, () => void];
 
 export default function useStateWithTimeout<S>(defaultValue: S, timeout?: number): Return<S>;

--- a/packages/orbit-components/src/hooks/useTheme/index.d.ts
+++ b/packages/orbit-components/src/hooks/useTheme/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 import { ThemeShape } from "../../defaultTheme";
 
 declare const useTheme: () => ThemeShape;

--- a/packages/orbit-components/src/hooks/useToggle/index.d.ts
+++ b/packages/orbit-components/src/hooks/useToggle/index.d.ts
@@ -1,3 +1,2 @@
-// @flow
 declare const UseToggle: (initial: boolean) => [boolean, () => void];
 export { UseToggle, UseToggle as default };

--- a/packages/orbit-components/src/hooks/useTranslate/index.d.ts
+++ b/packages/orbit-components/src/hooks/useTranslate/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 import Values from "../../Translate/index";
 
 type TranslateFunction = (key: string, values?: typeof Values) => string;

--- a/packages/orbit-components/src/index.d.ts
+++ b/packages/orbit-components/src/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: https://github.com/kiwicom/orbit/
 
@@ -6,7 +5,7 @@ declare module "@kiwicom/orbit-components";
 
 export { Alert } from "./Alert/index";
 export { AlertButton } from "./Alert/AlertButton/index";
-export { AirportIllustration } from "./AirportIllustration/index";
+export { AirportIllustration } from "./AirportIllustration";
 export { Badge } from "./Badge/index";
 export { NotificationBadge } from "./NotificationBadge/index";
 export { Breadcrumbs } from "./Breadcrumbs/index";
@@ -23,14 +22,14 @@ export { CarrierLogo } from "./CarrierLogo/index";
 export { DestinationHeader } from "./deprecated/DestinationHeader/index";
 export { DestinationCard } from "./deprecated/DestinationCard/index";
 export { Dialog } from "./Dialog/index";
-export { FeatureIcon } from "./FeatureIcon/index";
+export { FeatureIcon } from "./FeatureIcon";
 export { Heading } from "./Heading/index";
 export { Hide } from "./Hide/index";
 export { InputField } from "./InputField/index";
 export { InputGroup } from "./InputGroup/index";
 export { InputStepper } from "./InputStepper/index";
 export { InputStepperStateless } from "./InputStepper/InputStepperStateless/index";
-export { Illustration } from "./Illustration/index";
+export { Illustration } from "./Illustration";
 export { List } from "./List/index";
 export { ListItem } from "./List/ListItem/index";
 export { ListChoice } from "./ListChoice/index";
@@ -57,7 +56,7 @@ export { Stack } from "./Stack/index";
 export { Sticky } from "./Sticky/index";
 export { Separator } from "./Separator/index";
 export { SkipNavigation } from "./SkipNavigation/index";
-export { ServiceLogo } from "./ServiceLogo/index";
+export { ServiceLogo } from "./ServiceLogo";
 export { Textarea } from "./Textarea/index";
 export { Card } from "./Card/index";
 export { CardSection } from "./Card/CardSection/index";

--- a/packages/orbit-components/src/primitives/BadgePrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/BadgePrimitive/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 import * as React from "react";
 
 import * as Common from "../../common/common";

--- a/packages/orbit-components/src/primitives/IllustrationPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/IllustrationPrimitive/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/utils/Grid/index.d.ts
+++ b/packages/orbit-components/src/utils/Grid/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/utils/Slide/index.d.ts
+++ b/packages/orbit-components/src/utils/Slide/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 

--- a/packages/orbit-components/src/utils/boundingClientRect/index.d.ts
+++ b/packages/orbit-components/src/utils/boundingClientRect/index.d.ts
@@ -1,5 +1,3 @@
-// @flow
-
 type Dimensions = {
   top: number;
   right: number;

--- a/packages/orbit-components/src/utils/cloneWithTooltip/index.d.ts
+++ b/packages/orbit-components/src/utils/cloneWithTooltip/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 import * as React from "react";
 
 declare const CloneWithTooltip: (

--- a/packages/orbit-components/src/utils/handleKeyDown/index.d.ts
+++ b/packages/orbit-components/src/utils/handleKeyDown/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 import * as Common from "../../common/common";
 
 type Event = Common.Event<React.SyntheticEvent<HTMLDivElement> | React.KeyboardEvent<HTMLElement>>;

--- a/packages/orbit-components/src/utils/mediaQuery/index.d.ts
+++ b/packages/orbit-components/src/utils/mediaQuery/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 import { Interpolation } from "styled-components";

--- a/packages/orbit-components/src/utils/onlyIE/index.d.ts
+++ b/packages/orbit-components/src/utils/onlyIE/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 import { Interpolation } from "styled-components";
 
 declare const OnlyIE: (style: Interpolation<any>, breakpoint?: string) => Interpolation<any>;

--- a/packages/orbit-components/src/utils/randomID/index.d.ts
+++ b/packages/orbit-components/src/utils/randomID/index.d.ts
@@ -1,4 +1,2 @@
-// @flow
-
 declare const RandomID: (value: string) => string;
 export { RandomID, RandomID as default };

--- a/packages/orbit-components/src/utils/rtl/index.d.ts
+++ b/packages/orbit-components/src/utils/rtl/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 import { ThemeType } from "../../defaultTheme";
 
 export type LeftToRight = <T1, T2>(left: T1, right: T2) => (theme: ThemeType) => T1 | T2;

--- a/packages/orbit-components/src/utils/scroll/index.d.ts
+++ b/packages/orbit-components/src/utils/scroll/index.d.ts
@@ -1,5 +1,3 @@
-// @flow
-
 export declare const addScrollHandler: (
   onScrollFunction: () => void,
   element?: Node,

--- a/packages/orbit-components/src/utils/toggleDown/index.d.ts
+++ b/packages/orbit-components/src/utils/toggleDown/index.d.ts
@@ -1,2 +1,1 @@
-// @flow
 export default function toggleDown(contentHeight: number): any;

--- a/packages/orbit-components/src/utils/toggleUp/index.d.ts
+++ b/packages/orbit-components/src/utils/toggleUp/index.d.ts
@@ -1,2 +1,1 @@
-// @flow
 export default function toggleUp(contentHeight: number): any;

--- a/packages/orbit-components/src/utils/transition/index.d.ts
+++ b/packages/orbit-components/src/utils/transition/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 import { ThemeType } from "../../defaultTheme";
 
 export declare const Transition: (

--- a/packages/orbit-components/src/utils/validateDecrement/index.d.ts
+++ b/packages/orbit-components/src/utils/validateDecrement/index.d.ts
@@ -1,5 +1,3 @@
-// @flow
-
 export type Params = {
   value: number;
   minValue?: number;

--- a/packages/orbit-components/src/utils/validateIncrement/index.d.ts
+++ b/packages/orbit-components/src/utils/validateIncrement/index.d.ts
@@ -1,4 +1,3 @@
-// @flow
 import { Params } from "../validateDecrement/index";
 
 declare const ValidateIncrement: (arg: Params) => number;

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,18 @@ For live preview check out [Storybook](https://kiwicom.github.io/orbit/) or [orb
 
 You can also try `orbit-components` live on [CodeSandbox](https://codesandbox.io/s/github/designkiwicom/orbit-sandbox).
 
+## Types
+
+Orbit comes with both Flow and Typescript definitions files, so you can choose what fits your project. However, if you work with Typescript, you need to add type for `styled-components`.
+
+```
+// with npm
+npm install @types/styled-components --save-dev
+
+// with yarn
+yarn add @types/styled-components -D
+```
+
 ## Main Sections:
 
 - [Components](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/)

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ yarn add @types/styled-components -D
 
 ## Contributing
 
-We are working on making this project fully open source. We appreciate any contributions you might make.
+We are working on making this project a fully open source. We appreciate any contributions you might make.
 
 [Bug reports](https://github.com/kiwicom/orbit/issues/new?template=bug_report.md) and [feature request](https://github.com/kiwicom/orbit/issues/new?template=feature_request.md) are welcome but, please use the correct template.
 


### PR DESCRIPTION
Took some changes from old PR: #1874 

- README has info about Types from @filipdanisko 
- removed all //flow comments from `*.d.ts`
<br/><br/><br/><url>LiveURL: https://orbit-chore-ts.surge.sh</url>