### PR TITLE
chore: downgrade Yarn

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -2,4 +2,4 @@
 # yarn lockfile v1
 
 
-yarn-path ".yarn/releases/yarn-1.22.4.js"
+yarn-path ".yarn/releases/yarn-1.19.1.js"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     }
   },
   "engines": {
-    "yarn": ">=1.22.4"
+    "yarn": ">=1.19.1"
   },
   "author": "kiwi.com",
   "license": "MIT",


### PR DESCRIPTION
This is because we ran into this longstanding issue when we tried to
install gatsby-plugin-sharp and gatsby-transformer-sharp:

https://github.com/yarnpkg/yarn/issues/7807
<br/><br/><br/><url>LiveURL: https://orbit-downgrade-yarn.surge.sh</url>