### PR TITLE
ListChoice tests

### DIFF
--- a/packages/orbit-components/src/ListChoice/__tests__/index.test.js
+++ b/packages/orbit-components/src/ListChoice/__tests__/index.test.js
@@ -1,119 +1,77 @@
 // @flow
 import * as React from "react";
-import { shallow } from "enzyme";
-import { render } from "react-dom";
-import { nullthrows } from "@adeira/js";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import ListChoice from "../index";
 import Accommodation from "../../icons/Accommodation";
 
-let screen;
-const body = nullthrows(document.body, "Expected document to have a body");
-
-beforeEach(() => {
-  screen = document.createElement("div");
-  body.appendChild(screen);
-});
-
-afterEach(() => {
-  body.removeChild(screen);
-});
-
 describe("ListChoice", () => {
   const title = "Choice Title";
-  const description = "Further description";
   const dataTest = "test";
-  const selected = true;
-  const selectable = true;
   const onClick = jest.fn();
 
-  const component = shallow(
-    <ListChoice
-      title={title}
-      description={description}
-      selectable={selectable}
-      selected={selected}
-      disabled
-      icon={<Accommodation />}
-      onClick={onClick}
-      dataTest={dataTest}
-    />,
-  );
-  const content = component.find("ListChoice__StyledListChoiceContent");
+  render(<ListChoice title={title} dataTest={dataTest} />);
+  it("should have data-test", () => {
+    expect(screen.getByTestId(dataTest)).toBeInTheDocument();
+  });
+
   it("should render icon", () => {
-    expect(component.find("Accommodation").exists()).toBe(true);
-  });
-  it("should render data-test", () => {
-    expect(component.render().prop("data-test")).toBe(dataTest);
-  });
-  it("should render title and description", () => {
-    expect(content.find("Heading").children().text()).toBe(title);
-    expect(content.find("Text").children().text()).toBe(description);
-  });
-  it("should render checkbox with checked false", () => {
-    expect(component.find("Checkbox").prop("checked")).toBe(true);
-  });
-  it("should NOT execute onClick method", () => {
-    component.simulate("click");
-    expect(onClick).not.toHaveBeenCalled();
-  });
-  it("should execute onClick method", () => {
-    component.setProps({ disabled: false });
-    component.simulate("click");
-    expect(onClick).toHaveBeenCalled();
-  });
-  it("should have role button when not selectable", () => {
     render(
       <ListChoice
         title={title}
-        description={description}
-        selectable={false}
-        icon={<Accommodation />}
-        onClick={onClick}
+        icon={<Accommodation ariaLabel="Accommodation" />}
         dataTest={dataTest}
       />,
-      screen,
     );
+    const icon = screen.getByLabelText("Accommodation");
+    expect(icon.tagName.toLowerCase()).toBe("svg");
+  });
 
-    const listChoice = screen.querySelector(`[data-test="${dataTest}"]`);
-    expect(listChoice?.getAttribute("role")).toBe("button");
+  it("should render title and description", () => {
+    const description = "Further description";
+    render(<ListChoice title={title} description={description} />);
+    expect(screen.getByText(description)).toBeInTheDocument();
+  });
+
+  it("should render checkbox with checked false", () => {
+    render(<ListChoice title={title} selectable />);
+    expect(screen.getByRole("checkbox", { checked: false })).toBeInTheDocument();
+  });
+
+  it("should NOT execute onClick method", () => {
+    render(<ListChoice title={title} disabled onClick={onClick} dataTest={dataTest} />);
+    const component = screen.getByTestId(dataTest);
+    userEvent.click(component);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("should execute onClick method", () => {
+    render(<ListChoice title={title} onClick={onClick} dataTest={dataTest} />);
+    const el = screen.getByTestId(dataTest);
+    userEvent.click(el);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("should have role button when not selectable", () => {
+    render(<ListChoice title={title} onClick={onClick} />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
   });
 
   it("should have role checkbox when selectable", () => {
-    render(
-      <ListChoice
-        title={title}
-        description={description}
-        selectable
-        selected={false}
-        icon={<Accommodation />}
-        onClick={onClick}
-        dataTest={dataTest}
-      />,
-      screen,
-    );
-
-    const listChoice = screen.querySelector(`[data-test="${dataTest}"]`);
-    expect(listChoice?.getAttribute("role")).toBe("checkbox");
-    expect(listChoice?.getAttribute("aria-checked")).toBe("false");
+    render(<ListChoice title={title} selectable dataTest={dataTest} />);
+    expect(screen.getByTestId(dataTest)).toHaveAttribute("role", "checkbox");
   });
 
-  it("should have aria-checked true when selectable and selected", () => {
-    render(
-      <ListChoice
-        title={title}
-        description={description}
-        selectable
-        selected
-        icon={<Accommodation />}
-        onClick={onClick}
-        dataTest={dataTest}
-      />,
-      screen,
-    );
+  it("should have focus", () => {
+    render(<ListChoice title={title} selectable dataTest={dataTest} />);
+    userEvent.tab();
+    expect(screen.getByTestId(dataTest)).toHaveFocus();
+  });
 
-    const listChoice = screen.querySelector(`[data-test="${dataTest}"]`);
-    expect(listChoice?.getAttribute("role")).toBe("checkbox");
-    expect(listChoice?.getAttribute("aria-checked")).toBe("true");
+  it("should not have focus", () => {
+    render(<ListChoice title={title} disabled selectable dataTest={dataTest} />);
+    userEvent.tab();
+    expect(screen.getByTestId(dataTest)).toHaveFocus();
   });
 });

--- a/packages/orbit-components/src/ListChoice/__tests__/index.test.js
+++ b/packages/orbit-components/src/ListChoice/__tests__/index.test.js
@@ -11,8 +11,8 @@ describe("ListChoice", () => {
   const dataTest = "test";
   const onClick = jest.fn();
 
-  render(<ListChoice title={title} dataTest={dataTest} />);
   it("should have data-test", () => {
+    render(<ListChoice title={title} dataTest={dataTest} />);
     expect(screen.getByTestId(dataTest)).toBeInTheDocument();
   });
 
@@ -59,7 +59,7 @@ describe("ListChoice", () => {
   });
 
   it("should have role checkbox when selectable", () => {
-    render(<ListChoice title={title} selectable dataTest={dataTest} />);
+    render(<ListChoice title={title} selectable selected dataTest={dataTest} />);
     expect(screen.getByTestId(dataTest)).toHaveAttribute("role", "checkbox");
   });
 
@@ -72,6 +72,6 @@ describe("ListChoice", () => {
   it("should not have focus", () => {
     render(<ListChoice title={title} disabled selectable dataTest={dataTest} />);
     userEvent.tab();
-    expect(screen.getByTestId(dataTest)).toHaveFocus();
+    expect(screen.getByTestId(dataTest)).not.toHaveFocus();
   });
 });


### PR DESCRIPTION
- Should not be squashed (as we agreed, i suppose it's time me to start use that our agreement) 
- 2 commits (switch to testing-library and focus test)<br/><br/><br/><url>LiveURL: https://orbit-feat-testing-library-listchoice.surge.sh</url>