### PR TITLE
fix(Tooltip): only call `preventDefault` on mobile

### DIFF
--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.js
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.js
@@ -65,16 +65,13 @@ const TooltipPrimitive = ({
     setRenderWithTimeout(false);
   }, [setRenderWithTimeout]);
 
-  const handleInMobile = useCallback(
+  const handleClick = useCallback(
     ev => {
       if (stopPropagation) {
         ev.stopPropagation();
       }
-      ev.preventDefault();
-      setRender(true);
-      clearRenderTimeout();
     },
-    [clearRenderTimeout, setRender, stopPropagation],
+    [stopPropagation],
   );
 
   const handleOutMobile = useCallback(() => {
@@ -88,7 +85,7 @@ const TooltipPrimitive = ({
       <StyledTooltipChildren
         onMouseEnter={handleIn}
         onMouseLeave={handleOut}
-        onClick={handleInMobile}
+        onClick={handleClick}
         onFocus={handleIn}
         onBlur={handleOut}
         ref={container}


### PR DESCRIPTION
Calling was aborting stuff like `change` event on chekcbox, so Checkbox nested inside Tooltip doesn't work. This bug was introduced in #2230, where a piece of functionality was accidentally copied to `TooltipPrimitive`. I wonder how is this supposed to work on mobile, though… what should happen when you click on an interactive element to show the tooltip? This question is unrelated to this PR because that's how it always worked, I'm just wondering.

I was not able to test this fix because this bug is too complicated for jsdom, we need Cypress.

Request from #plz-orbit: https://skypicker.slack.com/archives/CAMS40F7B/p1605019864259600
<br/><br/><br/><url>LiveURL: https://orbit-fix-tooltip-checkbox.surge.sh</url>