### PR TITLE
fix(InputFile): forward onFocus event handler

### DIFF
--- a/packages/orbit-components/src/InputFile/index.js
+++ b/packages/orbit-components/src/InputFile/index.js
@@ -112,6 +112,7 @@ const InputFile = React.forwardRef<Props, HTMLInputElement>(
       error,
       help,
       onChange,
+      onFocus,
       onBlur,
       allowedFileTypes,
       tabIndex,
@@ -129,7 +130,7 @@ const InputFile = React.forwardRef<Props, HTMLInputElement>(
           name={name}
           error={error}
           onChange={onChange}
-          onFocus={onChange}
+          onFocus={onFocus}
           onBlur={onBlur}
           accept={allowedFileTypes}
           ref={ref}


### PR DESCRIPTION
Focusing the input was previously triggering the `onChange` event handler, now `onFocus` is properly being forwarded. This should not be a problem, but is technically breaking for anyone that was relying on this behavior.

This behavior was there from the beginning, I assume it's a mistake because the component takes `onFocus` which it doesn't use.
<br/><br/><br/><url>LiveURL: https://orbit-fix-input-file-onFocus.surge.sh</url>