### PR TITLE
docs: limit Prose margins to direct children

### DIFF
--- a/docs/src/components/Prose.tsx
+++ b/docs/src/components/Prose.tsx
@@ -6,14 +6,14 @@ const Prose = styled.div`
   > * + * {
     margin-top: ${({ theme }) => theme.orbit.spaceSmall};
   }
-  h1 {
+  > h1 {
     margin-bottom: ${({ theme }) => theme.orbit.spaceLarge};
   }
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
+  > h2,
+  > h3,
+  > h4,
+  > h5,
+  > h6 {
     margin-top: ${({ theme }) => theme.orbit.spaceLarge};
   }
 `;


### PR DESCRIPTION
The reason for this is that we don't want nested headings, like in the `Tile` component, to have unexpected margins. One such example is in #2706.