### PR TITLE
docs: establish clear URL strategy for documents

### DIFF
--- a/config/eslintJS.js
+++ b/config/eslintJS.js
@@ -39,6 +39,7 @@ module.exports = {
           "**/tasks/**",
           "docs/gatsby-*.js",
           "docs/plugins/**",
+          "docs/utils/**",
           "packages/*/.storybook/**",
           "**/config/**",
           "gulpfile.js",

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -33,12 +33,12 @@ module.exports = {
     {
       resolve: `@gatsby-contrib/gatsby-plugin-elasticlunr-search`,
       options: {
-        fields: ["title", "excerpt", "slug"],
+        fields: ["title", "excerpt", "path"],
         resolvers: {
           Mdx: {
             title: n => n.frontmatter.title,
             excerpt: n => n.frontmatter.excerpt,
-            slug: n => n.fields.slug,
+            path: n => n.fields.path,
           },
         },
       },

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -1,25 +1,21 @@
 const { createFilePath } = require(`gatsby-source-filesystem`);
-// creates a "collection" field to it easier to filter nodes created by
-// gatsby-source-filesystem instead of awkwardly filtering by file path
-// https://github.com/gatsbyjs/gatsby/issues/1634#issuecomment-388899348
-
-const omitNumbers = str =>
-  str
-    .split("/")
-    .map(s => s.replace(/^\d+-\s*/g, ""))
-    .join("/");
+const { getDocumentUrlPath } = require("./utils/document");
 
 exports.onCreateNode = ({ node, getNode, actions }) => {
   if (node.internal.type !== "Mdx") return;
   const { createNodeField } = actions;
   const parent = getNode(node.parent);
-  const slug = createFilePath({ node, getNode, basePath: `pages` });
+  const filePath = createFilePath({ node, getNode, basePath: `pages` });
 
   createNodeField({
     node,
-    name: `slug`,
-    value: omitNumbers(slug),
+    name: "path",
+    value: getDocumentUrlPath(filePath),
   });
+
+  // creates a "collection" field to make it easier to filter nodes created by
+  // gatsby-source-filesystem instead of awkwardly filtering by file path
+  // https://github.com/gatsbyjs/gatsby/issues/1634#issuecomment-388899348
 
   createNodeField({
     node,
@@ -35,7 +31,9 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       allMdx(filter: { fields: { collection: { eq: "documentation" } } }) {
         nodes {
           id
-          slug
+          fields {
+            path
+          }
         }
       }
     }
@@ -44,11 +42,9 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     reporter.panicOnBuild(`Error when querying guides.`);
     return;
   }
-  result.data.allMdx.nodes.forEach(({ id, slug }) => {
-    const cuttedSlug = omitNumbers(slug);
-
+  result.data.allMdx.nodes.forEach(({ id, fields }) => {
     createPage({
-      path: `/${cuttedSlug}`,
+      path: fields.path,
       component: `${__dirname}/src/templates/Doc.tsx`,
       context: { id },
     });

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,6 +19,7 @@
     "@types/mdx-js__react": "^1.5.3",
     "babel-plugin-inline-react-svg": "^1.1.2",
     "babel-preset-gatsby": "^0.7.0",
+    "dedent": "^0.7.0",
     "downshift": "^6.0.10",
     "gatsby": "^2.27.0",
     "gatsby-image": "^2.6.0",
@@ -26,6 +27,7 @@
     "gatsby-plugin-sharp": "^2.12.0",
     "gatsby-source-filesystem": "^2.6.0",
     "gatsby-transformer-sharp": "^2.7.0",
+    "js-yaml": "^4.0.0",
     "tailwindcss": "^1.9.6"
   },
   "dependencies": {

--- a/docs/src/components/Card.tsx
+++ b/docs/src/components/Card.tsx
@@ -10,7 +10,7 @@ interface Props {
   title: string;
   icon?: React.ComponentType;
   moreText?: string;
-  linkTo: string;
+  linkTo?: string;
   children: React.ReactNode;
 }
 
@@ -61,32 +61,34 @@ export default function Card({ title, moreText = "Learn more", linkTo, children 
           </p>
         </div>
       </div>
-      <div
-        css={css`
-          text-align: right;
-        `}
-      >
-        <Link
+      {linkTo && (
+        <div
           css={css`
-            display: inline-flex;
-            align-items: center;
-            > * + * {
-              margin-left: 0.25rem;
-            }
-            color: ${theme.orbit.colorTextLinkPrimary};
-            font-weight: 500;
-            text-decoration: underline;
-            &:hover {
-              color: ${theme.orbit.colorTextLinkPrimaryHover};
-              text-decoration: none;
-            }
+            text-align: right;
           `}
-          to={linkTo}
         >
-          <span>{moreText}</span>
-          <ArrowRight />
-        </Link>
-      </div>
+          <Link
+            css={css`
+              display: inline-flex;
+              align-items: center;
+              > * + * {
+                margin-left: 0.25rem;
+              }
+              color: ${theme.orbit.colorTextLinkPrimary};
+              font-weight: 500;
+              text-decoration: underline;
+              &:hover {
+                color: ${theme.orbit.colorTextLinkPrimaryHover};
+                text-decoration: none;
+              }
+            `}
+            to={linkTo}
+          >
+            <span>{moreText}</span>
+            <ArrowRight />
+          </Link>
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/src/components/SearchInput/index.tsx
+++ b/docs/src/components/SearchInput/index.tsx
@@ -18,7 +18,7 @@ interface SearchResult {
   id: string;
   excerpt: string;
   title: string;
-  slug: string;
+  path: string;
 }
 
 interface Props {
@@ -97,10 +97,10 @@ const Input = React.forwardRef<HTMLInputElement, Props>(function SearchInput(
         {isOpen &&
           results.length > 0 &&
           results.map(item => {
-            const { title, slug, id } = item;
+            const { title, id, path } = item;
             return (
               <StyledDropdownItem key={id} {...getItemProps({ item })}>
-                <Link to={slug}>{title}</Link>
+                <Link to={path}>{title}</Link>
               </StyledDropdownItem>
             );
           })}

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -59,7 +59,7 @@ export default function Home() {
                 size="large"
                 as={Link}
                 iconRight={<ArrowRight />}
-                to="/getting-started/for-designers/kiwi"
+                to="/getting-started/for-designers/"
               >
                 Get started
               </ButtonLink>
@@ -82,7 +82,7 @@ export default function Home() {
             <Card
               title="Components"
               moreText="See our components"
-              linkTo="/components/action/button/guidelines"
+              linkTo="/components/action/button/"
             >
               Our components are a collection of interface elements that can be reused across the
               Orbit design system.
@@ -92,7 +92,7 @@ export default function Home() {
             <Card
               title="Patterns"
               moreText="See our patterns"
-              linkTo="/design-patterns/progressive-disclosure"
+              linkTo="/design-patterns/progressive-disclosure/"
             >
               Missing description for patterns card.
             </Card>
@@ -109,17 +109,17 @@ export default function Home() {
           <Heading as="h2">Foundation</Heading>
           <Inline spacing="XLarge">
             <CardWrapper>
-              <Card title="Colors" linkTo="/foundation/colors/colors">
+              <Card title="Colors" linkTo="/foundation/colors/">
                 Color is used to signal structure on a page, to highlight or emphasize...
               </Card>
             </CardWrapper>
             <CardWrapper>
-              <Card title="Typography" linkTo="/">
+              <Card title="Typography">
                 Typography is critical for communicating the hierarchy of a page.
               </Card>
             </CardWrapper>
             <CardWrapper>
-              <Card title="Spacings" linkTo="/">
+              <Card title="Spacings">
                 Consistent spacing makes an interface more clear and easy to scan.
               </Card>
             </CardWrapper>
@@ -146,21 +146,18 @@ export default function Home() {
           <Heading as="h2">Content</Heading>
           <Inline spacing="XLarge">
             <CardWrapper>
-              <Card
-                title="Voice & tone"
-                linkTo="/kiwi-use/content/specific-areas/social-media/tone-of-voice"
-              >
+              <Card title="Voice & tone" linkTo="/kiwi-use/content/specific-areas/social-media/">
                 How we write at Kiwi.com.
               </Card>
             </CardWrapper>
             <CardWrapper>
-              <Card title="Grammar & mechanics" linkTo="/kiwi-use/content/grammar-and-mechanics">
+              <Card title="Grammar & mechanics" linkTo="/kiwi-use/content/grammar-and-mechanics/">
                 Typography is critical for communicating the hierarchy of a page.Basic grammar
                 guidelines for writing with Orbit.
               </Card>
             </CardWrapper>
             <CardWrapper>
-              <Card title="Glossary" linkTo="/kiwi-use/content/glossary">
+              <Card title="Glossary" linkTo="/kiwi-use/content/glossary/">
                 A list of most used words and phrases in Kiwi.com products.
               </Card>
             </CardWrapper>

--- a/docs/utils/__tests__/document.test.js
+++ b/docs/utils/__tests__/document.test.js
@@ -1,0 +1,42 @@
+const fsx = require("fs-extra");
+const path = require("path");
+const dedent = require("dedent");
+
+const { getDocumentUrlPath } = require("../document");
+
+const ROOT = path.resolve(__dirname, "../../src/documentation");
+
+jest.mock("fs", () => require("memfs").fs);
+
+describe("document utils", () => {
+  describe(getDocumentUrlPath.name, () => {
+    it("should return URL path based on document's file path", async () => {
+      await fsx.mkdirp(`${ROOT}/01-getting-started`);
+      await fsx.writeFile(
+        `${ROOT}/01-getting-started/meta.yml`,
+        dedent`
+        title: Getting started
+        type: folder
+      `,
+      );
+      expect(getDocumentUrlPath("/01-getting-started/01-for-developers.mdx")).toBe(
+        "/getting-started/for-developers/",
+      );
+      await fsx.mkdirp(`${ROOT}/01-getting-started/02-for-designers`);
+      await fsx.writeFile(
+        `${ROOT}/01-getting-started/02-for-designers/meta.yml`,
+        dedent`
+        title: For designers
+        excerpt: Everything you need to start designing with Orbit UI kit.
+        type: tabs
+      `,
+      );
+      expect(getDocumentUrlPath("/01-getting-started/02-for-designers/01-kiwi.mdx")).toBe(
+        "/getting-started/for-designers/",
+      );
+      expect(getDocumentUrlPath("/01-getting-started/02-for-designers/02-open-source.mdx")).toBe(
+        "/getting-started/for-designers/open-source/",
+      );
+    });
+  });
+});

--- a/docs/utils/document.js
+++ b/docs/utils/document.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+const yaml = require("js-yaml");
+
+const rePathNumbers = new RegExp(`(${path.sep})\\d+-`, "g");
+const omitNumbers = filePath => filePath.replace(rePathNumbers, "$1");
+
+const ROOT = path.resolve(__dirname, "../src/documentation");
+
+function getDocumentUrlPath(filePath) {
+  const { dir, base, name } = path.parse(filePath);
+  if (!base.startsWith("01-")) {
+    return omitNumbers(path.join(dir, name, "/"));
+  }
+  const metaPath = path.join(ROOT, dir, "meta.yml");
+  const meta = fs.existsSync(metaPath) ? yaml.load(fs.readFileSync(metaPath)) : {};
+  return meta.type === "tabs"
+    ? omitNumbers(path.join(dir, "/"))
+    : omitNumbers(path.join(dir, name, "/"));
+}
+
+module.exports = {
+  getDocumentUrlPath,
+};

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "make-runnable": "^1.3.8",
     "markdown-chalk": "^2.1.0",
     "markdown-magic": "^1.0.0",
+    "memfs": "^3.2.0",
     "merge-stream": "^2.0.0",
     "mkdirp": "^1.0.4",
     "prettier": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6249,6 +6249,11 @@ argparse@^1.0.10, argparse@^1.0.6, argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -16222,6 +16227,13 @@ js-yaml@^3.11.0, js-yaml@^3.13.1, js-yaml@^3.8.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+  dependencies:
+    argparse "^2.0.1"
 
 js-yaml@~3.7.0:
   version "3.7.0"


### PR DESCRIPTION
- The custom `slug` field has been renamed to `path` to communicate that it can be used for linking, but also because `gatsby-plugin-mdx` also provides a field called `slug`, which I assume is what already caused a confusion in `createPages`, where `slug` was being used instead of `fields.slug`.

- All local URL paths (i.e. the values of `Link`'s `to` prop) should have a trailing slash, to avoid potential SEO problems with the same page treated as two different pages

- First tabs are treated as the default view for the URL, the effect of this change is illustrated by the URL changed on the landing page. This was achieved by reading the `type` in the `meta.yml` file when constructing the path. I was able to easily test this without actually reading and writing to the filesystem by using [`memfs`](https://www.npmjs.com/package/memfs).
