### PR TITLE
feat(tokens): rename spacing scale to proportion based

### DIFF
--- a/packages/orbit-design-tokens/src/dictionary/build.ts
+++ b/packages/orbit-design-tokens/src/dictionary/build.ts
@@ -12,6 +12,7 @@ const build = () => {
     name: "javascript/foundation",
     transforms: [
       "attribute/nov",
+      "attribute/nov/camelCase",
       "attribute/nov/alias",
       "attribute/nov/type",
       "name/nov/camel",
@@ -25,6 +26,7 @@ const build = () => {
     transforms: [
       "attribute/nov",
       "attribute/nov/isReferenced",
+      "attribute/nov/camelCase",
       "attribute/nov/type",
       "value/nov/alias",
       "name/nov/camel",

--- a/packages/orbit-design-tokens/src/dictionary/definitions/foundation/space.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/foundation/space.json
@@ -1,44 +1,44 @@
 {
   "foundation": {
     "space": {
-      "XXS": {
+      "half-x": {
+        "type": "spacing",
+        "value": 2,
+        "internal": true
+      },
+      "one-x": {
         "type": "spacing",
         "value": 4,
         "internal": true
       },
-      "XS": {
+      "two-x": {
         "type": "spacing",
         "value": 8,
         "internal": true
       },
-      "S": {
+      "three-x": {
         "type": "spacing",
         "value": 12,
         "internal": true
       },
-      "M": {
+      "four-x": {
         "type": "spacing",
         "value": 16,
         "internal": true
       },
-      "L": {
+      "six-x": {
         "type": "spacing",
         "value": 24,
         "internal": true
       },
-      "XL": {
+      "eight-x": {
         "type": "spacing",
         "value": 32,
         "internal": true
       },
-      "XXL": {
+      "ten-x": {
         "type": "spacing",
         "value": 40,
-        "internal": true
-      },
-      "XXXL": {
-        "type": "spacing",
-        "value": 52,
         "internal": true
       }
     }

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/space.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/space.json
@@ -1,0 +1,38 @@
+{
+  "global": {
+    "space": {
+      "half-x": {
+        "type": "spacing",
+        "value": "{foundation.space.half-x}"
+      },
+      "one-x": {
+        "type": "spacing",
+        "value": "{foundation.space.one-x}"
+      },
+      "two-x": {
+        "type": "spacing",
+        "value": "{foundation.space.two-x}"
+      },
+      "three-x": {
+        "type": "spacing",
+        "value": "{foundation.space.three-x}"
+      },
+      "four-x": {
+        "type": "spacing",
+        "value": "{foundation.space.four-x}"
+      },
+      "six-x": {
+        "type": "spacing",
+        "value": "{foundation.space.six-x}"
+      },
+      "eight-x": {
+        "type": "spacing",
+        "value": "{foundation.space.eight-x}"
+      },
+      "ten-x": {
+        "type": "spacing",
+        "value": "{foundation.space.ten-x}"
+      }
+    }
+  }
+}

--- a/packages/orbit-design-tokens/src/dictionary/transforms/attributes/index.ts
+++ b/packages/orbit-design-tokens/src/dictionary/transforms/attributes/index.ts
@@ -21,7 +21,7 @@ export const attributeNOV = {
     const generatedAttrs = {};
 
     for (let i = 0; i < path.length && i < NOV_STRUCTURE.length; i += 1) {
-      generatedAttrs[NOV_STRUCTURE[i]] = _.camelCase(path[i]);
+      generatedAttrs[NOV_STRUCTURE[i]] = path[i];
     }
     return Object.assign(generatedAttrs, attributes);
   },
@@ -40,12 +40,21 @@ export const attributeIsReferenced = {
   },
 };
 
+/*
+  Transforms all attributes of names/object/variant structure to camelCased string.
+ */
 export const attributeNOVCamelCase = {
   name: "attribute/nov/camelCase",
   type: "attribute",
   transformer: ({ attributes }: Property): Attributes => {
-    const { namespace, object, variant, subVariant } = attributes;
     const camelCased = {};
+    for (let i = 0; i < NOV_STRUCTURE.length; i += 1) {
+      const key = NOV_STRUCTURE[i];
+      if (attributes[key]) {
+        camelCased[key] = _.camelCase(String(attributes[key]));
+      }
+    }
+
     return Object.assign(attributes, camelCased);
   },
 };


### PR DESCRIPTION
Rename spacing tokens to proportion based format.

I had the change the proposed schema, because it will be very limiting to use `2-x` (or camelCased variant `2x`) as a token name. 
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Identifier_after_number

The problem would be mainly noticeable in the foundation usage, e.g. if somebody would like to change the spacings token via `createTheme` function he would have to pass these properties in different way – which is not that common when comes to usage of object in Javascript. It would be also limitation for us. See further code examples.

The definition for spacing token would like this:

```js
const space = {
  "2x": "value",
  "4x": "value",
  ...
}
```

Then also the mapping from foundation to global/component-specific tokens would be a bit tricky, all the time we would have to ensure that the value is properly referenced in the Javascript format, e.g.:

```js
// you can't use `space2x: foundation.space.2x`
const tokens = {
  space2x: foundation.space["2x"],
  space4x: foundation.space["4x"],
  ...
}
```

**Therefore it would be better to use verbal values instead of numbers for the multiplier or fraction, e.g. `one-x`, `half-x`**

The last change I have made was to split the `attribute/nov` camelCase string conversion to specific attribute transform, so it doesn't do this side effect.