### PR TITLE
feat(tokens): add z-index values to global tokens

### DIFF
--- a/packages/orbit-design-tokens/src/dictionary/build.ts
+++ b/packages/orbit-design-tokens/src/dictionary/build.ts
@@ -22,7 +22,13 @@ const build = () => {
   });
   StyleDictionary.registerTransformGroup({
     name: "javascript/tokens",
-    transforms: ["attribute/nov", "attribute/nov/type", "value/nov/alias", "name/nov/camel"],
+    transforms: [
+      "attribute/nov",
+      "attribute/nov/isReferenced",
+      "attribute/nov/type",
+      "value/nov/alias",
+      "name/nov/camel",
+    ],
   });
   StyleDictionary.registerTransformGroup({
     name: "xml/tokens",

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/z-indices.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/z-indices.json
@@ -1,0 +1,26 @@
+{
+  "global": {
+    "z-index": {
+      "default": {
+        "type": "z-index",
+        "value": 1
+      },
+      "sticky": {
+        "type": "z-index",
+        "value": 100
+      },
+      "modal-overlay": {
+        "type": "z-index",
+        "value": 800
+      },
+      "modal": {
+        "type": "z-index",
+        "value": 825
+      },
+      "on-the-top": {
+        "type": "z-index",
+        "value": 900
+      }
+    }
+  }
+}

--- a/packages/orbit-design-tokens/src/dictionary/transforms/attributes/index.ts
+++ b/packages/orbit-design-tokens/src/dictionary/transforms/attributes/index.ts
@@ -30,7 +30,6 @@ export const attributeNOV = {
 export const attributeIsReferenced = {
   name: "attribute/nov/isReferenced",
   type: "attribute",
-  // marcher: ({ attributes: { namespace } }: Property): boolean => namespace !== "foundation",
   transformer: ({ value, attributes }: Property): Attributes => {
     const { namespace, object, variant, subVariant } = attributes;
     if ([namespace, object, variant, subVariant].every(v => v == null)) {

--- a/packages/orbit-design-tokens/src/dictionary/transforms/attributes/index.ts
+++ b/packages/orbit-design-tokens/src/dictionary/transforms/attributes/index.ts
@@ -27,6 +27,20 @@ export const attributeNOV = {
   },
 };
 
+export const attributeIsReferenced = {
+  name: "attribute/nov/isReferenced",
+  type: "attribute",
+  // marcher: ({ attributes: { namespace } }: Property): boolean => namespace !== "foundation",
+  transformer: ({ value, attributes }: Property): Attributes => {
+    const { namespace, object, variant, subVariant } = attributes;
+    if ([namespace, object, variant, subVariant].every(v => v == null)) {
+      throw new Error(errorTransform("attribute/nov/isReferenced", "attribute/nov"));
+    }
+    const aliased = attributes.namespace === "foundation" || /{[\w.-]+}/g.test(String(value));
+    return { aliased, ...attributes };
+  },
+};
+
 export const attributeNOVCamelCase = {
   name: "attribute/nov/camelCase",
   type: "attribute",

--- a/packages/orbit-design-tokens/src/dictionary/transforms/values/index.ts
+++ b/packages/orbit-design-tokens/src/dictionary/transforms/values/index.ts
@@ -1,4 +1,4 @@
-import { Property } from "style-dictionary";
+import { Property, Value } from "style-dictionary";
 
 import { isSpacing, isBorderRadius } from "../../utils/is";
 import { errorTransform } from "../../utils/errorMessage";
@@ -10,7 +10,7 @@ export const spacingJavascript = {
   name: "value/spacing/javascript",
   type: "value",
   matcher: isSpacing,
-  transformer: ({ value }: Property): string => {
+  transformer: ({ value }: Property): Value => {
     return `${value}px`;
   },
 };
@@ -21,7 +21,7 @@ export const spacingJavascript = {
 export const stringJavascript = {
   name: "value/string/javascript",
   type: "value",
-  transformer: ({ value }: Property): string => {
+  transformer: ({ value }: Property): Value => {
     return `"${value}"`;
   },
 };
@@ -33,30 +33,31 @@ export const borderRadiusJavascript = {
   name: "value/border-radius/javascript",
   type: "value",
   matcher: isBorderRadius,
-  transformer: ({ value }: Property): string => {
+  transformer: ({ value }: Property): Value => {
     const normalizedValue = Number(value);
     if (normalizedValue) {
       return `${normalizedValue}px`;
     }
-    return String(value);
+    return value;
   },
 };
 
 /*
-  Transforms attributes from attribute/nov to interlaced identifiers.
+  Transforms attributes from attribute/nov to interlaced identifiers,
+  only for referenced aliases.
   e.g. foundation.space.value
-  TODO in future:
-  - other types has leading dot at the end (only palette is being exposed via global tokens for now)
  */
 export const foundationAlias = {
   name: "value/nov/alias",
   type: "value",
-  transformer: (prop: Property): string => {
-    const { attributes } = prop;
-    const { namespace, object, variant, subVariant } = attributes;
-    if ([namespace, object, variant, subVariant].every(value => value == null)) {
+  transformer: ({
+    attributes: { namespace, object, variant, subVariant, aliased },
+    value,
+  }: Property): Value => {
+    if ([namespace, object, variant, subVariant].every(v => v == null)) {
       throw new Error(errorTransform("value/nov/alias", "attribute/nov"));
     }
+    if (!aliased) return value;
     return [namespace, object, variant, subVariant].filter(Boolean).join(".");
   },
 };


### PR DESCRIPTION
Added old z-index values to global tokens.

Because the original intention of `attribute/nov/alias` was to create value of the original reference, it didn't count with case when the global (or component-specific) token is not connected to the foundation via reference alias. 