### PR TITLE
ci: force cli colors on GitHub Workflows

### DIFF
--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
 
+env: # Set environment variables for every job and step in this workflow
+  CLICOLOR: "1" # Enable colors for *NIX commands
+  PY_COLORS: "1" # Enable colors for Python-based utilities
+  FORCE_COLOR: "1" # Force colors in the terminal
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,11 @@ name: Compressed Size
 
 on: [pull_request]
 
+env: # Set environment variables for every job and step in this workflow
+  CLICOLOR: "1" # Enable colors for *NIX commands
+  PY_COLORS: "1" # Enable colors for Python-based utilities
+  FORCE_COLOR: "1" # Force colors in the terminal
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - master
 
+env: # Set environment variables for every job and step in this workflow
+  CLICOLOR: "1" # Enable colors for *NIX commands
+  PY_COLORS: "1" # Enable colors for Python-based utilities
+  FORCE_COLOR: "1" # Force colors in the terminal
+
 jobs:
   build_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Let's add some color to the GItHub Workflow outputs so it's easier to skim.

### Before
<img width="642" alt="Screenshot 2020-11-04 at 19 05 56" src="https://user-images.githubusercontent.com/524272/98151705-e3deea80-1ed0-11eb-9179-619ad3642051.png">
<img width="1012" alt="Screenshot 2020-11-04 at 19 02 50" src="https://user-images.githubusercontent.com/524272/98151434-729f3780-1ed0-11eb-8fcf-5b8f3fc30aaf.png">


### After
<img width="723" alt="Screenshot 2020-11-04 at 19 06 17" src="https://user-images.githubusercontent.com/524272/98151750-f6592400-1ed0-11eb-8ae0-89844abfc600.png">
<img width="1055" alt="Screenshot 2020-11-04 at 19 03 05" src="https://user-images.githubusercontent.com/524272/98151451-7af77280-1ed0-11eb-8f0f-11ac2ab76a95.png">

<br/><br/><br/><url>LiveURL: https://orbit-sampi-github-workflow-colors.surge.sh</url>