### PR TITLE
test(TooltipPrimitive): small fixes

### DIFF
--- a/packages/orbit-components/src/primitives/TooltipPrimitive/__tests__/index.test.js
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/__tests__/index.test.js
@@ -2,22 +2,20 @@
 import * as React from "react";
 import { render } from "@testing-library/react";
 
-// TODO: it is failing without it, seems like @testing-library does not see it in global config
-import "jest-styled-components";
 import Tooltip from "../index";
 import Airplane from "../../../icons/Airplane";
 
+jest.mock("../../../utils/randomID", () => name => `${name}50000-id-50000`);
+
 describe("Tooltip", () => {
-  const content = "Write some message to the user";
-  jest.spyOn(React, "useMemo").mockImplementationOnce(() => "TooltipID50000-id-50000");
-
-  const { container } = render(
-    <Tooltip content={content}>
-      <Airplane />
-    </Tooltip>,
-  );
-
   it("it should match snapshot", () => {
+    const content = "Write some message to the user";
+    const { container } = render(
+      <Tooltip content={content}>
+        <Airplane />
+      </Tooltip>,
+    );
+
     expect(container.firstChild).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
I went to check whether `TooltipPrimitive` tests needed to be refactored to Testing Library, they were already using it but I noticed a couple of things.

- `jest-styled-components` needed to be imported before because the
component was being rendered outside the test block

- instead of mocking `useMemo` implementation, which is very bad, we're
now mocking the `randomID` util, which was the purpose of the `useMemo`
mock
