### PR TITLE
improve: improve Babel plugin's script names

### DIFF
--- a/packages/babel-plugin-orbit-components/package.json
+++ b/packages/babel-plugin-orbit-components/package.json
@@ -24,8 +24,8 @@
     "README.md"
   ],
   "scripts": {
-    "generateTestFile": "node scripts/generateImports.js",
-    "build": "babel __fixtures__/index.js --out-file dist/index.js --root-mode upward",
-    "test": "yarn generateTestFile && yarn build && node scripts/testRequire.js"
+    "test:file": "node scripts/generateImports.js",
+    "test:compile": "babel __fixtures__/index.js --out-file dist/index.js --root-mode upward",
+    "test": "yarn test:file && yarn test:compile && node scripts/testRequire.js"
   }
 }


### PR DESCRIPTION
Other workspaces define `build` script as something that needs to happen
before publish, but here it was a part of the test script. It's handy
to be able to just run `npx lerna run build`, so keeping the name
`build` consistent is useful.
<br/><br/><br/><url>LiveURL: https://orbit-improve-babel-plugin-script-names.surge.sh</url>