### PR TITLE
chore: fix master deploy because of missing build step of design tokens

### DIFF
--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install dependencies
         run: yarn install && yarn bootstrap
 
+      - name: Build design tokens
+        run: yarn orbit-design-tokens build
+
       - name: Deploy storybook
         run: yarn orbit-components deploy:storybook --ci
         env:


### PR DESCRIPTION
Missed this step in the import of `orbit-design-tokens`.<br/><br/><br/><url>LiveURL: https://orbit-fix-master-deploy-tokens.surge.sh</url>