### PR TITLE
docs: update changelogs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ packages/*/lib
 packages/*/umd
 flow-typed
 **/package.json
+CHANGELOG.md

--- a/packages/orbit-components/CHANGELOG.md
+++ b/packages/orbit-components/CHANGELOG.md
@@ -8,11 +8,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* **InputFile:** forward onFocus event handler ([#2461](https://github.com/kiwicom/orbit/issues/2461)) ([92ad4da](https://github.com/kiwicom/orbit/commit/92ad4da10e4c90b81917083af762a9ae7bf6048f))
-* **SkipNavigation:** fix typos in stories ([#2414](https://github.com/kiwicom/orbit/issues/2414)) ([b380a1c](https://github.com/kiwicom/orbit/commit/b380a1cd70649bbea781fb026c659b1ea5902bf6))
-* **Stack:** add forgotten interface export ([#2456](https://github.com/kiwicom/orbit/issues/2456)) ([a85d20a](https://github.com/kiwicom/orbit/commit/a85d20aee69b29ac8a5305a77ad9078623569e48))
-* **Tooltip:** do not propagate the onClick event on mobile when stopPropagate is set to true ([#2438](https://github.com/kiwicom/orbit/issues/2438)) ([00467c5](https://github.com/kiwicom/orbit/commit/00467c5d3f77e49f2fbccf848c8ae0328c38f8ad))
-* remove //flow from *.d.ts ([5a57884](https://github.com/kiwicom/orbit/commit/5a57884281dc952ad959e53608b3a9dee8239e85))
+- **InputFile:** forward onFocus event handler ([#2461](https://github.com/kiwicom/orbit/issues/2461)) ([92ad4da](https://github.com/kiwicom/orbit/commit/92ad4da10e4c90b81917083af762a9ae7bf6048f))
+- **SkipNavigation:** fix typos in stories ([#2414](https://github.com/kiwicom/orbit/issues/2414)) ([b380a1c](https://github.com/kiwicom/orbit/commit/b380a1cd70649bbea781fb026c659b1ea5902bf6))
+- **Stack:** add forgotten interface export ([#2456](https://github.com/kiwicom/orbit/issues/2456)) ([a85d20a](https://github.com/kiwicom/orbit/commit/a85d20aee69b29ac8a5305a77ad9078623569e48))
+- **Tooltip:** do not propagate the onClick event on mobile when stopPropagate is set to true ([#2438](https://github.com/kiwicom/orbit/issues/2438)) ([00467c5](https://github.com/kiwicom/orbit/commit/00467c5d3f77e49f2fbccf848c8ae0328c38f8ad))
+- remove //flow from \*.d.ts ([5a57884](https://github.com/kiwicom/orbit/commit/5a57884281dc952ad959e53608b3a9dee8239e85))
+- **CountryFlag** stop exporting `getCountryProps` ([#2436](https://github.com/kiwicom/orbit/pull/2436)) ([e001aabe](https://github.com/kiwicom/orbit/commit/e001aabea64b132977ba534ee54eb059794a68a4))
+- **ButtonPrimitive** correctly forward `ref` ([#2418](https://github.com/kiwicom/orbit/pull/2418)) ([cf4c4f33](https://github.com/kiwicom/orbit/commit/cf4c4f33fc41fa7af80d2861014ea653dc44cd89))
 
 
 ### Features

--- a/packages/orbit-design-tokens/CHANGELOG.md
+++ b/packages/orbit-design-tokens/CHANGELOG.md
@@ -6,14 +6,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 # 0.12.0 (2020-11-04)
 
 
-### Bug Fixes
-
-* **fontFamily:** escaping of value in SASS format ([#200](https://github.com/kiwicom/orbit-design-tokens/issues/200)) ([f40b34a](https://github.com/kiwicom/orbit-design-tokens/commit/f40b34a150efab1b5385d84d10b9a15c4b3568b4))
-
-
-### Features
-
-* **Packages:** import orbit-design-tokens ([1b886bf](https://github.com/kiwicom/orbit-design-tokens/commit/1b886bfa21c98feb3755dcbb605568a7ac8796d9))
-* expose design tokens as XML for Exponea ([#292](https://github.com/kiwicom/orbit-design-tokens/issues/292)) ([0126217](https://github.com/kiwicom/orbit-design-tokens/commit/0126217ea2668746ae48fdedffc280c8400bcf52))
-* typescript types ([#247](https://github.com/kiwicom/orbit-design-tokens/issues/247)) ([c79656f](https://github.com/kiwicom/orbit-design-tokens/commit/c79656f72bcacd43812bfc86545c9197a888ef26))
-* **colors:** Improve accessibility and better visual consistency of colors ([#197](https://github.com/kiwicom/orbit-design-tokens/issues/197)) ([d3c0b41](https://github.com/kiwicom/orbit-design-tokens/commit/d3c0b4142ae674d3e070c9a69eaa12262bb7665f))
+No changes, this release is just a side-effect of importing `@kiwicom/orbit-design-tokens` into the monorepo.


### PR DESCRIPTION
- stop prettifying changelogs because they are auto-generated

- remove all info from @kiwicom/orbit-design-tokens changelog because
the release doesn't contain anything new, it's just a side-effect of
importing to monorepo

- update @kiwicom/orbit-components changelog with missing info
<br/><br/><br/><url>LiveURL: https://orbit-docs-changelogs.surge.sh</url>