### PR TITLE
feat(tokens): rename palette shades to secondary and tertiary

### DIFF
--- a/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/blue.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/blue.json
@@ -8,12 +8,12 @@
             "value": "#E8F4FD",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#D0E9FB",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#B4DBF8",
             "internal": true
@@ -25,12 +25,12 @@
             "value": "#0172CB",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#0161AC",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#01508E",
             "internal": true
@@ -42,12 +42,12 @@
             "value": "#005AA3",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#004F8F",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#003E70",
             "internal": true

--- a/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/cloud.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/cloud.json
@@ -8,12 +8,12 @@
             "value": "#F5F7F9",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#E5EAEF",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#D6DEE6",
             "internal": true
@@ -25,12 +25,12 @@
             "value": "#EFF2F5",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#DCE3E9",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#CAD4DE",
             "internal": true

--- a/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/green.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/green.json
@@ -8,12 +8,12 @@
             "value": "#EBF4EC",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#D7EAD9",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#C3DFC7",
             "internal": true
@@ -25,12 +25,12 @@
             "value": "#28A138",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#238B31",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#1D7228",
             "internal": true
@@ -42,12 +42,12 @@
             "value": "#2B7336",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#25642F",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#1F5126",
             "internal": true

--- a/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/ink.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/ink.json
@@ -8,12 +8,12 @@
             "value": "#BAC7D5",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#A6B6C8",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#94A8BE",
             "internal": true
@@ -25,12 +25,12 @@
             "value": "#5F738C",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#52647A",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#465567",
             "internal": true
@@ -42,12 +42,12 @@
             "value": "#252A31",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#181B20",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#0B0C0F",
             "internal": true

--- a/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/orange.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/orange.json
@@ -8,12 +8,12 @@
             "value": "#FDF0E3",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#FAE2C7",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#F8D3AB",
             "internal": true
@@ -25,12 +25,12 @@
             "value": "#E98305",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#DC7C05",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#CD7304",
             "internal": true
@@ -42,12 +42,12 @@
             "value": "#A25100",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#8F4700",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#753A00",
             "internal": true

--- a/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/product.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/product.json
@@ -8,12 +8,12 @@
             "value": "#ECF8F7",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#D6F0EE",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#C0E8E4",
             "internal": true
@@ -25,12 +25,12 @@
             "value": "#00A991",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#009882",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#008F7B",
             "internal": true
@@ -42,12 +42,12 @@
             "value": "#007F6D",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#007060",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#006657",
             "internal": true

--- a/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/red.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/red.json
@@ -8,12 +8,12 @@
             "value": "#FAEAEA",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#F4D2D2",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#EEB9B9",
             "internal": true
@@ -25,12 +25,12 @@
             "value": "#D21C1C",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#B91919",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#9D1515",
             "internal": true
@@ -42,12 +42,12 @@
             "value": "#970C0C",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#890B0B",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#6D0909",
             "internal": true

--- a/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/social.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/social.json
@@ -8,12 +8,12 @@
             "value": "#3B5998",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#385490",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#354F88",
             "internal": true

--- a/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/white.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/foundation/palette/white.json
@@ -8,12 +8,12 @@
             "value": "#FFFFFF",
             "internal": true
           },
-          "hover": {
+          "secondary": {
             "type": "color",
             "value": "#F1F4F7",
             "internal": true
           },
-          "active": {
+          "tertiary": {
             "type": "color",
             "value": "#E7ECF1",
             "internal": true

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/blue.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/blue.json
@@ -9,11 +9,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.blue.light.default}"
+            "value": "{foundation.palette.blue.light.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.blue.light.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.blue.light.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.blue.light.active}"
+            "value": "{foundation.palette.blue.light.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.blue.light.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.blue.light.tertiary}"
           }
         },
         "normal": {
@@ -23,11 +35,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.blue.normal.hover}"
+            "value": "{foundation.palette.blue.normal.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.blue.normal.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.blue.normal.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.blue.normal.active}"
+            "value": "{foundation.palette.blue.normal.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.blue.normal.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.blue.normal.tertiary}"
           }
         },
         "dark": {
@@ -37,11 +61,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.blue.dark.hover}"
+            "value": "{foundation.palette.blue.dark.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.blue.dark.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.blue.dark.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.blue.dark.active}"
+            "value": "{foundation.palette.blue.dark.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.blue.dark.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.blue.dark.tertiary}"
           }
         },
         "darker": {

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/cloud.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/cloud.json
@@ -9,11 +9,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.cloud.light.hover}"
+            "value": "{foundation.palette.cloud.light.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.cloud.light.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.cloud.light.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.cloud.light.active}"
+            "value": "{foundation.palette.cloud.light.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.cloud.light.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.cloud.light.tertiary}"
           }
         },
         "normal": {
@@ -23,11 +35,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.cloud.normal.hover}"
+            "value": "{foundation.palette.cloud.normal.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.cloud.normal.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.cloud.normal.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.cloud.normal.active}"
+            "value": "{foundation.palette.cloud.normal.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.cloud.normal.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.cloud.normal.tertiary}"
           }
         },
         "dark": {

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/green.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/green.json
@@ -9,11 +9,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.green.light.hover}"
+            "value": "{foundation.palette.green.light.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.green.light.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.green.light.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.green.light.active}"
+            "value": "{foundation.palette.green.light.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.green.light.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.green.light.tertiary}"
           }
         },
         "normal": {
@@ -23,11 +35,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.green.normal.hover}"
+            "value": "{foundation.palette.green.normal.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.green.normal.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.green.normal.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.green.normal.active}"
+            "value": "{foundation.palette.green.normal.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.green.normal.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.green.normal.tertiary}"
           }
         },
         "dark": {
@@ -37,11 +61,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.green.dark.hover}"
+            "value": "{foundation.palette.green.dark.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.green.dark.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.green.dark.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.green.dark.active}"
+            "value": "{foundation.palette.green.dark.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.green.dark.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.green.dark.tertiary}"
           }
         },
         "darker": {

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/ink.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/ink.json
@@ -9,11 +9,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.ink.lighter.hover}"
+            "value": "{foundation.palette.ink.lighter.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.ink.lighter.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.ink.lighter.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.ink.lighter.active}"
+            "value": "{foundation.palette.ink.lighter.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.ink.lighter.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.ink.lighter.tertiary}"
           }
         },
         "light": {
@@ -23,11 +35,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.ink.light.hover}"
+            "value": "{foundation.palette.ink.light.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.ink.light.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.ink.light.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.ink.light.active}"
+            "value": "{foundation.palette.ink.light.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.ink.light.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.ink.light.tertiary}"
           }
         },
         "normal": {
@@ -37,11 +61,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.ink.normal.hover}"
+            "value": "{foundation.palette.ink.normal.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.ink.normal.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.ink.normal.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.ink.normal.active}"
+            "value": "{foundation.palette.ink.normal.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.ink.normal.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.ink.normal.tertiary}"
           }
         }
       }

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/orange.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/orange.json
@@ -9,11 +9,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.orange.light.hover}"
+            "value": "{foundation.palette.orange.light.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.orange.light.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.orange.light.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.orange.light.active}"
+            "value": "{foundation.palette.orange.light.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.orange.light.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.orange.light.tertiary}"
           }
         },
         "normal": {
@@ -23,11 +35,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.orange.normal.hover}"
+            "value": "{foundation.palette.orange.normal.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.orange.normal.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.orange.normal.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.orange.normal.active}"
+            "value": "{foundation.palette.orange.normal.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.orange.normal.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.orange.normal.tertiary}"
           }
         },
         "dark": {
@@ -37,11 +61,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.orange.dark.hover}"
+            "value": "{foundation.palette.orange.dark.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.orange.dark.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.orange.dark.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.orange.dark.active}"
+            "value": "{foundation.palette.orange.dark.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.orange.dark.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.orange.dark.tertiary}"
           }
         },
         "darker": {

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/product.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/product.json
@@ -9,11 +9,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.product.light.hover}"
+            "value": "{foundation.palette.product.light.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.product.light.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.product.light.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.product.light.active}"
+            "value": "{foundation.palette.product.light.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.product.light.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.product.light.tertiary}"
           }
         },
         "normal": {
@@ -23,11 +35,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.product.normal.hover}"
+            "value": "{foundation.palette.product.normal.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.product.normal.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.product.normal.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.product.normal.active}"
+            "value": "{foundation.palette.product.normal.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{foundation.palette.product.normal.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.product.normal.tertiary}"
           }
         },
         "dark": {
@@ -37,11 +61,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.product.dark.hover}"
+            "value": "{foundation.palette.product.dark.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.product.dark.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.product.dark.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.product.dark.active}"
+            "value": "{foundation.palette.product.dark.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.product.dark.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.product.dark.tertiary}"
           }
         },
         "darker": {

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/red.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/red.json
@@ -9,11 +9,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.red.light.hover}"
+            "value": "{foundation.palette.red.light.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.red.light.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.red.light.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.red.light.active}"
+            "value": "{foundation.palette.red.light.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.red.light.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.red.light.tertiary}"
           }
         },
         "normal": {
@@ -23,11 +35,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.red.normal.hover}"
+            "value": "{foundation.palette.red.normal.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.red.normal.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.red.normal.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.red.normal.active}"
+            "value": "{foundation.palette.red.normal.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.red.normal.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.red.normal.tertiary}"
           }
         },
         "dark": {
@@ -37,11 +61,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.red.dark.hover}"
+            "value": "{foundation.palette.red.dark.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.red.dark.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.red.dark.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.red.dark.active}"
+            "value": "{foundation.palette.red.dark.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.red.dark.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.red.dark.tertiary}"
           }
         },
         "darker": {

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/social.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/social.json
@@ -9,11 +9,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.social.facebook.hover}"
+            "value": "{foundation.palette.social.facebook.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.social.facebook.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.social.facebook.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.social.facebook.active}"
+            "value": "{foundation.palette.social.facebook.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{foundation.palette.social.facebook.tertiary"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.social.facebook.tertiary}"
           }
         }
       }

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/white.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/white.json
@@ -9,11 +9,23 @@
           },
           "hover": {
             "type": "color",
-            "value": "{foundation.palette.white.normal.hover}"
+            "value": "{foundation.palette.white.normal.secondary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.white.normal.secondary}"
+          },
+          "secondary": {
+            "type": "color",
+            "value": "{foundation.palette.white.normal.secondary}"
           },
           "active": {
             "type": "color",
-            "value": "{foundation.palette.white.normal.active}"
+            "value": "{foundation.palette.white.normal.tertiary}",
+            "deprecated": true,
+            "deprecated-replace": "{global.palette.white.normal.tertiary}"
+          },
+          "tertiary": {
+            "type": "color",
+            "value": "{foundation.palette.white.normal.tertiary}"
           }
         }
       }


### PR DESCRIPTION
Renamed shades of colors from `hover` to `secondary` and `active` to `tertiary` because of new semantic meaning.