### PR TITLE
chore: update Yarn lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3662,14 +3662,6 @@
   resolved "https://registry.yarnpkg.com/@kiwicom/browserslist-config/-/browserslist-config-1.0.0.tgz#4abe67d42fd037f87e5abc20eb9e392a14639a30"
   integrity sha512-PoLLgols9+D58y58m5dbFCSxe6SqT7v+80zPqvDY/qfb/ZYbZ8dcCDrceMgdu2z0oP0D7ZtGK+7lpPXsIqRDYw==
 
-"@kiwicom/orbit-components@^0.106.0":
-  version "0.106.0"
-  resolved "https://registry.yarnpkg.com/@kiwicom/orbit-components/-/orbit-components-0.106.0.tgz#3d027946c60a7078c1aaf3dd4b30ddd4a898e616"
-  integrity sha512-9XsYTaeyRzhJwFGIy9ObJjBzDsoitG6vwQqDOvCjkFDQu9sJ7Tar9ICsVgfZ3hwJq9yGbScc/bvEaCLrCRB5pQ==
-  dependencies:
-    "@adeira/js" "^1.3.0"
-    "@kiwicom/orbit-design-tokens" "^0.13.1"
-
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"


### PR DESCRIPTION
Not sure where this section came from, but I keep getting this change when I run `npx lerna bootstrap`, so I guess we don't need it anymore.
<br/><br/><br/><url>LiveURL: https://orbit-chore-yarn-lockfile.surge.sh</url>