### PR TITLE
chore: use AbstractComponent instead of Ref type spread

### DIFF
--- a/packages/orbit-components/src/Checkbox/index.js.flow
+++ b/packages/orbit-components/src/Checkbox/index.js.flow
@@ -5,7 +5,7 @@
 import * as React from "react";
 import type { ReactComponentStyled } from "styled-components";
 
-import type { Globals, Ref } from "../common/common.js.flow";
+import type { Globals } from "../common/common.js.flow";
 
 export type Props = {|
   +label?: React.Node,
@@ -20,9 +20,8 @@ export type Props = {|
   +tooltip?: ?React.Element<any>,
   +onChange?: (ev: SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
   ...Globals,
-  ...Ref,
 |};
 
-declare export default React.ComponentType<Props>;
+declare export default React.AbstractComponent<Props, HTMLElement>;
 
 declare export var Label: ReactComponentStyled<any>;

--- a/packages/orbit-components/src/InputField/index.js.flow
+++ b/packages/orbit-components/src/InputField/index.js.flow
@@ -5,13 +5,7 @@
 import * as React from "react";
 import type { ReactComponentStyled } from "styled-components";
 
-import type {
-  Globals,
-  Ref,
-  Translation,
-  TranslationString,
-  DataAttrs,
-} from "../common/common.js.flow";
+import type { Globals, Translation, TranslationString, DataAttrs } from "../common/common.js.flow";
 import type { spaceAfter } from "../common/getSpacingToken";
 
 export type Size = "small" | "normal";
@@ -20,7 +14,6 @@ type InputMode = "numeric" | "tel" | "decimal" | "email" | "url" | "search" | "t
 
 export type Props = {|
   ...Globals,
-  ...Ref,
   ...spaceAfter,
   ...DataAttrs,
   +size?: Size,

--- a/packages/orbit-components/src/InputStepper/index.js.flow
+++ b/packages/orbit-components/src/InputStepper/index.js.flow
@@ -4,13 +4,12 @@
 */
 import * as React from "react";
 
-import type { Globals, Ref, Translation } from "../common/common.js.flow";
+import type { Globals, Translation } from "../common/common.js.flow";
 import type { Size } from "../InputField/index";
 import type { spaceAfter } from "../common/getSpacingToken/index";
 
 export type SharedProps = {|
   ...Globals,
-  ...Ref,
   ...spaceAfter,
   +size?: Size,
   +label?: Translation,
@@ -36,4 +35,4 @@ export type Props = {|
   +onChange?: number => void | Promise<any>,
 |};
 
-declare export default React.ComponentType<Props>;
+declare export default React.AbstractComponent<Props, HTMLElement>;

--- a/packages/orbit-components/src/Radio/index.js.flow
+++ b/packages/orbit-components/src/Radio/index.js.flow
@@ -4,7 +4,7 @@
 */
 import * as React from "react";
 
-import type { Globals, Ref } from "../common/common.js.flow";
+import type { Globals } from "../common/common.js.flow";
 
 export type Props = {|
   +label?: React.Node,
@@ -19,7 +19,6 @@ export type Props = {|
   +tooltip?: ?React.Element<any>,
   +onChange?: (ev: SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
   ...Globals,
-  ...Ref,
 |};
 
-declare export default React.ComponentType<Props>;
+declare export default React.AbstractComponent<Props, HTMLElement>;

--- a/packages/orbit-components/src/Select/index.js.flow
+++ b/packages/orbit-components/src/Select/index.js.flow
@@ -5,13 +5,7 @@
 import * as React from "react";
 import type { ReactComponentStyled } from "styled-components";
 
-import type {
-  Globals,
-  Ref,
-  Translation,
-  TranslationString,
-  DataAttrs,
-} from "../common/common.js.flow";
+import type { Globals, Translation, TranslationString, DataAttrs } from "../common/common.js.flow";
 import type { spaceAfter } from "../common/getSpacingToken/index";
 
 type Option = {|
@@ -25,7 +19,6 @@ type Size = "small" | "normal";
 
 export type Props = {|
   ...Globals,
-  ...Ref,
   ...spaceAfter,
   ...DataAttrs,
   +id?: string,
@@ -50,4 +43,4 @@ export type Props = {|
 
 declare export var SelectContainer: ReactComponentStyled<any>;
 
-declare export default React.ComponentType<Props>;
+declare export default React.AbstractComponent<Props, HTMLElement>;


### PR DESCRIPTION
Removed `...Ref` from `index.js.flow` files, where `AbstractComponent` is possible to use<br/><br/><br/><url>LiveURL: https://orbit-chore-remove-ref.surge.sh</url>