### PR TITLE
chore: add @kiwicom/orbit-components depenency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
     "serve": "gatsby serve"
   },
   "devDependencies": {
+    "@kiwicom/orbit-components": "^0.101.0",
     "@kiwicom/orbit-design-tokens": "^0.12.2",
     "@mapbox/rehype-prism": "^0.5.0",
     "@mdx-js/mdx": "^1.6.21",


### PR DESCRIPTION
This is necessary because orbit.kiwi uses components from
@kiwicom/orbit-components, without it adding it to dependencies the
build fails.
<br/><br/><br/><url>LiveURL: https://orbit-chore-docs-add-missing-dependency.surge.sh</url>