### PR TITLE
test(InputGroup): rewrite to Testing Library

### DIFF
--- a/packages/orbit-components/src/InputGroup/__tests__/index.test.js
+++ b/packages/orbit-components/src/InputGroup/__tests__/index.test.js
@@ -1,109 +1,78 @@
 // @flow
 import * as React from "react";
-import { shallow } from "enzyme";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import InputGroup from "../index";
-import Select from "../../Select";
 import InputField from "../../InputField";
-import CountryFlag from "../../CountryFlag";
-import { CODES } from "../../CountryFlag/consts";
-import SPACINGS_AFTER from "../../common/getSpacingToken/consts";
+import defaultTheme from "../../defaultTheme";
 
-describe(`InputGroup - Phone number`, () => {
-  const label = "Phone number";
-  const dataTest = "test";
-  const flex = ["0 0 130px", "1 1 100%"];
-  const onChange = jest.fn();
-  const onFocus = jest.fn();
-  const onBlur = jest.fn();
-  const spaceAfter = SPACINGS_AFTER.NORMAL;
-  const ref = React.createRef();
-  const selectOptions = [
-    { value: 1, label: "+420" },
-    { value: 2, label: "+421" },
-  ];
-  const selectValue = 1;
-
-  const countryFlagCode = CODES.CZ;
-
-  const inputPlaceholder = "e.g. 123 456 789";
-  const inputMaxLength = 11;
-  const inputValue = "777 888 999";
-  const component = shallow(
-    <InputGroup
-      label={label}
-      flex={flex}
-      help={
-        <div>
-          Enter your <strong>phone number</strong>
-        </div>
-      }
-      onChange={onChange}
-      dataTest={dataTest}
-      onFocus={onFocus}
-      onBlur={onBlur}
-      spaceAfter={spaceAfter}
-    >
-      <Select
-        options={selectOptions}
-        value={selectValue}
-        prefix={<CountryFlag code={countryFlagCode} />}
-        ref={ref}
-      />
-      <InputField placeholder={inputPlaceholder} maxLength={inputMaxLength} value={inputValue} />
-    </InputGroup>,
-  );
-  const input = component.find("InputField");
-  const select = component.find("Select");
-  const group = component.find("InputGroup__StyledInputGroup");
-
-  it("Select should have ref", () => {
-    expect(ref.current).toBeDefined();
+describe("InputGroup", () => {
+  it("should render label", () => {
+    render(
+      <InputGroup label="Label">
+        <InputField />
+      </InputGroup>,
+    );
+    expect(screen.getByRole("group", { name: "Label" })).toBeInTheDocument();
   });
-
-  it("should contain a label", () => {
-    expect(component.find("FormLabel").render().text()).toBe(label);
+  it("should pass dataTest to data-test", () => {
+    render(
+      <InputGroup dataTest="test">
+        <InputField />
+      </InputGroup>,
+    );
+    expect(screen.getByTestId("test")).toBeInTheDocument();
   });
-  it("should contain an input", () => {
-    expect(input.exists()).toBe(true);
+  it("should add margin using spaceAfter", () => {
+    render(
+      <InputGroup spaceAfter="normal">
+        <InputField />
+      </InputGroup>,
+    );
+    expect(screen.getByRole("group")).toHaveStyle({ marginBottom: defaultTheme.orbit.spaceSmall });
   });
-  it("should contain a select", () => {
-    expect(select.exists()).toBe(true);
-    expect(component.render().prop("data-test")).toBe(dataTest);
+  it("should render help message", () => {
+    render(
+      <InputGroup help="help message">
+        <InputField />
+      </InputGroup>,
+    );
+    expect(screen.getByText("help message")).toBeInTheDocument();
   });
-  it("should have spaceAFter", () => {
-    expect(group.prop("spaceAfter")).toBe(spaceAfter);
+  it("should render error message", () => {
+    render(
+      <InputGroup error="error message">
+        <InputField />
+      </InputGroup>,
+    );
+    expect(screen.getByText("error message")).toBeInTheDocument();
   });
-  it("should contain a fake div with styling", () => {
-    expect(component.find("InputGroup__FakeGroup").exists()).toBe(true);
+  it("should remove labels, help and error messages from child inputs", () => {
+    render(
+      <InputGroup>
+        <InputField label="Label" help="help message" />
+        <InputField error="error message" />
+      </InputGroup>,
+    );
+    expect(screen.queryByLabelText("Label")).not.toBeInTheDocument();
+    expect(screen.queryByText("help message")).not.toBeInTheDocument();
+    expect(screen.queryByText("error message")).not.toBeInTheDocument();
   });
-  it("should contain FeedBack", () => {
-    expect(component.find(`FormFeedback`).exists()).toBe(true);
-  });
-  it("input should execute onChange method", () => {
-    input.simulate("change");
+  it("should pass event handlers to child inputs", () => {
+    const onChange = jest.fn();
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    render(
+      <InputGroup onChange={onChange} onFocus={onFocus} onBlur={onBlur}>
+        <InputField />
+      </InputGroup>,
+    );
+    const input = screen.getByRole("textbox");
+    userEvent.type(input, "text");
     expect(onChange).toHaveBeenCalled();
-  });
-  it("select should execute onChange method", () => {
-    select.simulate("change");
-    expect(onChange).toHaveBeenCalled();
-  });
-  it("input should execute onFocus method", () => {
-    input.simulate("focus");
     expect(onFocus).toHaveBeenCalled();
-  });
-  it("select should execute onFocus method", () => {
-    select.simulate("focus");
-    expect(onFocus).toHaveBeenCalled();
-  });
-  it("input should execute onBlur method", () => {
-    input.simulate("focus");
-    input.simulate("blur");
-    expect(onBlur).toHaveBeenCalled();
-  });
-  it("select should execute onBlur method", () => {
-    select.simulate("focus");
-    select.simulate("blur");
+    fireEvent.blur(input);
     expect(onBlur).toHaveBeenCalled();
   });
 });

--- a/packages/orbit-components/src/InputGroup/index.js
+++ b/packages/orbit-components/src/InputGroup/index.js
@@ -240,15 +240,6 @@ const InputGroup = ({
           return (
             <StyledChild flex={childFlex}>
               {React.cloneElement(item, {
-                ref: node => {
-                  // Call the original ref, if any
-                  const { ref } = item;
-                  if (typeof ref === "function") {
-                    ref(node);
-                  } else if (ref !== null) {
-                    ref.current = node;
-                  }
-                },
                 size,
                 label: undefined,
                 help: undefined,


### PR DESCRIPTION
I removed our implementation of preserving `ref` in input children
because `cloneElement` already preserves refs by default.

https://reactjs.org/docs/react-api.html#cloneelement
<br/><br/><br/><url>LiveURL: https://orbit-test-testing-library-input-group.surge.sh</url>