### PR TITLE
improve: add Jest display name for ESLint plugin

### DIFF
--- a/packages/eslint-plugin-orbit-components/jest.config.js
+++ b/packages/eslint-plugin-orbit-components/jest.config.js
@@ -1,0 +1,6 @@
+// @noflow
+
+module.exports = {
+  displayName: "eslint-plugin-orbit-components",
+  testEnvironment: "node",
+};


### PR DESCRIPTION
This prints out the `eslint-plugin-orbit-components` label in Jest
output like the rest of the workspaces.
<br/><br/><br/><url>LiveURL: https://orbit-improve-eslint-plugin-jest-config.surge.sh</url>