### PR TITLE
fix: expose getScrollPosition in Modal

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,12 @@ module.exports = {
       files: "*.ts?(x)",
       extends: ["./config/eslintTS"],
     },
+    {
+      files: "**/__typetests__/**",
+      rules: {
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+      },
+    },
     // some ESLint rules fail in certain cases, so we're disabling them
     {
       files: ["packages/orbit-components/src/utils/**/*"],

--- a/packages/orbit-components/src/Modal/__tests__/index.test.js
+++ b/packages/orbit-components/src/Modal/__tests__/index.test.js
@@ -12,6 +12,10 @@ import Illustration from "../../Illustration";
 
 jest.useFakeTimers("modern");
 
+jest.mock("../../hooks/useMediaQuery", () => () => ({
+  isLargeMobile: true,
+}));
+
 beforeEach(() => {
   jest.clearAllTimers();
 });
@@ -68,7 +72,7 @@ describe("Modal", () => {
   });
 
   it("should expose ref scrolling API", () => {
-    const ref = React.createRef();
+    const ref = React.createRef<React.ElementRef<typeof Modal>>();
     render(
       <Modal ref={ref} dataTest="test">
         content
@@ -76,7 +80,9 @@ describe("Modal", () => {
     );
 
     ref.current?.setScrollPosition(20);
-    expect(screen.getByTestId("test").scrollTop).toBe(20);
+    const scrollPosition = ref.current?.getScrollPosition();
+    expect(scrollPosition).toBe(screen.getByTestId("test").scrollTop);
+    expect(scrollPosition).toBe(20);
   });
 
   it("should call callback function when clicking on close button", () => {

--- a/packages/orbit-components/src/Modal/__typetests__/index.js
+++ b/packages/orbit-components/src/Modal/__typetests__/index.js
@@ -1,0 +1,12 @@
+// @flow
+import * as React from "react";
+
+import Modal from "..";
+
+export default function Test() {
+  const ref = React.useRef<React.ElementRef<typeof Modal> | null>(null);
+  React.useEffect(() => {
+    ref.current?.getScrollPosition();
+  }, []);
+  return <Modal ref={ref}>content</Modal>;
+}

--- a/packages/orbit-components/src/Modal/__typetests__/index.tsx
+++ b/packages/orbit-components/src/Modal/__typetests__/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import Modal from "../";
+
+export default function Test() {
+  const ref = React.useRef<React.ElementRef<typeof Modal> | null>(null);
+  React.useEffect(() => {
+    ref.current?.getScrollPosition();
+  }, []);
+  return <Modal ref={ref}>content</Modal>;
+}

--- a/packages/orbit-components/src/Modal/index.d.ts
+++ b/packages/orbit-components/src/Modal/index.d.ts
@@ -20,7 +20,10 @@ export interface Props extends Common.Global {
   readonly hasCloseButton?: boolean;
 }
 
-type Instance = { setScrollPosition: (value: number) => void };
+type Instance = {
+  getScrollPosition: () => number | null;
+  setScrollPosition: (value: number) => void;
+};
 
 declare const Modal: React.ForwardRefExoticComponent<
   React.PropsWithoutRef<Props> & React.RefAttributes<Instance>

--- a/packages/orbit-components/src/Modal/index.js.flow
+++ b/packages/orbit-components/src/Modal/index.js.flow
@@ -36,7 +36,10 @@ export type Props = {|
   ...Globals,
 |};
 
-export type Instance = {| setScrollPosition: (value: number) => void |};
+export type Instance = {|
+  getScrollPosition: () => number | null,
+  setScrollPosition: (value: number) => void,
+|};
 
 declare export default React.AbstractComponent<Props, Instance>;
 


### PR DESCRIPTION
Reading scroll position was unintentionally possible when Modal was a class component because people could access Modal's elements through refs and read their `scrollTop`, but they had to duplicate Modal's logic for figuring out which element to read based on the viewport.

These changes implement official API for this called `getScrollPosition` which handles this internally.

Initially I thought of exposing `scrollPosition` value, but as we’ve discussed we would then have to read it all the time, which has performance implications, then I thought of `scrollingElement`, but it would be tedious for people to constantly check whether `scrollingElement.current` exists, and besides we only want to allow them to read scroll position and nothing more, so eventually I came up with `getScrollPosition`, which pairs very nicely with `setScrollPosition`.
<br/><br/><br/><url>LiveURL: https://orbit-fix-modal-scroll-position.surge.sh</url>