### PR TITLE
fix(InputFile): use button tag for select button

### DIFF
--- a/packages/orbit-components/src/InputFile/index.js
+++ b/packages/orbit-components/src/InputFile/index.js
@@ -137,7 +137,7 @@ const InputFile = React.forwardRef<Props, HTMLInputElement>(
         />
         {label && <FormLabel filled={Boolean(fileName)}>{label}</FormLabel>}
         <FakeInput error={error}>
-          <Button type="secondary" size="small" iconLeft={<Attachment />} asComponent="div">
+          <Button type="secondary" size="small" iconLeft={<Attachment />}>
             {buttonLabel}
           </Button>
           <StyledFileInput fileName={fileName} error={error}>


### PR DESCRIPTION
This improves accessibility. For some reason this was being set as `div` from the beginning (#231), but I don't see a reason for it (anymore).
<br/><br/><br/><url>LiveURL: https://orbit-fix-input-file-select-button-a11y.surge.sh</url>