### PR TITLE
fix(RTL): fix Flow types of utilities

### DIFF
--- a/packages/orbit-components/src/utils/rtl/index.js.flow
+++ b/packages/orbit-components/src/utils/rtl/index.js.flow
@@ -1,15 +1,17 @@
 // @flow
 import type { ThemeProps } from "../../defaultTheme";
 
-export type LeftToRight = <T1, T2>(left: T1, right: T2) => ({| ...ThemeProps |}) => T1 | T2;
+export type LeftToRight = <T1, T2>(left: T1, right: T2) => ({ ...ThemeProps, ... }) => T1 | T2;
 
-export type RtlSpacing = (value: string) => ({| ...ThemeProps |}) => string;
+export type RtlSpacing = (value: string) => ({ ...ThemeProps, ... }) => string;
 
-export type BorderRadius = (value: string) => ({| ...ThemeProps |}) => string;
+export type BorderRadius = (value: string) => ({ ...ThemeProps, ... }) => string;
 
-export type TextAlign = (value: "left" | "right") => ({| ...ThemeProps |}) => string | LeftToRight;
+export type TextAlign = (
+  value: "left" | "right",
+) => ({ ...ThemeProps, ... }) => string | LeftToRight;
 
-export type Translate3d = (value: string) => ({| ...ThemeProps |}) => string;
+export type Translate3d = (value: string) => ({ ...ThemeProps, ... }) => string;
 
 declare export var rtlSpacing: RtlSpacing;
 


### PR DESCRIPTION
When we converted Flow types to exact in #2331, types of RTL utilities
should have stayes inexact because, other than the theme,
styled-components interpolations also receive component props.

As an additional precautionary measure, now they are explicitly inexact
in case we ever make exact types the default.
<br/><br/><br/><url>LiveURL: https://orbit-fix-rtl-spacing-flow-type.surge.sh</url>