### PR TITLE
test(Translate): test React component directly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,12 @@ module.exports = {
       extends: ["./config/eslintTS"],
     },
     {
+      files: "**/__tests__/**",
+      rules: {
+        "global-require": "off",
+      },
+    },
+    {
       files: "**/__typetests__/**",
       rules: {
         "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/packages/orbit-components/src/Translate/__tests__/index.test.js
+++ b/packages/orbit-components/src/Translate/__tests__/index.test.js
@@ -1,16 +1,28 @@
 // @flow
-import { pureTranslate } from "../index";
+import React from "react";
+import { render, screen } from "@testing-library/react";
 
 describe("Translate", () => {
-  const dictionary = {
-    button_close: "Close",
-  };
-
-  it("should return correct translations", () => {
-    expect(pureTranslate(dictionary, "button_close")).toBe("Close");
+  it("should return translation", () => {
+    jest.doMock("../../hooks/useDictionary", () => () => ({
+      wizard_progress: "Custom __number__ of __total__",
+    }));
+    const Translate = require("..").default;
+    render(
+      <Translate
+        tKey="wizard_progress"
+        values={{
+          number: 5,
+          total: 10,
+        }}
+      />,
+    );
+    expect(screen.getByText("Custom 5 of 10")).toBeInTheDocument();
   });
 
-  it("Will fallback to default lang", () => {
-    expect(pureTranslate({}, "button_close")).toBe("Close");
+  it("should fall back to default dictionary", () => {
+    const Translate = require("..").default;
+    render(<Translate tKey="loading" />);
+    expect(screen.getByText("Loading")).toBeInTheDocument();
   });
 });

--- a/packages/orbit-components/src/Translate/index.js
+++ b/packages/orbit-components/src/Translate/index.js
@@ -1,7 +1,5 @@
 // @flow
-import * as React from "react";
-
-import DictionaryContext from "../Dictionary/DictionaryContext";
+import useDictionary from "../hooks/useDictionary";
 import DEFAULT_DICTIONARY from "../data/dictionary/en-GB.json";
 
 import type { Props, PureTranslate } from "./index";
@@ -19,10 +17,9 @@ export const pureTranslate: PureTranslate = (translations, key, values = {}) => 
   );
 };
 
-const Translate = ({ tKey, values }: Props) => (
-  <DictionaryContext.Consumer>
-    {dictionary => pureTranslate(dictionary, tKey, values)}
-  </DictionaryContext.Consumer>
-);
+const Translate = ({ tKey, values }: Props) => {
+  const dictionary = useDictionary();
+  return pureTranslate(dictionary, tKey, values);
+};
 
 export default Translate;


### PR DESCRIPTION
The tests were testing lower level API instead of the component itself. Now we're testing `pureTranslate` indirectly through the Translate component because that's the API that people are using.

Mocking `window.matchMedia` was necessary because `ThemeProvider` requires it.<br/><br/><br/><url>LiveURL: https://orbit-testing-library-translate.surge.sh</url>