### PR TITLE
ci: fix bug where deleted files were being linted

### DIFF
--- a/tasks/eslintCI.js
+++ b/tasks/eslintCI.js
@@ -29,11 +29,12 @@ async function eslintCI() {
 
   // changed file names saved by GitHub Action "Get Changed Files"
   // https://github.com/lots0logs/gh-action-get-changed-files
-  const allChangedFiles = JSON.parse(await fsx.readFile(`${process.env.HOME}/files.json`));
-  const deletedFiles = JSON.parse(await fsx.readFile(`${process.env.HOME}/files_deleted.json`));
-  const candidateFiles = allChangedFiles
-    .filter(fileName => !deletedFiles.includes(fileName))
-    .filter(isCandidateForLinting);
+  const addedFiles = JSON.parse(await fsx.readFile(`${process.env.HOME}/files_added.json`));
+  const modifiedFiles = JSON.parse(await fsx.readFile(`${process.env.HOME}/files_modified.json`));
+  const renamedFiles = JSON.parse(await fsx.readFile(`${process.env.HOME}/files_renamed.json`));
+  const candidateFiles = [...new Set([...addedFiles, ...modifiedFiles, ...renamedFiles])].filter(
+    isCandidateForLinting,
+  );
   const criticalFiles = candidateFiles.filter(shouldLintAll);
 
   let pathsToLint;


### PR DESCRIPTION
The initial assumption was that `files.json` file by the GitHub Action [Get Changed Files](https://github.com/lots0logs/gh-action-get-changed-files) contained the sum of files from `files_modified.json`, `files_added.json`, `files_deleted.json`, and `files_renamed.json`, but it appears that sometimes it also contained files that were created and then deleted in the _same_ PR, and those files were not a part of `files_deleted.json` so they were not being filtered out.

So now instead of `files.json` we're concatentating files from `files_added.json`, `files_modified.json`, and `files_renamed.json`.<br/><br/><br/><url>LiveURL: https://orbit-ci-fix-eslint-ci.surge.sh</url>