### PR TITLE
fix(Accordion): allow any children type in Flow

### DIFF
--- a/packages/orbit-components/src/Accordion/index.js.flow
+++ b/packages/orbit-components/src/Accordion/index.js.flow
@@ -9,7 +9,7 @@ import type { Globals } from "../common/common.js.flow";
 import typeof AccordionSectionType from "./AccordionSection/index.js.flow";
 
 export type Props = {|
-  +children?: React.ChildrenArray<React.Element<AccordionSectionType>>,
+  +children?: React.Node,
   +expandedSection?: string | number,
   +onExpand?: (sectionId: string | number) => void | Promise<any>,
   +loading?: boolean,


### PR DESCRIPTION
It turned out that people who use `Accordion` need to be able to pass any node as `children`.<br/><br/><br/><url>LiveURL: https://orbit-fix-accordion-children-type.surge.sh</url>