### PR TITLE
fix(Wizard): translate progress label on mobile

### DIFF
--- a/packages/orbit-components/src/Wizard/index.js
+++ b/packages/orbit-components/src/Wizard/index.js
@@ -13,6 +13,7 @@ import Modal from "../Modal";
 import { CardSection } from "../Card";
 import useMediaQuery from "../hooks/useMediaQuery";
 import useTheme from "../hooks/useTheme";
+import useTranslate from "../hooks/useTranslate";
 
 import type { Props } from ".";
 
@@ -27,6 +28,7 @@ const Wizard = ({ dataTest, id, completedSteps, activeStep, children, onChangeSt
   const theme = useTheme();
   const [open, setOpen] = React.useState(false);
   const toggle = React.useRef<React.ElementRef<typeof ButtonLink> | null>(null);
+  const translate = useTranslate();
 
   const isCompact = !isLargeMobile;
   const childrenArray = React.Children.toArray(children);
@@ -78,7 +80,12 @@ const Wizard = ({ dataTest, id, completedSteps, activeStep, children, onChangeSt
             }}
           >
             <Stack as="span" inline>
-              <b>{`${activeStep + 1} of ${stepsCount}`}</b>{" "}
+              <b>
+                {translate("wizard_progress", {
+                  number: activeStep + 1,
+                  total: stepsCount,
+                })}
+              </b>{" "}
               <span
                 css={css`
                   font-weight: normal;

--- a/packages/orbit-components/src/data/dictionary/en-GB.json
+++ b/packages/orbit-components/src/data/dictionary/en-GB.json
@@ -13,5 +13,6 @@
   "navigationbar_open_menu": "Open navigation menu",
   "pagination_label_next": "Next",
   "pagination_label_prev": "Previous",
-  "ratingstar_description": "Rating __number__ out of __total__"
+  "ratingstar_description": "Rating __number__ out of __total__",
+  "wizard_progress": "__number__ of __total__"
 }


### PR DESCRIPTION
I didn't use the `fetch-translations` script because credentials weren't the only problem, it seems like it wasn't used for a while because I got an error for some short codes. I just added the translation script to `en-GB.json` instead, let me know if I was supposed to do it in a different way.
<br/><br/><br/><url>LiveURL: https://orbit-fix-wizard-translation.surge.sh</url>