### PR TITLE
Rewrite tests for CountryFlag to TestingLibrary

### DIFF
--- a/packages/orbit-components/src/CountryFlag/__tests__/index.test.js
+++ b/packages/orbit-components/src/CountryFlag/__tests__/index.test.js
@@ -1,53 +1,46 @@
 // @flow
 import * as React from "react";
-import { shallow } from "enzyme";
+import { render, screen, cleanup } from "@testing-library/react";
 
-import CountryFlag, { getCountryProps } from "../index";
-import { CODES } from "../consts";
+import CountryFlag from "../index";
 
-const code = CODES.ANYWHERE;
-const name = "Anywhere";
-const dataTest = "test";
-
-describe(`CountryFlag of ${name}`, () => {
-  const component = shallow(<CountryFlag code={code} name={name} dataTest={dataTest} />);
-  const flag = component.find("CountryFlag__StyledImage");
-  it("should have passed props", () => {
-    expect(flag.render().prop("src")).toContain(code);
-    expect(flag.render().prop("srcset")).toContain(code);
-    expect(flag.prop("alt")).toBe(name);
-    expect(flag.prop("title")).toBe(name);
-    expect(flag.render().prop("data-test")).toBe(dataTest);
+describe("CountryFlag", () => {
+  it("should have expected DOM output", () => {
+    render(<CountryFlag code="anywhere" name="Anywhere" dataTest="test" />);
+    const flag = screen.getByRole("img", { name: "Anywhere" });
+    expect(flag).toHaveAttribute("src", expect.stringContaining("anywhere"));
+    expect(flag).toHaveAttribute("srcset", expect.stringContaining("anywhere"));
+    expect(screen.getByTitle("Anywhere")).toBeInTheDocument();
+    expect(screen.getByAltText("Anywhere")).toBeInTheDocument();
+    expect(screen.getByTestId("test")).toBeInTheDocument();
   });
-});
-
-describe("CountryFlag props", () => {
-  it("should support empty code or name", () => {
-    expect(getCountryProps()).toEqual({ code: "anywhere", name: "Anywhere" });
-    expect(getCountryProps(null, "Country")).toEqual({ code: "anywhere", name: "Country" });
-    expect(getCountryProps("US")).toEqual({ code: "us" });
+  it("should support omitting code and name", () => {
+    let flag;
+    render(<CountryFlag />);
+    flag = screen.getByRole("img", { name: "Anywhere" });
+    expect(flag).toHaveAttribute("src", expect.stringContaining("anywhere"));
+    cleanup();
+    render(<CountryFlag name="Country" />);
+    flag = screen.getByRole("img", { name: "Country" });
+    expect(flag).toHaveAttribute("src", expect.stringContaining("anywhere"));
+    cleanup();
+    render(<CountryFlag code="us" />);
+    flag = screen.getByRole("img");
+    expect(flag).toHaveAttribute("src", expect.stringContaining("us"));
+    expect(flag).not.toHaveAttribute("alt");
+    expect(flag).not.toHaveAttribute("title");
   });
-
   it("should warn and fallback on unknown code", () => {
     const consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    expect(getCountryProps("404", "Country")).toEqual({ code: "anywhere", name: "Country" });
-    expect(getCountryProps("unknown")).toEqual({ code: "anywhere", name: "Anywhere" });
-    expect(consoleSpy).toHaveBeenCalledTimes(2);
-    expect(consoleSpy).toHaveBeenNthCalledWith(1, "Country code not supported: 404");
-    expect(consoleSpy).toHaveBeenNthCalledWith(2, "Country code not supported: unknown");
+    render(<CountryFlag code="404" name="Country" />);
+    const flag = screen.getByRole("img", { name: "Country" });
+    expect(flag).toHaveAttribute("src", expect.stringContaining("anywhere"));
+    expect(consoleSpy).toHaveBeenCalledWith("Country code not supported: 404");
     consoleSpy.mockRestore();
   });
-  it("should not warn about null code", () => {
-    const consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    expect(consoleSpy).not.toBeCalled();
-    getCountryProps(null);
-    getCountryProps();
-  });
   it("should support case insensitive code", () => {
-    expect(getCountryProps("US")).toEqual({ code: "us" });
-    expect(getCountryProps("de")).toEqual({ code: "de" });
-  });
-  it("should support valid input", () => {
-    expect(getCountryProps("fr", "France")).toEqual({ code: "fr", name: "France" });
+    render(<CountryFlag code="US" />);
+    const flag = screen.getByRole("img");
+    expect(flag).toHaveAttribute("src", expect.stringContaining("us"));
   });
 });

--- a/packages/orbit-components/src/CountryFlag/index.js
+++ b/packages/orbit-components/src/CountryFlag/index.js
@@ -73,7 +73,7 @@ StyledShadow.defaultProps = {
   theme: defaultTheme,
 };
 
-export function getCountryProps(code: ?string, name: ?string): {| code: string, name: ?string |} {
+function getCountryProps(code: ?string, name: ?string): {| code: string, name: ?string |} {
   const codeNormalized = code ? code.toUpperCase().replace("-", "_") : "ANYWHERE";
   const countryCodeExists = codeNormalized in CODES;
 

--- a/packages/orbit-components/src/CountryFlag/index.js.flow
+++ b/packages/orbit-components/src/CountryFlag/index.js.flow
@@ -13,12 +13,4 @@ export type Props = {|
   ...Globals,
 |};
 
-declare export var getCountryProps: (
-  code: ?string,
-  name: ?string,
-) => {|
-  +code: string,
-  +name: string,
-|};
-
 declare export default React.ComponentType<Props>;


### PR DESCRIPTION
- test(CountryFlag): rewrite to Testing Library
- fix(CountryFlag): stop exporting getCountryProps

This should be rebased upon merging because it contains multiple commits. This change could've technically gone into the `test` commit, but I'm leaving 0.0001% chance that someone was actually this function, which seems internal in all regards.
<br/><br/><br/><url>LiveURL: https://orbit-test-testing-library-country-flag.surge.sh</url>