### PR TITLE
fix(ButtonPrimitive): Button hover state when clicked

### DIFF
--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.js
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.js
@@ -177,7 +177,7 @@ export const StyledButtonPrimitive = styled(
       ${iconContainerColor(icons && icons.foregroundFocus)};
     }
 
-    &:focus:hover,
+    &:focus:not(:active):hover,
     &:hover {
       ${!disabled &&
       css`

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.js
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.js
@@ -142,17 +142,6 @@ export const StyledButtonPrimitive = styled(
       height: ${icons && icons.height};
     }
 
-    &:hover {
-      ${!disabled &&
-      css`
-        background: ${backgroundHover};
-        color: ${foregroundHover}!important;
-        box-shadow: ${boxShadowHover};
-        text-decoration: none;
-        ${iconContainerColor(icons && icons.foregroundHover)};
-      `};
-    }
-
     &:active {
       ${!disabled &&
       css`
@@ -186,6 +175,18 @@ export const StyledButtonPrimitive = styled(
       color: ${foregroundFocus}!important;
       text-decoration: none;
       ${iconContainerColor(icons && icons.foregroundFocus)};
+    }
+
+    &:focus:hover,
+    &:hover {
+      ${!disabled &&
+      css`
+        background: ${backgroundHover};
+        color: ${foregroundHover}!important;
+        box-shadow: ${boxShadowHover};
+        text-decoration: none;
+        ${iconContainerColor(icons && icons.foregroundHover)};
+      `};
     }
   `}};
 `;


### PR DESCRIPTION
When Button is clicked, chrome keeps it in focus state thus hiding any future hover states.