### PR TITLE
docs: add content for development section

### DIFF
--- a/docs/src/documentation/05-development/01-guides/01-developing-layouts.mdx
+++ b/docs/src/documentation/05-development/01-guides/01-developing-layouts.mdx
@@ -1,3 +1,76 @@
 ---
 title: Developing layouts
+redirect_from:
+  - /guides/developing-layouts/
 ---
+
+Orbit offers options for developing clear layouts in a systematic way that fits the Orbit system.
+There are a few different components that offer specific possibilities.
+
+To see which component is right for you, try out this interactive decision tree.
+The reasons for the recommendations are below.
+
+<iframe
+  style="border: 1px solid rgba(0, 0, 0, 0.1);width:700px; height:350px;"
+  src="https://www.figma.com/embed?embed_host=share&amp;url=https%3A%2F%2Fwww.figma.com%2Fproto%2FA90hZFLfuo4C69QvApNuRw%2FLayout-component-guide%3Fnode-id%3D1%253A179%26scaling%3Dmin-zoom"
+  allowfullscreen=""
+></iframe>
+
+Each of the five basic layout components has specific cases where it's used:
+
+| Component | Use cases                                                                                                                                                                                                                                                                                                                                                            |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Layout    | Fixed page layouts                                                                                                                                                                                                                                                                                                                                                   |
+| Grid      | General screen layout (including modals)                                                                                                                                                                                                                                                                                                                             |
+| Box       | Component layout, positioning,spacing, visual style (universal building block for layouts)                                                                                                                                                                                                                                                                           |
+| Stack     | For single-direction groups of components <ul><li>Adds space between elements horizontally **_or_** vertically</li><li>Can be a column</li><li>Container can be inline</li><li>Offers more options for each direction (between & around in justify and stretch in align)</li><li>More flex options: shrink, grow, basis</li><li>Option for wrap or no wrap</li></ul> |
+| Inline    | For groups of components that could go in both directions<ul><li>Adds space between elements horizontally **_and_** vertically</li><li>Can't force a column</li><li>Container can't be inline (onlycontents)</li><li>Always wraps</li></ul>                                                                                                                          |
+
+## Components
+
+### Page layout
+
+For laying out everything on a screen there are two basic options:
+
+- [Layout](/components/layout/layout/)
+- [Grid](/components/layout/grid/)
+
+The Layout component offers three basic options for columns.
+These can be slightly customized in terms of when they appear.
+But the basic format is set.
+
+Grids offer more flexibility in laying out your screens.
+It lets you set up rows and columns for your screens
+that can change based on screen size and media queries.
+There are many more options that you have to set.
+
+### Building block
+
+To build your screens, Orbit offers the basic building block of a [box](/components/layout/box/).
+
+It provides a range of options on **position**, **layout**, **spacing**, and **visuals**.
+Use it within your page layout to get your components exactly where you want them.
+
+The many options available offer you freedom for your layouts.
+But it also means you have more things you need to set.
+
+Boxes work well for positioning and providing spacing
+for both individual and groups of components.
+
+### Groups of components
+
+In addition to boxes,
+there are two components that offer consistent **spacing** for groups of components:
+
+- [Stack](/components/layout/stack/)
+- [Inline](/components/layout/inline/)
+
+Stacks work when you want to focus on a group of components laid out in a single direction.
+The direction can be either horizontal or vertical
+and there are lots of options for how the components will fit into the space.
+In all cases, there will be consistent spacing in a single direction.
+
+Inline components give you consistent spacing both horizontally and vertically.
+They work for sets of components that might span multiple lines.
+There are fewer options for fitting the components into the space,
+but there is consistent spacing in two directions.

--- a/docs/src/documentation/05-development/01-guides/02-dictionary.mdx
+++ b/docs/src/documentation/05-development/01-guides/02-dictionary.mdx
@@ -1,3 +1,73 @@
 ---
 title: Dictionary
+redirect_from:
+  - /guides/dictionary/
 ---
+
+Our dictionary handles common translations like `Close` in components.
+
+Find our dictionary at: `@kiwicom/orbit-components/lib/data/dictionary/...`
+The files contain our own translations.
+
+## Example
+
+You can use dictionaries with various components.
+
+```jsx
+import en_GB from "@kiwicom/orbit-components/lib/data/dictionary/en-GB.json";
+import cs_CZ from "@kiwicom/orbit-components/lib/data/dictionary/cs-CZ.json";
+import Pagination from "@kiwicom/orbit-components/lib/Pagination";
+import ThemeProvider from "@kiwicom/orbit-components/lib/ThemeProvider";
+import defaultTheme from "@kiwicom/orbit-components/lib/defaultTheme";
+
+const App = () => (
+  <ThemeProvider theme={defaultTheme} dictionary={en_GB}>
+    <Pagination pageCount={4} selectedPage={3} hideLabels={false} />
+  </ThemeProvider>
+  <ThemeProvider theme={defaultTheme} dictionary={cs_CZ}>
+    <Pagination pageCount={4} selectedPage={3} hideLabels={false} />
+  </ThemeProvider>
+);
+```
+
+It's also possible to use them with [Translate components](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/Translate)
+and useTranslate hooks for your functional components.
+
+## Fallbacks
+
+- If a translation key doesn't exist in your language,
+  the fallback is `en_GB`, which is our default language.
+- If a translation key doesn't exist in either file (your language, the default language),
+  the translation key will be rendered (for example, `button_close`).
+
+## Your own dictionary
+
+You can add your own dictionary.
+Just pass an object containing keys and values.
+
+```jsx
+import ThemeProvider from "@kiwicom/orbit-components/lib/ThemeProvider";
+
+const App = () => (
+  <ThemeProvider
+    dictionary={{
+      button_close: "My own translation",
+    }}
+  >
+    <Button type="secondary" size="large" />
+  </ThemeProvider>
+);
+```
+
+## Languages
+
+We store all inner strings we translate inside of our Github repository
+and export them to NPM.
+
+<FancyLink icon="github">
+
+
+[See all language files](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/data/dictionary)
+
+</FancyLink>
+

--- a/docs/src/documentation/05-development/01-guides/03-using-component-types.mdx
+++ b/docs/src/documentation/05-development/01-guides/03-using-component-types.mdx
@@ -1,12 +1,18 @@
 ---
 title: Using component types
+exceprt: Guidelines on how to use and make the most out of exported component types in Typescript and Flow.
+redirect_from:
+  - /guides/using-component-types/
 ---
 
-In `Orbit`, all components export their `Props` object so you can then import it into your project and use it to access their fields.
+In `Orbit`, all components export their `Props` object
+so you can then import it into your project and use it to access their fields.
 
-A common use case is to be able type the different `enums` that `Orbit` has, such as `alignment` for Popover and `weight` for Text.
+A common use case is to be able type the different `enums` that `Orbit` has,
+such as `alignment` for Popover and `weight` for Text.
 
-In the following snippet (using `Typescript`), the type checker will complain because `type` is not the `enum` type but a general `string` type.
+In the following snippet (using `Typescript`),
+the type checker will complain because `type` is not the `enum` type but a general `string` type.
 
 ```jsx
 import Text from "@kiwicom/orbit-components/lib/Text";
@@ -20,11 +26,17 @@ const WrappedText = ({ children, type }) => <Text type={type}>{children}</Text>;
 export default WrappedText;
 ```
 
-To solve this, you need to have a way to access the different `Props` fields to correctly type the fields that are passed on to `Orbit` components. Fortunately, there is a way to do so with the different type-checking systems.
+To solve this, you need to have a way to access the different `Props` fields
+to correctly type the fields that are passed on to `Orbit` components.
+Fortunately, there is a way to do so with the different type-checking systems.
 
 ## Typescript
 
-In `Typescript`, you can access the fields using [index types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#index-types). For example, a type that contains `field_name` from a given `TypeName` would be `TypeName["field_name"]`, so the issue above could be solved by modifying the prop's type:
+In `Typescript`,
+you can access the fields using [index types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#index-types).
+For example, a type that contains `field_name` from a given `TypeName`
+would be `TypeName["field_name"]`,
+so the issue above could be solved by modifying the prop's type:
 
 ```jsx
 import Text, { Props as TextProps } from "@kiwicom/orbit-components/lib/Text";
@@ -40,7 +52,9 @@ export default WrappedText;
 
 ## Flow
 
-In `Flow`, you can access the fields using [`$PropertyType`](https://flow.org/en/docs/types/utilities/#toc-propertytype), so the example would be fixed as follows:
+In `Flow`,
+you can access the fields using [`$PropertyType`](https://flow.org/en/docs/types/utilities/#toc-propertytype),
+so the example would be fixed as follows:
 
 ```jsx
 import Text from "@kiwicom/orbit-components/lib/Text";

--- a/docs/src/documentation/05-development/01-guides/04-no-exporting-components.mdx
+++ b/docs/src/documentation/05-development/01-guides/04-no-exporting-components.mdx
@@ -1,3 +1,125 @@
 ---
 title: Why we don't export styled components
+redirect_from:
+  - /guides/why-we-dont-want-to-allow-extending-orbit-react-components/
 ---
+
+We know that Orbit React components are built upon styled-components,
+which allow you to easily extend other existing React components with the styled factory.
+Still, we, as Orbit maintainers, don't want to allow it,
+even though it would allow many of our developers to develop features easily
+with a better developer experience.
+
+Both approaches, allowing such extension and not,
+have a lot of pros and cons that have to be considered.
+So we would like to clearly state all of them we can and explain our decision clearly.
+
+## Pros
+
+We think the following pros to allowing the extension of Orbit React components are the most important.
+
+### Simpler JSX structure with fewer wrappers with custom overrides
+
+Given the nature of how styled-components work,
+the main benefit would be a simpler JSX structure.
+Mainly because of the possibility of extending our components,
+developers could attach additional styles in a very easy way.
+
+### Better developer experience with Orbit
+
+We also believe that allowing extension would lead to
+a better developer experience when working with Orbit.
+Developers would not have to think if our components support a particular use case
+and would simply override the behaviour or visual style of our components.
+
+## Cons
+
+On the other hand, we think that allowing the extension of Orbit React components
+would bring us and also our frontend developers many cons
+that might not manifest immediately, but most probably would in the future.
+
+### Consistency issues
+
+One of our main long-term goals is to ensure consistency across our applications.
+We believe that allowing extension would lead to worse consistency
+since developers would have a very easy way to implement designs
+that might not be aligned with the current possibilities that Orbit provides.
+It would lead also to fewer requests for enhancements, new features, and bug fixes
+and would slow down the growth of Orbit in some way.
+
+### Dependent on Orbit DOM structure
+
+Most of our components may be considered very simple,
+or by some definitions atoms or molecules.
+But in reality, their DOM and style structure may not be that simple---as a single DOM element.
+So it can be hard to properly extend some Orbit React components
+without exact CSS selectors that follow the exact DOM structure.
+For the future sustainability and maintainability of our components,
+we can't provide or support their DOM structures,
+which can be changed with refactoring or major visual updates.
+
+### All styled-components would have to have a public and documented API
+
+With allowance, we would have to document all of the inner styled-components
+that make up Orbit React components and have them publicly documented.
+This would add unnecessary complexity on our shoulders
+and require us to make updates and releases less often.
+
+### Harder to update to new versions as we could break the public API
+
+As said before, having a more public and documented API would mean
+that between some minor versions (and major versions once we will release the first major)
+it would most likely be harder to release quick updates of the newest version to production
+and would require a lot of work in users' repositories.
+
+### Impossibility to lint all overrides and custom styles
+
+As far as we know, there isn't any tooling that would allow us to control or determine
+which CSS properties are being used in the extended component and which are being overridden.
+So we couldn't transparently support how our components would be used.
+This, in the end, could lead to inconsistent behaviour or visual style for our applications,
+even though we can't prohibit all possibilities when it comes to custom CSS overrides.
+
+### Extending functionality to styled-components requires running more JS code
+
+Given the nature of how styled-components work,
+allowing extension could lead to unnecessary complexity in UI components
+and also more time-consuming runtimes.
+The most problematic part is managing the StyleSheetManager context state,
+which can be expensive.
+And with combinations of multiple extensions, it could lead to performance issues.
+
+### You'd become a maintainer of the UI
+
+Most importantly, allowing extension would mean that you'd be becoming a maintainer of the UI.
+We wouldn't be able to provide you with a guarantee over the UI that you need to develop.
+You should be responsible only for minor and major layouts that the feature requires
+and not for elementary pieces of the UI.
+Last but not least, you should spend most of your time on implementing functionality
+and not on the UI, which should be consistent in our applications and solved on a systematic level.
+
+Neutral:
+
+- Fewer support requests/fewer versions
+- Fewer reports that something doesn't work (bug fixes, features requests)
+- Solving topics on design level and systematic approach
+
+## On balance
+
+Overall, for us, allowing the extension of our components
+would bring too many drawbacks without enough benefits.
+It would mean we would get fewer requests for support and fewer opportunities
+to build Orbit into something better with more features and versions.
+It would mean we wouldn't be solving issues systematically
+and so you would have to spend more of your time solving minor issues.
+
+We understand the lack of flexibility is a drawback.
+That's why we've started other initiatives to give you more control
+while remaining inside the Orbit design system.
+For example, we began introducing primitive components,
+which give you all of the same basic functionalities with a lot more control over the visual style.
+
+If there's something that'd you'd like to have control over, let us know,
+in [#plz-orbit](https://skypicker.slack.com/archives/CAMS40F7B), on [Spectrum](https://spectrum.chat/orbit),
+or directly in our [GitHub repository](https://github.com/kiwicom/orbit).
+We want to cover all major use cases and work together to make Orbit the best it can be.

--- a/docs/src/documentation/05-development/01-guides/05-eslint-plugin.mdx
+++ b/docs/src/documentation/05-development/01-guides/05-eslint-plugin.mdx
@@ -1,3 +1,9 @@
 ---
 title: ESLint plugin
+redirect_from:
+  - /guides/eslint-plugin/
 ---
+
+import ESLintPluginReadMe from "@kiwicom/babel-plugin-orbit-components/README.md"
+
+<ESLintPluginReadMe />

--- a/docs/src/documentation/05-development/02-utilities/01-media-queries.mdx
+++ b/docs/src/documentation/05-development/02-utilities/01-media-queries.mdx
@@ -1,5 +1,7 @@
 ---
 title: Media queries
+redirect_from:
+  - /utilities/media-queries/
 ---
 
 import MediaQueriesReadMe from "@kiwicom/orbit-components/src/utils/mediaQuery/README.md"

--- a/docs/src/documentation/05-development/02-utilities/02-rtl-languages.mdx
+++ b/docs/src/documentation/05-development/02-utilities/02-rtl-languages.mdx
@@ -1,3 +1,5 @@
 ---
 title: Right to left languages
+redirect_from:
+  - /utilities/right-to-left-languages/
 ---

--- a/docs/src/documentation/05-development/03-hooks/usefocustrap.mdx
+++ b/docs/src/documentation/05-development/03-hooks/usefocustrap.mdx
@@ -1,5 +1,7 @@
 ---
 title: useFocusTrap
+redirect_from:
+  - /utilities/usefocustrap/
 ---
 
 import UseFocusTrapReadMe from "@kiwicom/orbit-components/src/hooks/useFocusTrap/README.md";

--- a/docs/src/documentation/05-development/03-hooks/usemediaquery.mdx
+++ b/docs/src/documentation/05-development/03-hooks/usemediaquery.mdx
@@ -1,5 +1,7 @@
 ---
 title: useMediaQuery
+redirect_from:
+  - /utilities/usemediaquery/
 ---
 
 import UseMediaQueryReadMe from "@kiwicom/orbit-components/src/hooks/useMediaQuery/README.md";

--- a/packages/orbit-components/src/ThemeProvider/README.md
+++ b/packages/orbit-components/src/ThemeProvider/README.md
@@ -6,7 +6,7 @@ orbit-components has theming support via our own `<ThemeProvider>` which adds yo
 import ThemeProvider from "@kiwicom/orbit-components/lib/ThemeProvider";
 ```
 
-After adding import please wrap your application into `ThemeProvider` and you can provide your own [`theme`](https://github.com/kiwicom/orbit/blob/master/.github/theming.md) and [`dictionary`](hhttps://github.com/kiwicom/orbit/blob/master/.github/dictionary.md)
+After adding import please wrap your application into `ThemeProvider` and you can provide your own [`theme`](https://github.com/kiwicom/orbit/blob/master/.github/theming.md) and [`dictionary`](https://github.com/kiwicom/orbit/blob/master/docs/src/documentation/05-development/01-guides/02-dictionary.mdx)
 
 ```jsx
 <ThemeProvider theme={ownTheme} dictionary={ownDictionary}>
@@ -18,8 +18,8 @@ After adding import please wrap your application into `ThemeProvider` and you ca
 
 Table below contains all types of the props available in the ThemeProvider component.
 
-| Name         | Type         | Default | Description                                                                            |
-| :----------- | :----------- | :------ | :------------------------------------------------------------------------------------- |
-| **children** | `React.Node` |         | Your app                                                                               |
-| theme        | `[Object]`   |         | See [`theming`](https://github.com/kiwicom/orbit/blob/master/.github/theming.md)       |
-| dictionary   | `[Object]`   |         | See [`dictionary`](https://github.com/kiwicom/orbit/blob/master/.github/dictionary.md) |
+| Name         | Type         | Default | Description                                                                                                                         |
+| :----------- | :----------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------- |
+| **children** | `React.Node` |         | Your app                                                                                                                            |
+| theme        | `[Object]`   |         | See [`theming`](https://github.com/kiwicom/orbit/blob/master/.github/theming.md)                                                    |
+| dictionary   | `[Object]`   |         | See [`dictionary`](https://github.com/kiwicom/orbit/blob/master/docs/src/documentation/05-development/01-guides/02-dictionary.mdxd) |

--- a/packages/orbit-components/src/Translate/README.md
+++ b/packages/orbit-components/src/Translate/README.md
@@ -1,6 +1,6 @@
 # Translate
 
-We have support of our `Dictionary` see [this document](https://github.com/kiwicom/orbit/blob/master/.github/dictionary.md)
+We have support of our `Dictionary` see [this document](https://github.com/kiwicom/orbit/blob/master/docs/src/documentation/05-development/01-guides/02-dictionary.mdx)
 
 This component adds you possibility to take some strings from our dictionary.
 
@@ -17,8 +17,9 @@ Table below contains all types of the props available in Translate component.
 
 ```jsx
 import en_GB from "@kiwicom/orbit-components/lib/data/dictionary/en-GB.json";
-import ThemeProvider from "@kiwicom/orbit-components/lib/ThemeProvider";
 import Button from "@kiwicom/orbit-components/lib/Button";
+import Translate from "@kiwicom/orbit-components/lib/Translate";
+import ThemeProvider from "@kiwicom/orbit-components/lib/ThemeProvider";
 
 const App = () =>
   <ThemeProvider theme={...} dictionary={en_GB}>

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ yarn add @types/styled-components -D
 - [Icons](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/Icon/README.md)
 - [Right to left languages](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/utils/rtl/README.md)
 - [Theming](https://github.com/kiwicom/orbit/blob/master/.github/theming.md)
-- [Dictionary](https://github.com/kiwicom/orbit/blob/master/.github/dictionary.md)
+- [Dictionary](https://github.com/kiwicom/orbit/blob/master/docs/src/documentation/05-development/01-guides/02-dictionary.mdx)
 
 ## Contributing
 


### PR DESCRIPTION
Includes replacing links to `/.github/dictionary.md` in this repo.<br/><br/><br/><url>LiveURL: https://orbit-docs-development.surge.sh</url>