### PR TITLE
feat: add more content to the landing page

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "gatsby-remark-images": "^3.9.0",
-    "prism-react-renderer": "^1.1.1"
+    "prism-react-renderer": "^1.1.1",
+    "react-polymorphic-types": "^1.0.3"
   }
 }

--- a/docs/src/components/ArrowRight.tsx
+++ b/docs/src/components/ArrowRight.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { ArrowUp } from "@kiwicom/orbit-components/icons";
+import { css } from "styled-components";
+
+export default function ArrowRight(props: React.ComponentProps<typeof ArrowUp>) {
+  return (
+    <span
+      css={css`
+        svg {
+          transform: rotate(90deg);
+        }
+      `}
+    >
+      <ArrowUp {...props} />
+    </span>
+  );
+}

--- a/docs/src/components/ButtonLink.tsx
+++ b/docs/src/components/ButtonLink.tsx
@@ -18,7 +18,7 @@ type Props<T extends React.ElementType = typeof DefaultComponent> = PolymorphicP
 >;
 
 const StyledComponent = styled(DefaultComponent)<Props>`
-  ${({ theme, type, size = "medium" }) => css`
+  ${({ theme, type, size }) => css`
     display: inline-flex;
     align-items: center;
     ${size === "medium" &&
@@ -70,6 +70,8 @@ const StyledComponent = styled(DefaultComponent)<Props>`
 
 export default function ButtonLink<T extends React.ElementType = typeof DefaultComponent>({
   as: asProp,
+  type = "primary",
+  size = "medium",
   iconLeft,
   iconRight,
   children,
@@ -79,7 +81,7 @@ export default function ButtonLink<T extends React.ElementType = typeof DefaultC
 
   return (
     // @ts-expect-error react-polymorphic-types is currently not compatible with styled-components
-    <StyledComponent as={Component} {...restProps}>
+    <StyledComponent as={Component} type={type} size={size} {...restProps}>
       {iconLeft}
       <span>{children}</span>
       {iconRight}

--- a/docs/src/components/ButtonLink.tsx
+++ b/docs/src/components/ButtonLink.tsx
@@ -5,7 +5,7 @@ import { PolymorphicPropsWithoutRef } from "react-polymorphic-types";
 const DefaultComponent = "a";
 
 interface OwnProps {
-  type: "primary" | "secondary";
+  type?: "primary" | "secondary";
   size?: "medium" | "large";
   iconLeft?: React.ReactNode;
   iconRight?: React.ReactNode;

--- a/docs/src/components/ButtonLink.tsx
+++ b/docs/src/components/ButtonLink.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import styled, { css } from "styled-components";
+import { PolymorphicPropsWithoutRef } from "react-polymorphic-types";
+
+const DefaultComponent = "a";
+
+interface OwnProps {
+  type: "primary" | "secondary";
+  size?: "medium" | "large";
+  iconLeft?: React.ReactNode;
+  iconRight?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+type Props<T extends React.ElementType = typeof DefaultComponent> = PolymorphicPropsWithoutRef<
+  OwnProps,
+  T
+>;
+
+const StyledComponent = styled(DefaultComponent)<Props>`
+  ${({ theme, type, size = "medium" }) => css`
+    display: inline-flex;
+    align-items: center;
+    ${size === "medium" &&
+    css`
+      padding: 0.875rem 1.5rem;
+    `}
+    ${size === "large" &&
+    css`
+      padding: 1.25rem 2rem;
+    `}
+    border-radius: 100px; /* value safely greater than button height to achieve pill effect */
+    font-weight: 500;
+
+    > * + * {
+      margin-left: 10px;
+    }
+
+    ${type === "primary" &&
+    css`
+      background: ${theme.orbit.backgroundButtonPrimary};
+      color: ${theme.orbit.paletteWhite};
+      &:hover {
+        background: ${theme.orbit.backgroundButtonPrimaryHover};
+      }
+      &:active {
+        background: ${theme.orbit.backgroundButtonPrimaryActive};
+      }
+      &:focus {
+        background: ${theme.orbit.paletteProductNormal};
+      }
+    `}
+
+    ${type === "secondary" &&
+    css`
+      background: ${theme.orbit.paletteProductLight};
+      color: ${theme.orbit.paletteProductDark};
+      &:hover {
+        background: ${theme.orbit.paletteProductLightHover};
+      }
+      &:active {
+        background: ${theme.orbit.paletteProductLightActive};
+      }
+      &:focus {
+        background: ${theme.orbit.paletteProductLightHover};
+      }
+    `}
+  `}
+`;
+
+export default function ButtonLink<T extends React.ElementType = typeof DefaultComponent>({
+  as: asProp,
+  iconLeft,
+  iconRight,
+  children,
+  ...restProps
+}: Props<T>) {
+  const Component = asProp || DefaultComponent;
+
+  return (
+    // @ts-expect-error react-polymorphic-types is currently not compatible with styled-components
+    <StyledComponent as={Component} {...restProps}>
+      {iconLeft}
+      <span>{children}</span>
+      {iconRight}
+    </StyledComponent>
+  );
+}

--- a/docs/src/components/ButtonLink.tsx
+++ b/docs/src/components/ButtonLink.tsx
@@ -22,11 +22,11 @@ const StyledComponent = styled(DefaultComponent)<Props>`
     display: inline-flex;
     align-items: center;
     ${size === "medium" &&
-    css`
+    `
       padding: 0.875rem 1.5rem;
     `}
     ${size === "large" &&
-    css`
+    `
       padding: 1.25rem 2rem;
     `}
     border-radius: 100px; /* value safely greater than button height to achieve pill effect */

--- a/docs/src/components/Card.tsx
+++ b/docs/src/components/Card.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { Link } from "gatsby";
+import { Heading } from "@kiwicom/orbit-components";
+import ArrowRight from "./ArrowRight";
+import useTheme from "@kiwicom/orbit-components/lib/hooks/useTheme";
+import { css } from "styled-components";
+
+interface Props {
+  grow?: number;
+  title: string;
+  icon?: React.ComponentType;
+  moreText?: string;
+  linkTo: string;
+  children: React.ReactNode;
+}
+
+export default function Card({ title, moreText = "Learn more", linkTo, children }: Props) {
+  const theme = useTheme();
+  return (
+    <div
+      css={css`
+        padding: 2rem;
+        border-radius: 1rem;
+        background: ${theme.orbit.paletteWhite};
+        box-shadow: ${theme.orbit.boxShadowRaised};
+        display: flex;
+        flex-direction: column;
+      `}
+    >
+      <div
+        css={css`
+          flex: 1;
+          display: flex;
+        `}
+      >
+        <div
+          css={css`
+            align-self: start;
+            flex-shrink: 0;
+            width: 2rem;
+            height: 2rem;
+            background: ${theme.orbit.paletteProductLight};
+            border-radius: 50%;
+          `}
+        />
+        <div
+          css={css`
+            margin-left: 0.75rem;
+          `}
+        >
+          <Heading type="title2" as="h3">
+            {title}
+          </Heading>
+          <p
+            css={css`
+              margin-top: 0.5rem;
+              margin-bottom: 1.5rem;
+            `}
+          >
+            {children}
+          </p>
+        </div>
+      </div>
+      <div
+        css={css`
+          text-align: right;
+        `}
+      >
+        <Link
+          css={css`
+            display: inline-flex;
+            align-items: center;
+            > * + * {
+              margin-left: 0.25rem;
+            }
+            color: ${theme.orbit.colorTextLinkPrimary};
+            font-weight: 500;
+            text-decoration: underline;
+            &:hover {
+              color: ${theme.orbit.colorTextLinkPrimaryHover};
+              text-decoration: none;
+            }
+          `}
+          to={linkTo}
+        >
+          <span>{moreText}</span>
+          <ArrowRight />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,8 +1,23 @@
 import React from "react";
-import { Heading } from "@kiwicom/orbit-components";
+import { Link } from "gatsby";
+import { Heading, Inline } from "@kiwicom/orbit-components";
+import ArrowRight from "../components/ArrowRight";
+import { StarEmpty } from "@kiwicom/orbit-components/icons";
 import Layout from "../components/Layout";
 import RocketImage from "../components/RocketImage";
-import { css } from "styled-components";
+import ButtonLink from "../components/ButtonLink";
+import Card from "../components/Card";
+import styled, { css } from "styled-components";
+
+const CardWrapper = styled.div`
+  flex: 1;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  > :only-child {
+    flex: 1;
+  }
+`;
 
 export default function Home() {
   return (
@@ -12,17 +27,155 @@ export default function Home() {
         css={css`
           /* so that the rest of the content has a higher z-order than the image */
           position: relative;
+          width: 100%;
+          max-width: 80rem;
+          margin: 0 auto;
+
+          > * + * {
+            margin-top: 5.25rem;
+          }
         `}
       >
-        <Heading type="display">
+        <div>
+          <Heading type="display">
+            <div
+              css={css`
+                max-width: 20ch;
+                font-size: 48px;
+                line-height: 1.35;
+              `}
+            >
+              Open source design system for your next travel project.
+            </div>
+          </Heading>
+
           <div
             css={css`
-              max-width: 20ch;
+              margin-top: 3rem;
             `}
           >
-            Open source design system for your next travel project.
+            <Inline spacing="small">
+              <ButtonLink
+                type="primary"
+                size="large"
+                as={Link}
+                iconRight={<ArrowRight />}
+                to="/getting-started/for-designers/kiwi"
+              >
+                Get started
+              </ButtonLink>
+              <ButtonLink
+                type="secondary"
+                size="large"
+                iconLeft={<StarEmpty />}
+                href="https://github.com/kiwicom/orbit"
+                target="_blank"
+                rel="noopener noreferer"
+              >
+                Star us on GitHub
+              </ButtonLink>
+            </Inline>
           </div>
-        </Heading>
+        </div>
+
+        <Inline spacing="XLarge">
+          <CardWrapper>
+            <Card
+              title="Components"
+              moreText="See our components"
+              linkTo="/components/action/button/guidelines"
+            >
+              Our components are a collection of interface elements that can be reused across the
+              Orbit design system.
+            </Card>
+          </CardWrapper>
+          <CardWrapper>
+            <Card
+              title="Patterns"
+              moreText="See our patterns"
+              linkTo="/design-patterns/progressive-disclosure"
+            >
+              Missing description for patterns card.
+            </Card>
+          </CardWrapper>
+        </Inline>
+
+        <div
+          css={css`
+            > * + * {
+              margin-top: 2rem;
+            }
+          `}
+        >
+          <Heading as="h2">Foundation</Heading>
+          <Inline spacing="XLarge">
+            <CardWrapper>
+              <Card title="Colors" linkTo="/foundation/colors/colors">
+                Color is used to signal structure on a page, to highlight or emphasize...
+              </Card>
+            </CardWrapper>
+            <CardWrapper>
+              <Card title="Typography" linkTo="/">
+                Typography is critical for communicating the hierarchy of a page.
+              </Card>
+            </CardWrapper>
+            <CardWrapper>
+              <Card title="Spacings" linkTo="/">
+                Consistent spacing makes an interface more clear and easy to scan.
+              </Card>
+            </CardWrapper>
+          </Inline>
+          <div
+            css={css`
+              text-align: right;
+            `}
+          >
+            <ButtonLink type="secondary" href="#">
+              Show all items
+            </ButtonLink>
+          </div>
+        </div>
+
+        <div
+          css={css`
+            margin-top: 0;
+            > * + * {
+              margin-top: 2rem;
+            }
+          `}
+        >
+          <Heading as="h2">Content</Heading>
+          <Inline spacing="XLarge">
+            <CardWrapper>
+              <Card
+                title="Voice & tone"
+                linkTo="/kiwi-use/content/specific-areas/social-media/tone-of-voice"
+              >
+                How we write at Kiwi.com.
+              </Card>
+            </CardWrapper>
+            <CardWrapper>
+              <Card title="Grammar & mechanics" linkTo="/kiwi-use/content/grammar-and-mechanics">
+                Typography is critical for communicating the hierarchy of a page.Basic grammar
+                guidelines for writing with Orbit.
+              </Card>
+            </CardWrapper>
+            <CardWrapper>
+              <Card title="Glossary" linkTo="/kiwi-use/content/glossary">
+                A list of most used words and phrases in Kiwi.com products.
+              </Card>
+            </CardWrapper>
+          </Inline>
+          <div
+            css={css`
+              text-align: right;
+            `}
+          >
+            <ButtonLink type="secondary" href="#">
+              Show all items
+            </ButtonLink>
+          </div>
+        </div>
       </div>
     </Layout>
   );

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -41,7 +41,7 @@ export default function Home() {
             <div
               css={css`
                 max-width: 20ch;
-                font-size: 48px;
+                font-size: 3rem;
                 line-height: 1.35;
               `}
             >

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -56,7 +56,6 @@ export default function Home() {
           >
             <Inline spacing="small">
               <ButtonLink
-                type="primary"
                 size="large"
                 as={Link}
                 iconRight={<ArrowRight />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3662,14 +3662,6 @@
   resolved "https://registry.yarnpkg.com/@kiwicom/browserslist-config/-/browserslist-config-1.0.0.tgz#4abe67d42fd037f87e5abc20eb9e392a14639a30"
   integrity sha512-PoLLgols9+D58y58m5dbFCSxe6SqT7v+80zPqvDY/qfb/ZYbZ8dcCDrceMgdu2z0oP0D7ZtGK+7lpPXsIqRDYw==
 
-"@kiwicom/orbit-components@^0.106.0":
-  version "0.106.0"
-  resolved "https://registry.yarnpkg.com/@kiwicom/orbit-components/-/orbit-components-0.106.0.tgz#3d027946c60a7078c1aaf3dd4b30ddd4a898e616"
-  integrity sha512-9XsYTaeyRzhJwFGIy9ObJjBzDsoitG6vwQqDOvCjkFDQu9sJ7Tar9ICsVgfZ3hwJq9yGbScc/bvEaCLrCRB5pQ==
-  dependencies:
-    "@adeira/js" "^1.3.0"
-    "@kiwicom/orbit-design-tokens" "^0.13.1"
-
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"
@@ -22178,6 +22170,11 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-polymorphic-types@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-polymorphic-types/-/react-polymorphic-types-1.0.3.tgz#fa4a33e56d2e3a324e4e4a3b81447791aba35120"
+  integrity sha512-FVLrK9nEvr+gTIPf2lw/AzYOaeWRGbSdFLA+qqQIVNpCpdwqZqHkmhpTaChpZkG+Xub1fPMEuLmXTwNykVxbbQ==
 
 react-popper-tooltip@^2.11.0, react-popper-tooltip@^2.8.3:
   version "2.11.1"


### PR DESCRIPTION
I added buttons bellow the title, some of the cards, linked them to documents etc. There are many things still missing from the landing page, but it's much better to merge bit by bit than everything at once, especially in this early stage where we have to write a lot of code.

- icons in cards are missing because we don't have the SVGs yet
- the description of the Patterns card is missing, in Figma it's the same as the one in Components card
- some of the cards aren't linked because they don't have the corresponding docunment added to the codebase yet
- the "Show all items" button doesn't do anything yet
<br/><br/><br/><url>LiveURL: https://orbit-feat-landing-page.surge.sh</url>