### PR TITLE
chore: use standard file for Jest configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+// @noflow
+
+module.exports = {
+  projects: ["<rootDir>/packages/*"],
+};

--- a/jest.json
+++ b/jest.json
@@ -1,5 +1,0 @@
-{
-  "projects": [
-    "<rootDir>/packages/*"
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier:test": "prettier --check '**/*.md'",
     "eslint:ci": "gulp eslintCI",
     "flow:check": "flow check",
-    "test": "jest --config=jest.json",
+    "test": "jest",
     "test-ci": "yarn orbit-components check:icons && yarn build-ci && yarn flow:check && yarn tsc && yarn eslint:ci && yarn test --ci --maxWorkers=2 && yarn workspace @kiwicom/babel-plugin-orbit-components test && yarn prettier:test",
     "update-supported-browsers": "markdown --path .github/contribution/testing-conventions.md && git add .github/contribution/testing-conventions.md",
     "loki:test": "yarn workspace @kiwicom/orbit-components loki test",


### PR DESCRIPTION
Having to explicitly specify the JSON configuration when running Jest is limiting when running `npx jest`, and there are no advantages.
<br/><br/><br/><url>LiveURL: https://orbit-chore-jest-config-json.surge.sh</url>