### PR TITLE
fix/use intersect detect support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@svgr/core": "^2.0.0",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.1.0",
-    "@testing-library/react-hooks": "^3.7.0",
+    "@testing-library/react-hooks": "^5.0.3",
     "@testing-library/user-event": "^12.1.10",
     "@types/styled-components": "^5.1.4",
     "@typescript-eslint/eslint-plugin": "^4.9.0",

--- a/packages/orbit-components/src/hooks/useIntersect/__tests__/index.test.js
+++ b/packages/orbit-components/src/hooks/useIntersect/__tests__/index.test.js
@@ -1,6 +1,7 @@
 // @noflow
 import * as React from "react";
 import { render, screen, act } from "@testing-library/react";
+import { renderHook } from "@testing-library/react-hooks";
 
 import useIntersect from "..";
 
@@ -46,6 +47,11 @@ describe("useIntersect", () => {
     });
     expect(screen.getByRole("img")).toHaveAttribute("src", "source");
 
-    window.IntersectionObserver = undefined;
+    delete window.IntersectionObserver;
+  });
+
+  it("should skip functionality when IntersectionObserver is not supported", () => {
+    const { result } = renderHook(() => useIntersect({}));
+    expect(result.current.entry).toBeNull();
   });
 });

--- a/packages/orbit-components/src/hooks/useIntersect/index.js
+++ b/packages/orbit-components/src/hooks/useIntersect/index.js
@@ -12,6 +12,10 @@ export default ({ root = null, rootMargin, threshold = 0 }: IntersectionObserver
   const observer = useRef<null | IntersectionObserver>(null);
 
   useEffect(() => {
+    if ("IntersectionObserver" in window === false) {
+      return () => {};
+    }
+
     observer.current = new window.IntersectionObserver(([ent]) => updateEntry(ent), {
       root,
       rootMargin,

--- a/packages/orbit-components/src/hooks/useIntersect/index.js.flow
+++ b/packages/orbit-components/src/hooks/useIntersect/index.js.flow
@@ -1,9 +1,8 @@
 // @flow
-type Dispatch<S> = (args: S) => void;
-type SetAction<S> = S | ((prevState: S) => S);
+import * as React from "react";
 
 export type useIntersect = (
   intersect?: IntersectionObserverOptions,
-) => {| ref: Dispatch<SetAction<null | Element>> | null, entry: IntersectionObserverEntry | null |};
+) => {| ref: React.Ref<Element>, entry: IntersectionObserverEntry | null |};
 
 declare export default useIntersect;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,13 +3998,17 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.7.0.tgz#6d75c5255ef49bce39b6465bf6b49e2dac84919e"
-  integrity sha512-TwfbY6BWtWIHitjT05sbllyLIProcysC0dF0q1bbDa7OHLC6A6rJOYJwZ13hzfz3O4RtOuInmprBozJRyyo7/g==
+"@testing-library/react-hooks@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.0.3.tgz#dd0d2048817b013b266d35ca45e3ea48a19fd87e"
+  integrity sha512-UrnnRc5II7LMH14xsYNm/WRch/67cBafmrSQcyFh0v+UUmSf1uzfB7zn5jQXSettGwOSxJwdQUN7PgkT0w22Lg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@types/testing-library__react-hooks" "^3.4.0"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    filter-console "^0.1.1"
+    react-error-boundary "^3.1.0"
 
 "@testing-library/react@^11.1.0":
   version "11.2.3"
@@ -4390,6 +4394,13 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
+  integrity sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-syntax-highlighter@11.0.4":
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz#d86d17697db62f98046874f62fdb3e53a0bbc4cd"
@@ -4397,7 +4408,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-test-renderer@*":
+"@types/react-test-renderer@>=16.9.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.0.tgz#9be47b375eeb906fced37049e67284a438d56620"
   integrity sha512-nvw+F81OmyzpyIE1S0xWpLonLUZCMewslPuA8BtjSKc5XEbn8zEQBXS7KuOLHTNnSOEM2Pum50gHOoZ62tqTRg==
@@ -4411,7 +4422,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@>=16.9.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
   integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
@@ -4479,13 +4490,6 @@
   integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
   dependencies:
     "@types/jest" "*"
-
-"@types/testing-library__react-hooks@^3.4.0":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz#b8d7311c6c1f7db3103e94095fe901f8fef6e433"
-  integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
-  dependencies:
-    "@types/react-test-renderer" "*"
 
 "@types/tmp@^0.0.33":
   version "0.0.33"
@@ -11087,6 +11091,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-console@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/filter-console/-/filter-console-0.1.1.tgz#6242be28982bba7415bcc6db74a79f4a294fa67c"
+  integrity sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -19954,6 +19963,13 @@ react-element-to-jsx-string@^14.0.2, react-element-to-jsx-string@^14.3.2:
   dependencies:
     "@base2/pretty-print-object" "1.0.0"
     is-plain-object "3.0.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.0.tgz#9487443df2f9ba1db90d8ab52351814907ea4af3"
+  integrity sha512-lmPrdi5SLRJR+AeJkqdkGlW/CRkAUvZnETahK58J4xb5wpbfDngasEGu+w0T1iXEhVrYBJZeW+c4V1hILCnMWQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- chore: bump @testing-library/react-hooks
- fix(useIntersect): do nothing in browsers that don't support IntersectionObserver
<br/><br/><br/><url>LiveURL: https://orbit-fix-use-intersect-detect-support.surge.sh</url>