### PR TITLE
chore: add common eslint rules config file WIP

### DIFF
--- a/config/eslintCommon.js
+++ b/config/eslintCommon.js
@@ -1,0 +1,60 @@
+// @noflow
+const path = require("path");
+
+module.exports = {
+  extends: ["prettier/react"],
+  plugins: ["import", "prettier", "jest", "react-hooks", "plugin:react/recommended"],
+  rules: {
+    "no-console": ["error", { allow: ["warn", "error"] }],
+    "prettier/prettier": "error",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        packageDir: [
+          path.join(__dirname, "../"),
+          path.join(__dirname, "../packages/babel-plugin-orbit-components"),
+          path.join(__dirname, "../packages/orbit-components"),
+        ],
+        devDependencies: [
+          "**/*.test.js",
+          "**/__tests__/**",
+          "**/*.spec.js",
+          "**/*.stories.js",
+          "**/*.config.js",
+          "**/stories/**",
+          "packages/*/.storybook/**",
+          "packages/*/config/**",
+          "gulpfile.js",
+        ],
+      },
+    ],
+    "import/order": [
+      "error",
+      {
+        groups: [["builtin", "external"], ["parent", "sibling"], "index"],
+        "newlines-between": "always",
+      },
+    ],
+    "import/newline-after-import": "error",
+    "import/no-mutable-exports": "error",
+    "import/no-absolute-path": "error",
+    "import/no-cycle": ["error", { maxDepth: 1 }],
+    "import/prefer-default-export": "off",
+    "react/no-multi-comp": "off",
+    "react/prop-types": "off",
+    "react/require-default-props": "off", // Optional props can be undefined.
+    "react/state-in-constructor": "off",
+    "react/static-property-placement": "off",
+    "import/no-self-import": "off",
+    "react/destructuring-assignment": "off",
+    "react/no-access-state-in-setstate": "off",
+    "no-await-in-loop": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+    "jest/no-identical-title": "error",
+    "jest/no-standalone-expect": "error",
+    "jest/no-if": "error",
+    "jest/consistent-test-it": "warn",
+    "jest/no-focused-tests": "error",
+  },
+};

--- a/config/eslintCommon.js
+++ b/config/eslintCommon.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 module.exports = {
   extends: ["prettier/react"],
-  plugins: ["import", "prettier", "jest", "react-hooks", "plugin:react/recommended"],
+  plugins: ["import", "prettier", "jest", "react-hooks"],
   rules: {
     "no-console": ["error", { allow: ["warn", "error"] }],
     "prettier/prettier": "error",

--- a/config/eslintJS.js
+++ b/config/eslintJS.js
@@ -1,6 +1,4 @@
 // @noflow
-const path = require("path");
-
 module.exports = {
   env: {
     browser: true,
@@ -8,75 +6,24 @@ module.exports = {
   },
   parser: "babel-eslint",
   extends: [
+    "./eslintCommon.js",
     "airbnb",
     "plugin:flowtype/recommended",
     "prettier",
     "prettier/flowtype",
-    "prettier/react",
   ],
-  plugins: ["import", "flowtype", "prettier", "jest", "react-hooks", "eslint-plugin-adeira"],
+  plugins: ["flowtype", "eslint-plugin-adeira", ],
   rules: {
-    "no-console": ["error", { allow: ["warn", "error"] }],
-    "prettier/prettier": "error",
     "flowtype/require-exact-type": "error",
-    "import/no-extraneous-dependencies": [
-      "error",
-      {
-        packageDir: [
-          path.join(__dirname, "../"),
-          path.join(__dirname, "../packages/babel-plugin-orbit-components"),
-          path.join(__dirname, "../packages/orbit-components"),
-        ],
-        devDependencies: [
-          "**/*.test.js",
-          "**/__tests__/**",
-          "**/*.spec.js",
-          "**/*.stories.js",
-          "**/*.config.js",
-          "**/stories/**",
-          "packages/*/.storybook/**",
-          "packages/*/config/**",
-          "gulpfile.js",
-        ],
-      },
-    ],
-    "import/order": [
-      "error",
-      {
-        groups: [["builtin", "external"], ["parent", "sibling"], "index"],
-        "newlines-between": "always",
-      },
-    ],
-    "import/newline-after-import": "error",
-    "import/no-mutable-exports": "error",
-    "import/no-absolute-path": "error",
-    "import/no-cycle": ["error", { maxDepth: 1 }],
-    "import/prefer-default-export": "off",
     "react/jsx-no-bind": "error",
-    "react/no-multi-comp": "off",
-    "react/prop-types": "off",
-    "react/require-default-props": "off", // Optional props can be undefined.
     "react/default-props-match-prop-types": "off", // Conflict between Flow and ESLint
     "react/jsx-filename-extension": ["error", { extensions: [".js"] }], // Don't use jsx
     "react/jsx-props-no-spreading": "off",
     "react/jsx-fragments": ["error", "syntax"],
-    "react/state-in-constructor": "off",
-    "react/static-property-placement": "off",
     "jsx-a11y/label-has-for": "off", // control is wrapped in a label
     "jsx-a11y/href-no-hash": "off", // broken rule
     "flowtype/require-valid-file-annotation": ["error", "always"],
-    "import/no-self-import": "off",
-    "react/destructuring-assignment": "off",
-    "react/no-access-state-in-setstate": "off",
     "jsx-a11y/label-has-associated-control": "off",
-    "no-await-in-loop": "off",
-    "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
-    "jest/no-identical-title": "error",
-    "jest/no-standalone-expect": "error",
-    "jest/no-if": "error",
-    "jest/consistent-test-it": "warn",
-    "jest/no-focused-tests": "error",
     "adeira/no-internal-flow-type": "error",
   },
 };

--- a/config/eslintTS.js
+++ b/config/eslintTS.js
@@ -1,6 +1,7 @@
 // @noflow
 module.exports = {
   extends: [
+    "./eslintCommon.js",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
     "prettier/@typescript-eslint",


### PR DESCRIPTION
[2347](https://github.com/kiwicom/orbit/issues/2347)
This is a work in progress, I'm not sure if the new configuration is the best approach. I'll be glad to see some code review. 

This Pull Request meets the following criteria:

- [ ] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components has both `.flow` and `d.ts` files and are exprorted in `index.js.flow` and `index.d.ts`
