### PR TITLE
chore: replaced deprecated action env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,10 +57,10 @@ jobs:
           node-version: 12
 
       - name: Get BRANCH_NAME
-        run: echo ::set-env name=BRANCH_NAME::${{ github.head_ref }}
+        run: echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
 
       - name: Get BRANCH_URL
-        run: echo ::set-env name=BRANCH_URL::$(sed -e 's/[^a-zA-Z0-9]/-/g' <<< ${{ github.head_ref }})
+        run: echo "BRANCH_URL=$(sed -e 's/[^a-zA-Z0-9]/-/g' <<< ${{ github.head_ref }})" >> $GITHUB_ENV
 
       - name: Build storybook
         run: yarn orbit-components build:storybook


### PR DESCRIPTION
::set-env was disabled, so i've updated it
<br/><br/><br/><url>LiveURL: https://orbit-chore-update-actions.surge.sh</url>