### PR TITLE
fix(Tooltip): do not propagate the onClick event on mobile when stopPropagate is set to true

### DIFF
--- a/packages/orbit-components/src/Tooltip/__tests__/mobile.test.js
+++ b/packages/orbit-components/src/Tooltip/__tests__/mobile.test.js
@@ -1,0 +1,36 @@
+// @flow
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import Button from "../../Button";
+import Tooltip from "../index";
+
+jest.mock("../../hooks/useMediaQuery", () => {
+  return () => {
+    return {
+      isLargeMobile: false,
+    };
+  };
+});
+
+describe("Tooltip mobile", () => {
+  it("it should not propagate onClick event when closing the tooltip using the close button", () => {
+    const content = "Write some message to the user";
+    const onClick = jest.fn();
+    render(
+      <Button onClick={onClick}>
+        <Tooltip content={content} stopPropagation>
+          kek
+        </Tooltip>
+      </Button>,
+    );
+
+    // Open the tooltip
+    userEvent.click(screen.getByText("kek"));
+    // Close the tooltip
+    userEvent.click(screen.getByText("Close"));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/components/DialogContent.flow.js
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/components/DialogContent.flow.js
@@ -7,7 +7,7 @@ export type Props = {|
   shown: boolean,
   dialogId: ?string,
   children: React.Node,
-  onClose: () => void,
+  onClose: (ev: SyntheticEvent<HTMLElement>) => void,
   ...Globals,
 |};
 

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/components/DialogContent.js
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/components/DialogContent.js
@@ -103,7 +103,7 @@ const DialogContent = ({ dataTest, shown, dialogId, children, onClose }: Props) 
     ev => {
       ev.stopPropagation();
       if (ev.target === overlay.current) {
-        onClose();
+        onClose(ev);
       }
     },
     [onClose],
@@ -113,7 +113,7 @@ const DialogContent = ({ dataTest, shown, dialogId, children, onClose }: Props) 
       if (dialog.current) {
         const focusableElements = dialog.current.querySelectorAll(FOCUSABLE_ELEMENT_SELECTORS);
         if (Object.values(focusableElements).some(v => v === ev.target)) {
-          onClose();
+          onClose(ev);
         }
       }
     },

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js
@@ -49,7 +49,7 @@ const MobileDialog = ({
       setshown(false);
       setRenderWithTimeout(false);
     },
-    [setRenderWithTimeout, setshown],
+    [setRenderWithTimeout, setshown, stopPropagation],
   );
 
   if (!enabled) return children;

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js
@@ -41,10 +41,16 @@ const MobileDialog = ({
     [clearRenderTimeout, setRender, setshownWithTimeout, stopPropagation],
   );
 
-  const handleOutMobile = useCallback(() => {
-    setshown(false);
-    setRenderWithTimeout(false);
-  }, [setRenderWithTimeout, setshown]);
+  const handleOutMobile = useCallback(
+    ev => {
+      if (stopPropagation) {
+        ev.stopPropagation();
+      }
+      setshown(false);
+      setRenderWithTimeout(false);
+    },
+    [setRenderWithTimeout, setshown],
+  );
 
   if (!enabled) return children;
 


### PR DESCRIPTION
This Pull Request meets the following criteria:

- [x] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components has both `.flow` and `d.ts` files and are exprorted in `index.js.flow` and `index.d.ts`
