### PR TITLE
Various improvements in docs setup

### DIFF
--- a/config/eslintJS.js
+++ b/config/eslintJS.js
@@ -40,7 +40,7 @@ module.exports = {
           "docs/gatsby-*.js",
           "docs/plugins/**",
           "packages/*/.storybook/**",
-          "packages/*/config/**",
+          "**/config/**",
           "gulpfile.js",
         ],
       },

--- a/docs/config/jest-setup.js
+++ b/docs/config/jest-setup.js
@@ -1,0 +1,7 @@
+import { configure } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import "jest-styled-components";
+
+configure({
+  testIdAttribute: "data-test",
+});

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -15,7 +15,7 @@ module.exports = {
       resolve: "gatsby-plugin-mdx",
       options: {
         remarkPlugins: [],
-        rehypePlugins: [require("@mapbox/rehype-prism")],
+        rehypePlugins: [],
       },
     },
     "gatsby-transformer-sharp",

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -18,10 +18,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     query DocumentationQuery {
       allMdx(filter: { fields: { collection: { eq: "documentation" } } }) {
         nodes {
-          frontmatter {
-            title
-          }
-          body
+          id
           slug
         }
       }
@@ -40,10 +37,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     createPage({
       path: `/${slug}`,
       component: `${__dirname}/src/templates/Guide.tsx`,
-      context: {
-        title: guide.frontmatter.title,
-        body: guide.body,
-      },
+      context: { id: guide.id },
     });
   });
 };

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -36,7 +36,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
 
     createPage({
       path: `/${slug}`,
-      component: `${__dirname}/src/templates/Guide.tsx`,
+      component: `${__dirname}/src/templates/Doc.tsx`,
       context: { id: guide.id },
     });
   });

--- a/docs/jest.config.js
+++ b/docs/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  displayName: "orbit.kiwi",
+  testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["./config/jest-setup"],
+};

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,5 +21,8 @@
     "gatsby-source-filesystem": "^2.6.0",
     "gatsby-transformer-sharp": "^2.7.0",
     "tailwindcss": "^1.9.6"
+  },
+  "dependencies": {
+    "prism-react-renderer": "^1.1.1"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "@mapbox/rehype-prism": "^0.5.0",
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.21",
+    "@types/mdx-js__react": "^1.5.3",
     "babel-preset-gatsby": "^0.7.0",
     "gatsby": "^2.27.0",
     "gatsby-image": "^2.6.0",

--- a/docs/src/__tests__/mdx-components.test.tsx
+++ b/docs/src/__tests__/mdx-components.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import * as Components from "../mdx-components";
+
+describe("MDX components", () => {
+  describe("<a>", () => {
+    it("should adjust anchor element for external links", async () => {
+      render(<Components.a href="https://github.com/kiwicom/orbit">monorepo</Components.a>);
+      expect(screen.getByRole("link")).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  });
+});

--- a/docs/src/components/Code.tsx
+++ b/docs/src/components/Code.tsx
@@ -10,6 +10,9 @@ export const InlineCode = styled.code`
   color: #000;
   /* monospace typefaces appear a bit larger */
   font-size: calc(1em - 2px);
+  a & {
+    color: currentColor;
+  }
 `;
 
 interface CodeBlockProps {

--- a/docs/src/components/Code.tsx
+++ b/docs/src/components/Code.tsx
@@ -1,4 +1,7 @@
-import styled from "styled-components";
+import React from "react";
+import Highlight, { defaultProps } from "prism-react-renderer";
+import theme from "prism-react-renderer/themes/oceanicNext";
+import styled, { css } from "styled-components";
 
 export const InlineCode = styled.code`
   padding: 0.25em 0.5em;
@@ -9,84 +12,42 @@ export const InlineCode = styled.code`
   font-size: calc(1em - 2px);
 `;
 
-// copied from Prism's theme "Okaidia"
-export const Pre = styled.pre`
-  padding: 1em;
-  border-radius: 0.5em;
-  background: #272822;
-  color: #f8f8f2;
-
-  .token.comment,
-  .token.prolog,
-  .token.doctype,
-  .token.cdata {
-    color: slategray;
-  }
-
-  .token.punctuation {
-    color: #f8f8f2;
-  }
-
-  .namespace {
-    opacity: 0.7;
-  }
-
-  .token.property,
-  .token.tag,
-  .token.constant,
-  .token.symbol,
-  .token.deleted {
-    color: #f92672;
-  }
-
-  .token.boolean,
-  .token.number {
-    color: #ae81ff;
-  }
-
-  .token.selector,
-  .token.attr-name,
-  .token.string,
-  .token.char,
-  .token.builtin,
-  .token.inserted {
-    color: #a6e22e;
-  }
-
-  .token.operator,
-  .token.entity,
-  .token.url,
-  .language-css .token.string,
-  .style .token.string,
-  .token.variable {
-    color: #f8f8f2;
-  }
-
-  .token.atrule,
-  .token.attr-value,
-  .token.function,
-  .token.class-name {
-    color: #e6db74;
-  }
-
-  .token.keyword {
-    color: #66d9ef;
-  }
-
-  .token.regex,
-  .token.important {
-    color: #fd971f;
-  }
-
-  .token.important,
-  .token.bold {
-    font-weight: bold;
-  }
-  .token.italic {
-    font-style: italic;
-  }
-
-  .token.entity {
-    cursor: help;
-  }
-`;
+interface CodeBlockProps {
+  children: string;
+  className: string;
+}
+export const CodeBlock = ({ children, className }: CodeBlockProps) => {
+  const language = className.replace(/language-/, "");
+  return (
+    <Highlight
+      {...defaultProps}
+      code={children}
+      theme={theme}
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore avoid refining the string type to supported languages
+      language={language}
+    >
+      {({ style, tokens, getLineProps, getTokenProps }) => (
+        <div
+          css={css`
+            padding: 1em;
+            border-radius: 0.5em;
+            /* monospace typefaces appear a bit larger */
+            font-size: calc(1em - 2px);
+          `}
+          style={style}
+        >
+          {tokens
+            .filter(line => line.some(token => !token.empty)) // remove mysterious empty lines
+            .map((line, i) => (
+              <div key={i} {...getLineProps({ line, key: i })}>
+                {line.map((token, key) => (
+                  <span key={key} {...getTokenProps({ token, key })} />
+                ))}
+              </div>
+            ))}
+        </div>
+      )}
+    </Highlight>
+  );
+};

--- a/docs/src/hooks/__tests__/useIsUrlExternal.test.ts
+++ b/docs/src/hooks/__tests__/useIsUrlExternal.test.ts
@@ -1,0 +1,22 @@
+import { renderHook } from "@testing-library/react-hooks";
+
+import useIsUrlExternal from "../useIsUrlExternal";
+
+function isUrlExternal(url: string) {
+  const { result } = renderHook(() => useIsUrlExternal(url));
+  return result.current;
+}
+
+describe("useIsUrlExernal", () => {
+  it("should return true for external URLs", () => {
+    expect(isUrlExternal("https://www.wikipedia.org")).toBe(true);
+    expect(isUrlExternal("//www.wikipedia.org")).toBe(true);
+  });
+
+  it("should return false for local URLs", () => {
+    expect(isUrlExternal("/absolute")).toBe(false);
+    expect(isUrlExternal("relative")).toBe(false);
+    expect(isUrlExternal("#hash")).toBe(false);
+    expect(isUrlExternal("?query")).toBe(false);
+  });
+});

--- a/docs/src/hooks/useIsUrlExternal.ts
+++ b/docs/src/hooks/useIsUrlExternal.ts
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function useIsUrlExternal(url?: string): boolean {
+  return React.useMemo(() => {
+    if (!url) return false;
+    // https://stackoverflow.com/a/2911045/1247274
+    const parser = document.createElement("a");
+    parser.href = url;
+    return parser.hostname !== location.hostname;
+  }, [url]);
+}

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -16,7 +16,6 @@ interface Props {
 }
 
 export const p = Text;
-export const h1 = (props: Props) => <Heading as="h1" type="display" {...props} />;
 export const h2 = (props: Props) => <Heading as="h2" type="title1" {...props} />;
 export const h3 = (props: Props) => <Heading as="h3" type="title2" {...props} />;
 export const h4 = (props: Props) => <Heading as="h4" type="title3" {...props} />;

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -11,22 +11,70 @@ import {
 } from "@kiwicom/orbit-components";
 import { InlineCode, CodeBlock } from "./components/Code";
 
-interface Props {
-  children: React.ReactNode;
-}
-
-export const p = Text;
-export const h2 = (props: Props) => <Heading as="h2" type="title1" {...props} />;
-export const h3 = (props: Props) => <Heading as="h3" type="title2" {...props} />;
-export const h4 = (props: Props) => <Heading as="h4" type="title3" {...props} />;
-export const h5 = (props: Props) => <Heading as="h5" type="title4" {...props} />;
-export const h6 = (props: Props) => <Heading as="h6" type="title5" {...props} />;
-export const table = Table;
-export const thead = TableHead;
-export const tbody = TableBody;
-export const tr = TableRow;
-export const td = TableCell;
-export const th = TableCell;
+export const p = ({ children }: React.HTMLAttributes<HTMLParagraphElement>) => (
+  <Text>{children}</Text>
+);
+export const h2 = ({ children }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <Heading as="h2" type="title1">
+    {children}
+  </Heading>
+);
+export const h3 = ({ children }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <Heading as="h3" type="title2">
+    {children}
+  </Heading>
+);
+export const h4 = ({ children }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <Heading as="h4" type="title3">
+    {children}
+  </Heading>
+);
+export const h5 = ({ children }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <Heading as="h5" type="title4">
+    {children}
+  </Heading>
+);
+export const h6 = ({ children }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <Heading as="h6" type="title5">
+    {children}
+  </Heading>
+);
+export const table = ({ children }: React.TableHTMLAttributes<HTMLTableElement>) => (
+  <Table>{children}</Table>
+);
+export const thead = ({ children }: React.HTMLAttributes<HTMLTableSectionElement>) => (
+  <TableHead>{children}</TableHead>
+);
+export const tbody = ({ children }: React.HTMLAttributes<HTMLTableSectionElement>) => (
+  <TableBody>{children}</TableBody>
+);
+export const tr = ({ children }: React.HTMLAttributes<HTMLTableRowElement>) => (
+  <TableRow>{children}</TableRow>
+);
+export const td = ({
+  children,
+  align,
+  valign,
+}: React.TdHTMLAttributes<HTMLTableDataCellElement>) => (
+  <TableCell
+    as="td"
+    align={align === "left" || align === "center" || align === "right" ? align : undefined}
+    verticalAlign={valign}
+  >
+    {children}
+  </TableCell>
+);
+export const th = ({ children, align }: React.ThHTMLAttributes<HTMLTableHeaderCellElement>) => (
+  <TableCell
+    as="th"
+    align={align === "left" || align === "center" || align === "right" ? align : undefined}
+  >
+    {children}
+  </TableCell>
+);
 export const code = CodeBlock;
 export const inlineCode = InlineCode;
-export const a = TextLink;
+export const a = ({ children, href }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+  if (href) return <TextLink href={href}>{children}</TextLink>;
+  return <a href={href}>{children}</a>;
+};

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -9,7 +9,11 @@ import {
   TableRow,
   TableCell,
 } from "@kiwicom/orbit-components";
+import { NewWindow } from "@kiwicom/orbit-components/icons";
+import { navigate } from "gatsby";
+import { css } from "styled-components";
 import { InlineCode, CodeBlock } from "./components/Code";
+import useIsUrlExternal from "./hooks/useIsUrlExternal";
 
 export const p = ({ children }: React.HTMLAttributes<HTMLParagraphElement>) => (
   <Text>{children}</Text>
@@ -75,6 +79,28 @@ export const th = ({ children, align }: React.ThHTMLAttributes<HTMLTableHeaderCe
 export const code = CodeBlock;
 export const inlineCode = InlineCode;
 export const a = ({ children, href }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
-  if (href) return <TextLink href={href}>{children}</TextLink>;
-  return <a href={href}>{children}</a>;
+  const isExternal = useIsUrlExternal(href);
+  return (
+    <span
+      css={css`
+        /* TextLink's line-height affects nested elements like <code> */
+        a {
+          line-height: normal;
+        }
+      `}
+    >
+      <TextLink
+        href={href}
+        external={isExternal}
+        iconRight={isExternal && <NewWindow />}
+        onClick={event => {
+          if (isExternal || !href) return;
+          event.preventDefault();
+          navigate(href);
+        }}
+      >
+        {children}
+      </TextLink>
+    </span>
+  );
 };

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -9,7 +9,7 @@ import {
   TableRow,
   TableCell,
 } from "@kiwicom/orbit-components";
-import { InlineCode, Pre } from "./components/Code";
+import { InlineCode, CodeBlock } from "./components/Code";
 
 interface Props {
   children: React.ReactNode;
@@ -28,6 +28,6 @@ export const tbody = TableBody;
 export const tr = TableRow;
 export const td = TableCell;
 export const th = TableCell;
-export const pre = Pre;
+export const code = CodeBlock;
 export const inlineCode = InlineCode;
 export const a = TextLink;

--- a/docs/src/templates/Doc.tsx
+++ b/docs/src/templates/Doc.tsx
@@ -18,7 +18,7 @@ interface Props {
   };
 }
 
-export default function Guide({ data }: Props) {
+export default function Doc({ data }: Props) {
   const { frontmatter, body } = data.mdx;
   return (
     <Layout>
@@ -35,7 +35,7 @@ export default function Guide({ data }: Props) {
 }
 
 export const query = graphql`
-  query GuideQuery($id: String!) {
+  query DocQuery($id: String!) {
     mdx(id: { eq: $id }) {
       frontmatter {
         title

--- a/docs/src/templates/Guide.tsx
+++ b/docs/src/templates/Guide.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { graphql } from "gatsby";
 import { MDXProvider } from "@mdx-js/react";
 import { MDXRenderer } from "gatsby-plugin-mdx";
 import { Heading } from "@kiwicom/orbit-components";
@@ -7,19 +8,23 @@ import Prose from "../components/Prose";
 import * as components from "../mdx-components";
 
 interface Props {
-  pageContext: {
-    title: string;
-    body: string;
+  data: {
+    mdx: {
+      frontmatter: {
+        title: string;
+      };
+      body: string;
+    };
   };
 }
 
-export default function Guide({ pageContext }: Props) {
-  const { title, body } = pageContext;
+export default function Guide({ data }: Props) {
+  const { frontmatter, body } = data.mdx;
   return (
     <Layout>
       <Prose>
         <Heading as="h1" type="display">
-          {title}
+          {frontmatter.title}
         </Heading>
         <MDXProvider components={components}>
           <MDXRenderer>{body}</MDXRenderer>
@@ -28,3 +33,14 @@ export default function Guide({ pageContext }: Props) {
     </Layout>
   );
 }
+
+export const query = graphql`
+  query GuideQuery($id: String!) {
+    mdx(id: { eq: $id }) {
+      frontmatter {
+        title
+      }
+      body
+    }
+  }
+`;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 // @noflow
 
 module.exports = {
-  projects: ["<rootDir>/packages/*"],
+  projects: ["<rootDir>/packages/*", "<rootDir>/docs"],
 };

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@svgr/core": "^2.0.0",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.1.0",
+    "@testing-library/react-hooks": "^3.7.0",
     "@testing-library/user-event": "^12.1.10",
     "@types/styled-components": "^5.1.4",
     "@typescript-eslint/eslint-plugin": "^4.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20896,6 +20896,11 @@ pretty-hrtime@^1.0.0, pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
+prism-react-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.1.1.tgz#1c1be61b1eb9446a146ca7a50b7bcf36f2a70a44"
+  integrity sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug==
+
 prismjs@^1.8.4:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.20.0.tgz#9b685fc480a3514ee7198eac6a3bf5024319ff03"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5390,6 +5390,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.7.0.tgz#6d75c5255ef49bce39b6465bf6b49e2dac84919e"
+  integrity sha512-TwfbY6BWtWIHitjT05sbllyLIProcysC0dF0q1bbDa7OHLC6A6rJOYJwZ13hzfz3O4RtOuInmprBozJRyyo7/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/testing-library__react-hooks" "^3.4.0"
+
 "@testing-library/react@^11.1.0":
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.1.0.tgz#dfb4b3177d05a8ccf156b5fd14a5550e91d7ebe4"
@@ -5809,6 +5817,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@*":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.0.tgz#9be47b375eeb906fced37049e67284a438d56620"
+  integrity sha512-nvw+F81OmyzpyIE1S0xWpLonLUZCMewslPuA8BtjSKc5XEbn8zEQBXS7KuOLHTNnSOEM2Pum50gHOoZ62tqTRg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-textarea-autosize@^4.3.3":
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz#6c4d2753fa1864c98c0b2b517f67bb1f6e4c46de"
@@ -5878,6 +5893,13 @@
   integrity sha512-K7nUSpH/5i8i0NagTJ+uFUDRueDlnMNhJtMjMwTGPPSqyImbWC/hgKPDCKt6Phu2iMJg2kWqlax+Ucj2DKMwpA==
   dependencies:
     "@types/jest" "*"
+
+"@types/testing-library__react-hooks@^3.4.0":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz#b8d7311c6c1f7db3103e94095fe901f8fef6e433"
+  integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
+  dependencies:
+    "@types/react-test-renderer" "*"
 
 "@types/tmp@^0.0.33":
   version "0.0.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5681,6 +5681,13 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/mdx-js__react@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@types/mdx-js__react/-/mdx-js__react-1.5.3.tgz#2f858ab0ee5fc60b642f3764ef9001fe0530fe43"
+  integrity sha512-flP0BpS5rXnEbkU5ih79ARaI/+rK10Iee+zxTaWYtoiyc2+f1EJ8EnYgMmXHdAuI7OX4J9/hdoXfrfrri0AT+Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/micromatch@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.1.tgz#9381449dd659fc3823fd2a4190ceacc985083bc7"


### PR DESCRIPTION
This was based on the review comments I received in #2541.

- docs: solve syntax highlighting better
- docs: fetch guide info via id in the template
- chore: install type declarations for @mdx-js/react
- docs: remove MDX mapping for `<h1>`
- docs: get the most out of MDX component mapping
- docs: configure testing
- docs: refine MDX anchor style and handle external
- docs: adjust color of `<code>` in links

One thing I left out is guides URL, we'll do this separately after we agree on a complete content strategy, based on #2571.
<br/><br/><br/><url>LiveURL: https://orbit-docs-review-improvements.surge.sh</url>