### PR TITLE
improve: stop enforcing commit scope case

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
-    "scope-case": [2, "always", "pascal-case"],
+    "scope-case": [0],
     "footer-max-line-length": [2, "always", 150],
     "type-enum": [
       2,


### PR DESCRIPTION
I assume this was intended for committing changes to React components, but we also have hooks, helpers, etc. Having to commit the scope as PascalCase doesn't make sense, so we're disabling this rule.

This has been driving me crazy 😅 <br/><br/><br/><url>LiveURL: https://orbit-improve-commitlint-liberal-scope.surge.sh</url>