### PR TITLE
chore: ignore updates of @babel/types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     labels:
       - "dependency"
     versioning-strategy: "increase"
+    ignore:
+      # updating @babel/types breaks the ESLint rule orbit-components/button-has-title
+      # https://github.com/kiwicom/orbit/pull/2675
+      - dependency-name: "@babel/types"


### PR DESCRIPTION
Closes #2682.
<br/><br/><br/><url>LiveURL: https://orbit-dependabot-ignore-babel-typesb.surge.sh</url>