### PR TITLE
docs: fix error when language is not specified

### DIFF
--- a/docs/src/components/Code.tsx
+++ b/docs/src/components/Code.tsx
@@ -17,10 +17,10 @@ export const InlineCode = styled.code`
 
 interface CodeBlockProps {
   children: string;
-  className: string;
+  className?: string;
 }
 export const CodeBlock = ({ children, className }: CodeBlockProps) => {
-  const language = className.replace(/language-/, "");
+  const language = className?.replace(/language-/, "");
   return (
     <Highlight
       {...defaultProps}


### PR DESCRIPTION
<br/><br/><br/><url>LiveURL: https://orbit-docs-fix-no-language.surge.sh</url>