### PR TITLE
chore(adeira): use classic reactRuntime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,7 @@ const environments = {
 };
 
 module.exports = {
-  presets: [["@adeira/babel-preset-adeira", { target, environments }]],
+  presets: [["@adeira/babel-preset-adeira", { target, environments, reactRuntime: "classic" }]],
   plugins: ["babel-plugin-styled-components"],
   env: {
     test: {


### PR DESCRIPTION
with upgrade to new adeira, seems like we have to add that option to a plugin, because it uses by default new [JSX transform. ](https://github.com/adeira/universe/tree/master/src/babel-preset-adeira#new-jsx-transform)<br/><br/><br/><url>LiveURL: https://orbit-chore-babel-preset-adeira-config.surge.sh</url>