### PR TITLE
feat(Button): div behave like button, a11y

### DIFF
--- a/packages/orbit-components/src/primitives/ButtonPrimitive/__tests__/index.test.js
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/__tests__/index.test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ButtonPrimitive from "../index";
@@ -42,11 +42,13 @@ describe("ButtonPrimitive", () => {
     userEvent.click(button);
     expect(onClick).toHaveBeenCalled();
   });
+
   describe("disabled", () => {
     it("default", () => {
       render(<ButtonPrimitive disabled>Lorem ipsum</ButtonPrimitive>);
       expect(screen.getByRole("button")).toBeDisabled();
     });
+
     it("with href", () => {
       const onClick = jest.fn();
       render(
@@ -61,12 +63,14 @@ describe("ButtonPrimitive", () => {
       expect(onClick).not.toHaveBeenCalled();
     });
   });
+
   it("loading", () => {
     render(<ButtonPrimitive loading>Lorem ipsum</ButtonPrimitive>);
     const button = screen.getByRole("button");
     expect(button).toBeDisabled();
     expect(button.querySelector("svg")).toBeInTheDocument();
   });
+
   it("with href", () => {
     render(
       <ButtonPrimitive href="#" external>
@@ -74,5 +78,24 @@ describe("ButtonPrimitive", () => {
       </ButtonPrimitive>,
     );
     expect(screen.getByRole("link")).toHaveAttribute("href", "#");
+  });
+
+  it("should behave as button", () => {
+    const children = "Lorem ipsum";
+    const dataTest = "test";
+    const onClick = jest.fn();
+
+    render(
+      <ButtonPrimitive dataTest={dataTest} onClick={onClick} tabIndex={0} asComponent="div">
+        {children}
+      </ButtonPrimitive>,
+    );
+
+    const button = screen.getByTestId(dataTest);
+
+    userEvent.tab();
+    fireEvent.keyDown(button, { keyCode: 13 });
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(button).toHaveFocus();
   });
 });

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.js
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.js
@@ -12,6 +12,7 @@ import ButtonPrimitiveIconContainer, {
 import ButtonPrimitiveContentChildren from "./components/ButtonPrimitiveContentChildren";
 import mq from "../../utils/mediaQuery";
 import createRel from "./common/createRel";
+import onKeyDown from "../../utils/handleKeyDown";
 
 import type { Props } from "./index";
 
@@ -50,6 +51,9 @@ export const StyledButtonPrimitive = styled(
       const Component = isButtonWithHref ? "a" : asComponent;
       const buttonType = submit ? "submit" : "button";
 
+      const handleKeyDown = (ev: SyntheticKeyboardEvent<HTMLDivElement>) =>
+        asComponent === "div" ? onKeyDown(onClick)(ev) : undefined;
+
       return (
         <Component
           ref={ref}
@@ -62,6 +66,7 @@ export const StyledButtonPrimitive = styled(
           type={!isButtonWithHref ? buttonType : undefined}
           className={className}
           disabled={disabled}
+          onKeyDown={handleKeyDown}
           href={!disabled ? href : null}
           target={!disabled && href && external ? "_blank" : undefined}
           rel={createRel({ external, href, rel })}


### PR DESCRIPTION
[jira ticket](https://jira.kiwi.com/browse/ORBIT-681)

If button rendered as div, it should react onEnter and onSpace clicks.

Hope i did not miss something, @vepor can you check? <br/><br/><br/><url>LiveURL: https://orbit-fix-button-a11y.surge.sh</url>