### PR TITLE
fix(Inline): add inner wrapper for negative margin

### DIFF
--- a/packages/orbit-components/src/Inline/__tests__/index.test.js
+++ b/packages/orbit-components/src/Inline/__tests__/index.test.js
@@ -37,9 +37,9 @@ describe("#Inline", () => {
       </Inline>,
     );
     expect(screen.getByTestId(dataTest)).toBeInTheDocument();
-    const container = screen.getByTestId(dataTest);
-    expect(container).toHaveStyle({ alignItems: "center" });
-    expect(container).toHaveStyle({ justifyContent: "flex-start" });
+    const inner = screen.getByTestId(dataTest).firstChild;
+    expect(inner).toHaveStyle({ alignItems: "center" });
+    expect(inner).toHaveStyle({ justifyContent: "flex-start" });
   });
 
   it.each(Object.entries(tokens))(

--- a/packages/orbit-components/src/Inline/index.js
+++ b/packages/orbit-components/src/Inline/index.js
@@ -9,11 +9,7 @@ import { normalize } from "./helpers";
 
 import type { Props } from "./index";
 
-const StyledInline = styled(({ asComponent: Element, children, className, dataTest }) => (
-  <Element className={className} data-test={dataTest}>
-    {children}
-  </Element>
-))`
+const StyledInlineInner = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -30,12 +26,12 @@ const StyledInline = styled(({ asComponent: Element, children, className, dataTe
   }}
 `;
 
-StyledInline.defaultProps = {
+StyledInlineInner.defaultProps = {
   theme: defaultTheme,
 };
 
 const Inline = ({
-  as = "div",
+  as: Component = "div",
   mediumMobile,
   largeMobile,
   className,
@@ -49,14 +45,9 @@ const Inline = ({
   const viewportSizes = { smallMobile, mediumMobile, largeMobile, tablet, desktop };
 
   return (
-    <StyledInline
-      asComponent={as}
-      className={className}
-      dataTest={dataTest}
-      viewportSizes={viewportSizes}
-    >
-      {children}
-    </StyledInline>
+    <Component className={className} data-test={dataTest}>
+      <StyledInlineInner viewportSizes={viewportSizes}>{children}</StyledInlineInner>
+    </Component>
   );
 };
 


### PR DESCRIPTION
This way if someone applies margin to `Inline`, e.g. if it's nested
inside a component like `Stack`, its negative margin won't be
overridden.
<br/><br/><br/><url>LiveURL: https://orbit-fix-inline-inner.surge.sh</url>