### PR TITLE
improve: use `postinstall` instead of `install`

### DIFF
--- a/packages/eslint-plugin-orbit-internal/package.json
+++ b/packages/eslint-plugin-orbit-internal/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "rimraf ./dist && babel ./src --extensions '.ts' --out-dir ./dist",
-    "install": "yarn build"
+    "postinstall": "yarn build"
   },
   "dependencies": {
     "@babel/types": "=7.12.10"


### PR DESCRIPTION
This way it will run for people who install dependencies from root as well, because of the `postinstall` script in root.

 Orbit.kiwi: https://orbit-docs-improve-eslint-internal-postinstall.surge.sh
 Storybook: https://orbit-improve-eslint-internal-postinstall.surge.sh