### PR TITLE
fix(Accordion): missing onExpand ts

### DIFF
--- a/packages/orbit-components/src/Accordion/index.d.ts
+++ b/packages/orbit-components/src/Accordion/index.d.ts
@@ -11,8 +11,8 @@ declare module "@kiwicom/orbit-components/lib/Accordion";
 export interface Props extends Common.Global, Common.SpaceAfter {
   readonly children?: React.ReactNode;
   readonly expandedSection?: string | number;
+  readonly onExpand?: (sectionId: string | number) => void | Promise<any>;
   readonly loading?: boolean;
-  readonly dataA11ySection?: string;
 }
 
 declare const Accordion: React.FunctionComponent<Props>;


### PR DESCRIPTION
Noticed, that `Accordion` ts declarations missing `onExpand`<br/><br/><br/><url>LiveURL: https://orbit-fix-accordion-ts-declarations.surge.sh</url>