### PR TITLE
fix(Modal): ensure header overlay if title exists

### DIFF
--- a/packages/orbit-components/src/Modal/Modal.stories.js
+++ b/packages/orbit-components/src/Modal/Modal.stories.js
@@ -44,7 +44,7 @@ storiesOf("Modal", module)
         "You can try all possible configurations of this component. However, check Orbit.Kiwi for more detailed design guidelines.",
       );
       return (
-        <Modal onClose={onClose} size={size}>
+        <Modal size={size} onClose={onClose}>
           <ModalHeader title={title}>{description}</ModalHeader>
           <ModalSection>
             <Text>{content}</Text>

--- a/packages/orbit-components/src/Modal/ModalContext.d.ts
+++ b/packages/orbit-components/src/Modal/ModalContext.d.ts
@@ -8,6 +8,7 @@ declare module "@kiwicom/orbit-components/lib/Modal";
 export interface Props {
   readonly setDimensions?: () => void;
   readonly decideFixedFooter?: () => void;
+  readonly setHasModalTitle?: React.Dispatch<React.SetStateAction<boolean>>;
   readonly setHasModalSection?: () => void;
   readonly removeHasModalSection?: () => void;
   readonly manageFocus?: () => void;

--- a/packages/orbit-components/src/Modal/ModalContext.js
+++ b/packages/orbit-components/src/Modal/ModalContext.js
@@ -4,6 +4,7 @@ import * as React from "react";
 import type { WithModalContextType, ModalContextType } from "./ModalContext";
 
 export const ModalContext: ModalContextType = React.createContext({
+  setHasModalTitle: () => {},
   setHasModalSection: () => {},
   removeHasModalSection: () => {},
   callContextFunctions: () => {},

--- a/packages/orbit-components/src/Modal/ModalContext.js.flow
+++ b/packages/orbit-components/src/Modal/ModalContext.js.flow
@@ -2,6 +2,7 @@
 import * as React from "react";
 
 export type ModalContextProps = {|
+  +setHasModalTitle?: (boolean | (boolean => boolean)) => void,
   +setHasModalSection?: () => void,
   +removeHasModalSection?: () => void,
   +callContextFunctions?: () => void,

--- a/packages/orbit-components/src/Modal/ModalHeader/index.js
+++ b/packages/orbit-components/src/Modal/ModalHeader/index.js
@@ -156,11 +156,19 @@ const ModalHeader = ({
   title,
   dataTest,
 }: Props) => {
-  const { isMobileFullPage } = useContext(ModalContext);
+  const { setHasModalTitle, isMobileFullPage } = useContext(ModalContext);
 
   useModalContextFunctions();
 
+  React.useEffect(() => {
+    if (title) setHasModalTitle?.(true);
+    return () => {
+      setHasModalTitle?.(false);
+    };
+  }, [title, setHasModalTitle]);
+
   const hasHeader = title || description;
+
   return (
     <StyledModalHeader
       illustration={!!illustration}

--- a/packages/orbit-components/src/Modal/__tests__/index.test.js
+++ b/packages/orbit-components/src/Modal/__tests__/index.test.js
@@ -122,4 +122,19 @@ describe("Modal", () => {
     userEvent.click(screen.getByTestId(CLOSE_BUTTON_DATA_TEST));
     expect(onClose).toBeCalled();
   });
+
+  it("should have fixed header background overlay when needed", () => {
+    const { rerender } = render(
+      <Modal hasCloseButton onClose={() => {}}>
+        content
+      </Modal>,
+    );
+    screen.getByTestId("CloseContainer");
+    rerender(
+      <Modal>
+        <ModalHeader title="title" />
+      </Modal>,
+    );
+    screen.getByTestId("CloseContainer");
+  });
 });

--- a/packages/orbit-components/src/Modal/index.js
+++ b/packages/orbit-components/src/Modal/index.js
@@ -343,6 +343,7 @@ const Modal = React.forwardRef<Props, Instance>(
     const [loaded, setLoaded] = React.useState<boolean>(false);
     const [scrolled, setScrolled] = React.useState<boolean>(false);
     const [fullyScrolled, setFullyScrolled] = React.useState<boolean>(false);
+    const [hasModalTitle, setHasModalTitle] = React.useState<boolean>(false);
     const [hasModalSection, setHasModalSection] = React.useState<boolean>(false);
     const [clickedModalBody, setClickedModalBody] = React.useState<boolean>(false);
     const [fixedClose, setFixedClose] = React.useState<boolean>(false);
@@ -606,6 +607,8 @@ const Modal = React.forwardRef<Props, Instance>(
       }
     }, [children, prevChildren]);
 
+    const hasCloseContainer = hasModalTitle || (onClose && hasCloseButton);
+
     return (
       <ModalBody
         tabIndex="0"
@@ -639,19 +642,23 @@ const Modal = React.forwardRef<Props, Instance>(
             isMobileFullPage={isMobileFullPage}
             onMouseDown={handleMouseDown}
           >
-            {onClose && hasCloseButton && (
+            {hasCloseContainer && (
               <CloseContainer
+                data-test="CloseContainer"
                 modalWidth={modalWidth}
                 size={size}
                 scrolled={scrolled}
                 fixedClose={fixedClose}
                 isMobileFullPage={isMobileFullPage}
               >
-                <ModalCloseButton onClick={onClose} dataTest={CLOSE_BUTTON_DATA_TEST} />
+                {onClose && hasCloseButton && (
+                  <ModalCloseButton onClick={onClose} dataTest={CLOSE_BUTTON_DATA_TEST} />
+                )}
               </CloseContainer>
             )}
             <ModalContext.Provider
               value={{
+                setHasModalTitle,
                 setHasModalSection: () => setHasModalSection(true),
                 removeHasModalSection: () => setHasModalSection(false),
                 callContextFunctions,


### PR DESCRIPTION
The header background overlay existed only with close button, but it's
necessary if `ModalHeader` has `title` prop, too. This fix ensures this by
checking whether a nested `ModalHeader` has `title`.

Now the name `CloseContainer` is confusing because it implies that it's
strictly related to the close button, which is no longer the case, so we
should eventually start cleaning up Modal.

- [request](https://skypicker.slack.com/archives/CAMS40F7B/p1609862807464300)
<br/><br/><br/><url>LiveURL: https://orbit-fix-modal-header-without-close.surge.sh</url>