### PR TITLE
fix: stop relying on a transient dependency

### DIFF
--- a/packages/eslint-plugin-orbit-components/package.json
+++ b/packages/eslint-plugin-orbit-components/package.json
@@ -28,6 +28,9 @@
     "build": "rm -fr ./dist && babel ./src --extensions '.ts' --out-dir ./dist",
     "prepublishOnly": "yarn build"
   },
+  "dependencies": {
+    "@babel/types": "=7.12.10"
+  },
   "devDependencies": {
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-typescript": "^7.12.7",

--- a/packages/eslint-plugin-orbit-components/src/rules/buttonHasTitle.ts
+++ b/packages/eslint-plugin-orbit-components/src/rules/buttonHasTitle.ts
@@ -1,7 +1,7 @@
 import isOrbitComponent from "../utils/isOrbitComponent";
 import detectOriginalOrbitName from "../utils/detectOriginalOrbitName";
 import { Rule } from "eslint";
-import { types as t } from "@babel/core";
+import * as t from "@babel/types";
 
 export default {
   create: (context: Rule.RuleContext) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,6 +1107,15 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/types@=7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.10.tgz#7965e4a7260b26f09c56bcfcb0498af1f6d9b260"
+  integrity sha512-sf6wboJV5mGyip2hIpDSKsr80RszPinEFjsHTalMxZAZkoQ2/2yQzxlcFN52SJqsyPfLtPmenL4g2KB3KJXPDw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.12.1", "@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.12", "@babel/types@^7.12.5", "@babel/types@^7.12.6", "@babel/types@^7.12.7", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.12.12"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"


### PR DESCRIPTION
`button-has-title` is using types from `@babel/core`, exported by `@babel/types`, neither of which were defined in `dependencies` of `eslint-plugin-orbit-components`, meaning that it was relying on a transient dependency with an uncertain version number. #2660 fleshed out this problem, and research showed that the working version of `@babel/types` is `7.12.10`, so I installed it, locked the version number, and now it's being used directly instead of `@babel/core`.

Closes #2673.
Closes #2674. It's a more straightforward alternative.<br/><br/><br/><url>LiveURL: https://orbit-fix-eslint-button-has-minimal.surge.sh</url>