### PR TITLE
fix(Modal): lost focus on user interaction

### DIFF
--- a/packages/orbit-components/src/Modal/index.js
+++ b/packages/orbit-components/src/Modal/index.js
@@ -374,7 +374,7 @@ const Modal = React.forwardRef<Props, Instance>(
         clearTimeout(timer);
         window.removeEventListener("resize", handleResize);
       };
-    });
+    }, [handleResize]);
 
     React.useEffect(() => {
       if (children !== prevChildren) {

--- a/packages/orbit-components/src/Modal/index.js
+++ b/packages/orbit-components/src/Modal/index.js
@@ -359,31 +359,6 @@ const Modal = React.forwardRef<Props, Instance>(
 
     const prevChildren = usePrevious(children);
 
-    /* eslint-disable no-use-before-define */
-    React.useEffect(() => {
-      const timer: TimeoutID = setTimeout(() => {
-        setLoaded(true);
-        decideFixedFooter();
-        setDimensions();
-        setFirstFocus();
-      }, 15);
-
-      window.addEventListener("resize", handleResize);
-
-      return () => {
-        clearTimeout(timer);
-        window.removeEventListener("resize", handleResize);
-      };
-    }, [handleResize]);
-
-    React.useEffect(() => {
-      if (children !== prevChildren) {
-        decideFixedFooter();
-        setDimensions();
-      }
-    }, [children, prevChildren]);
-    /* eslint-enable no-use-before-define */
-
     const setDimensions = () => {
       const content = modalContent.current;
 
@@ -460,10 +435,10 @@ const Modal = React.forwardRef<Props, Instance>(
       keyboardHandler(event);
     };
 
-    const handleResize = () => {
+    const handleResize = React.useCallback(() => {
       setDimensions();
       decideFixedFooter();
-    };
+    }, []);
 
     const handleClickOutside = (event: MouseEvent) => {
       const clickedOutside =
@@ -570,6 +545,29 @@ const Modal = React.forwardRef<Props, Instance>(
     React.useImperativeHandle(ref, () => ({
       setScrollPosition,
     }));
+
+    React.useEffect(() => {
+      const timer: TimeoutID = setTimeout(() => {
+        setLoaded(true);
+        decideFixedFooter();
+        setDimensions();
+        setFirstFocus();
+      }, 15);
+
+      window.addEventListener("resize", handleResize);
+
+      return () => {
+        clearTimeout(timer);
+        window.removeEventListener("resize", handleResize);
+      };
+    }, [handleResize]);
+
+    React.useEffect(() => {
+      if (children !== prevChildren) {
+        decideFixedFooter();
+        setDimensions();
+      }
+    }, [children, prevChildren]);
 
     return (
       <ModalBody


### PR DESCRIPTION
When user interaction is done inside the modal, the focus of activeElement will be lost and `modalBody` or `modalContent` will be focused.<br/><br/><br/><url>LiveURL: https://orbit-fix-modal-focus.surge.sh</url>