### PR TITLE
improve: define postinstall scripts per-workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "orbit-design-tokens": "yarn workspace @kiwicom/orbit-design-tokens",
     "build": "yarn orbit-design-tokens build && yarn orbit-components build",
     "build-ci": "lerna bootstrap && yarn build",
-    "postinstall": "yarn orbit-components build:icons && yarn orbit-components build:typeFiles",
+    "postinstall": "lerna run postinstall --stream",
     "prettier:test": "prettier --check '**/*.md'",
     "eslint:ci": "eslint-config-prettier index.js index.ts && eslint . --report-unused-disable-directives",
     "flow:check": "flow check",

--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -4,6 +4,7 @@
   "description": "Orbit-components is a React component library which provides developers with the easiest possible way of building Kiwi.com’s products.",
   "sideEffects": false,
   "scripts": {
+    "postinstall": "yarn build:icons && yarn build:typeFiles",
     "storybook": "start-storybook -p 6007 -c .storybook --ci -s ./static",
     "prepublishOnly": "yarn build",
     "build": "yarn clean && yarn build:icons && yarn build:iconFont && yarn build:typeFiles && yarn build:lib && yarn build:module && yarn build:umd",


### PR DESCRIPTION
This makes it possible for each workspace to define their own
`postinstall` script instead of having to call them from the root. This
also makes the development experience friendlier because now installing
dependencies inside `packages/orbit-components`, for example, will run
the `ponstinstall` script for that workspace.
