### PR TITLE
improve: add codemod for spacing of Stack

### DIFF
--- a/packages/orbit-components/transforms/Stack-spacing.js
+++ b/packages/orbit-components/transforms/Stack-spacing.js
@@ -1,0 +1,72 @@
+// @noflow
+/* eslint-disable no-param-reassign */
+
+const mediaQueries = ["mediumMobile", "largeMobile", "tablet", "desktop", "largeDesktop"];
+
+const oldSpacings = [
+  "none",
+  "extraTight",
+  "tight",
+  "condensed",
+  "compact",
+  "natural",
+  "comfy",
+  "loose",
+  "extraLoose",
+];
+
+const newSpacings = [
+  "none",
+  "XXXSmall",
+  "XXSmall",
+  "XSmall",
+  "small",
+  "medium",
+  "large",
+  "XLarge",
+  "XXLarge",
+];
+
+const replaceValue = value => {
+  if (newSpacings.findIndex(v => v === value) === -1) {
+    return newSpacings[oldSpacings.findIndex(v => v === value)];
+  }
+  return value;
+};
+
+function transformStackSpacing(fileInfo, api) {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  // basic usage on JSX element with string literal
+  root
+    .find(j.JSXOpeningElement, { name: { name: "Stack" } })
+    .find(j.JSXAttribute, { name: { name: "spacing" } })
+    .forEach(path => {
+      path.node.value.value = replaceValue(path.node.value.value);
+    });
+
+  // usage in media queries with string literal
+  mediaQueries.forEach(mq => {
+    root
+      .findJSXElements("Stack")
+      .find(j.JSXAttribute, { name: { name: mq }, value: { type: "JSXExpressionContainer" } })
+      .find(j.ObjectExpression)
+      .find(j.Property, { key: { name: "spacing" } })
+      .forEach(path => {
+        path.node.value.value = replaceValue(path.node.value.value);
+      });
+  });
+
+  // usage in conditional expression
+  root
+    .findJSXElements("Stack")
+    .find(j.JSXAttribute, { name: { name: "spacing" } })
+    .find(j.ConditionalExpression)
+    .forEach(path => {
+      path.node.consequent.value = replaceValue(path.node.consequent.value);
+      path.node.alternate.value = replaceValue(path.node.alternate.value);
+    });
+  return root.toSource();
+}
+
+module.exports = transformStackSpacing;

--- a/packages/orbit-components/transforms/__testfixtures__/Stack-spacing.input.js
+++ b/packages/orbit-components/transforms/__testfixtures__/Stack-spacing.input.js
@@ -1,0 +1,35 @@
+// @noflow
+/* eslint-disable import/no-extraneous-dependencies */
+import React from "react";
+import { Stack, Button } from "@kiwicom/orbit-components";
+
+const MyApp = () => {
+  const isMobile = false;
+  return (
+    <Stack spacing="extraTight">
+      <Stack
+        spacing={isMobile ? "tight" : "condensed"}
+        mediumMobile={{ spacing: "condensed" }}
+        largeMobile={{ spacing: "compact" }}
+        tablet={{ spacing: "natural" }}
+        desktop={{ spacing: "comfy" }}
+        largeDesktop={{ spacing: "loose" }}
+      >
+        <Button type="primary">Hello World</Button>
+        <Button type="secondary">Hello World</Button>
+      </Stack>
+      <Stack
+        spacing="loose"
+        mediumMobile={{ spacing: "extraLoose" }}
+        largeMobile={{ spacing: "loose" }}
+        tablet={{ spacing: "condensed" }}
+        desktop={{ spacing: "extraTight" }}
+        largeDesktop={{ spacing: "none" }}
+      >
+        <Button type="primary">Hello World</Button>
+        <Button type="secondary">Hello World</Button>
+      </Stack>
+    </Stack>
+  );
+};
+export default MyApp;

--- a/packages/orbit-components/transforms/__testfixtures__/Stack-spacing.output.js
+++ b/packages/orbit-components/transforms/__testfixtures__/Stack-spacing.output.js
@@ -1,0 +1,35 @@
+// @noflow
+/* eslint-disable import/no-extraneous-dependencies */
+import React from "react";
+import { Stack, Button } from "@kiwicom/orbit-components";
+
+const MyApp = () => {
+  const isMobile = false;
+  return (
+    <Stack spacing="XXXSmall">
+      <Stack
+        spacing={isMobile ? "XXSmall" : "XSmall"}
+        mediumMobile={{ spacing: "XSmall" }}
+        largeMobile={{ spacing: "small" }}
+        tablet={{ spacing: "medium" }}
+        desktop={{ spacing: "large" }}
+        largeDesktop={{ spacing: "XLarge" }}
+      >
+        <Button type="primary">Hello World</Button>
+        <Button type="secondary">Hello World</Button>
+      </Stack>
+      <Stack
+        spacing="XLarge"
+        mediumMobile={{ spacing: "XXLarge" }}
+        largeMobile={{ spacing: "XLarge" }}
+        tablet={{ spacing: "XSmall" }}
+        desktop={{ spacing: "XXXSmall" }}
+        largeDesktop={{ spacing: "none" }}
+      >
+        <Button type="primary">Hello World</Button>
+        <Button type="secondary">Hello World</Button>
+      </Stack>
+    </Stack>
+  );
+};
+export default MyApp;

--- a/packages/orbit-components/transforms/__tests__/Stack-spacing.test.js
+++ b/packages/orbit-components/transforms/__tests__/Stack-spacing.test.js
@@ -1,0 +1,4 @@
+// @flow
+const { defineTest } = require("jscodeshift/dist/testUtils");
+
+defineTest(__dirname, "Stack-spacing");


### PR DESCRIPTION
Adding codemod to be able to shift usages of Stack to updated spacings that are coming in #2457.

```bash
yarn global add jscodeshift
jscodeshift --transform https://raw.githubusercontent.com/kiwicom/orbit/master/packages/orbit-components/transforms/Stacj-spacing.js [path] --parser=babel|babylon|flow|ts|tsx
```