### PR TITLE
feat(eslint-plugin-orbit): default-theme rule

### DIFF
--- a/packages/eslint-plugin-orbit-components/__tests__/defaultTheme.test.ts
+++ b/packages/eslint-plugin-orbit-components/__tests__/defaultTheme.test.ts
@@ -1,0 +1,93 @@
+import ruleTester from "../ruleTester";
+import defaultTheme, { ERRORS } from "../src/rules/defaultTheme";
+
+describe("defaultTheme", () => {
+  ruleTester.run("defaultTheme", defaultTheme, {
+    valid: [
+      {
+        code: `
+          import defaultTheme from "@kiwicom/orbit-components/lib/defaultTheme";\
+
+          const Wrapper = styled.div\`
+            display: \${({ theme }) => theme.orbit.paletteWhite};
+          \`;
+
+          Wrapper.defaultProps = {
+            theme: defaultTheme,
+          }
+        `,
+      },
+      {
+        code: `
+          import { defaultTheme } from "@kiwicom/orbit-components";\
+
+          const Wrapper = styled.div\`
+            display: \${({ theme }) => theme.orbit.paletteWhite};
+          \`;
+
+          Wrapper.defaultProps = {
+            theme: defaultTheme,
+          }
+        `,
+      },
+      {
+        code: `
+          import defaultTheme from "@kiwicom/orbit-components/lib/defaultTheme";\
+
+          <ThemeProvider theme={defaultTheme}>
+            <BrandProvider value={brand}>
+              <FetchedProvider value={fetched}>
+                <LogProvider value={{ log: (e, p) => cuckoo.nitro(e, p) }}>
+                  <InitRelayEnvironment clientID="frontend">{children}</InitRelayEnvironment>
+                </LogProvider>
+              </FetchedProvider>
+          </BrandProvider>
+        </ThemeProvider>
+        `,
+      },
+    ],
+    invalid: [
+      {
+        code: `
+        import defaultTheme from "@kiwicom/orbit-components/lib/defaultTheme";\
+
+          const failedStatus = {
+            isActive: true,
+            activeColor: defaultTheme.orbit.paletteOrangeNormal /* #f9971e */,
+            node: <CloseCircle color="warning" />,
+            content: getContentPerStatus(activeStatus, true),
+          }
+        `,
+        errors: [ERRORS.variableDeclaration],
+      },
+      {
+        code: `
+          import defaultTheme from "@kiwicom/orbit-components/lib/defaultTheme";\
+
+          const Wrapper = styled.div\`
+            color: $\{defaultTheme.orbit.paletteProductNormal};
+          \`
+        `,
+        errors: [ERRORS.styled],
+      },
+      {
+        code: `import theme from "@kiwicom/orbit-components/lib/defaultTheme";`,
+        errors: [ERRORS.import],
+      },
+      {
+        code: `
+          import defaultTheme from "@kiwicom/orbit-components/lib/defaultTheme";
+
+          const {
+            borderWidthCard,
+            borderStyleCard,
+            borderColorCard,
+            borderRadiusNormal,
+            spaceMedium,
+          } = defaultTheme.orbit;
+        `,
+        errors: [ERRORS.destructured],
+      },
+    ],
+  });
+});

--- a/packages/eslint-plugin-orbit-components/docs/rules/default-theme.md
+++ b/packages/eslint-plugin-orbit-components/docs/rules/default-theme.md
@@ -1,0 +1,64 @@
+# default-theme
+
+The aim of this rule is to prevent a wrong usage of the defaultTheme object from @kiwicom/orbit-components.
+
+## Rule details
+
+The following patterns are considered errors:
+
+```jsx
+import defaultTheme from "@kiwicom/orbit-components/lib/defaultTheme";
+
+const failedStatus = {
+  isActive: true,
+  activeColor: defaultTheme.orbit.paletteOrangeNormal,
+  node: <CloseCircle color="warning" />,
+  content: getContentPerStatus(activeStatus, true),
+};
+```
+
+```jsx
+import defaultTheme from "@kiwicom/orbit-components/lib/defaultTheme";
+
+const Wrapper = styled.div`
+  color: ${defaultTheme.orbit.paletteProductNormal};
+`;
+```
+
+```jsx
+import theme from "@kiwicom/orbit-components/lib/defaultTheme";
+```
+
+```jsx
+import defaultTheme from "@kiwicom/orbit-components/lib/defaultTheme";
+
+const {
+  borderWidthCard,
+  borderStyleCard,
+  borderColorCard,
+  borderRadiusNormal,
+  spaceMedium,
+} = defaultTheme.orbit;
+```
+
+Proper usage of defaultTheme is:
+
+```jsx
+import defaultTheme from "@kiwicom/orbit-components/lib/defaultTheme";
+
+const Wrapper = styled.div`
+  background: ${({ theme }) => theme.orbit.paletteWhite};
+`;
+
+Wrapper.defaultProps = {
+  theme: defaultTheme,
+};
+```
+
+In order to access theme for other cases, you should use `useTheme()` hook or `ThemeConsumer`
+
+## Rule options
+
+```
+"orbit-components/default-theme": <enabled>
+```

--- a/packages/eslint-plugin-orbit-components/src/configs/recommended.ts
+++ b/packages/eslint-plugin-orbit-components/src/configs/recommended.ts
@@ -5,6 +5,7 @@ const recommended = {
     "orbit-components/unnecessary-text": "error",
     "orbit-components/prefer-single-destructure": "warn",
     "orbit-components/custom-colors": "warn",
+    "orbit-components/default-theme": "error",
   },
 };
 

--- a/packages/eslint-plugin-orbit-components/src/index.ts
+++ b/packages/eslint-plugin-orbit-components/src/index.ts
@@ -3,12 +3,14 @@ import unnecessaryText from "./rules/unnecessaryText";
 import recommended from "./configs/recommended";
 import preferSingleDestructure from "./rules/preferSingleDestructure";
 import customColors from "./rules/customColors";
+import defaultTheme from "./rules/defaultTheme";
 
 export const rules = {
   "button-has-title": buttonHasTitle,
   "unnecessary-text": unnecessaryText,
   "prefer-single-destructure": preferSingleDestructure,
   "custom-colors": customColors,
+  "default-theme": defaultTheme,
 };
 
 export const configs = {

--- a/packages/eslint-plugin-orbit-components/src/rules/defaultTheme.ts
+++ b/packages/eslint-plugin-orbit-components/src/rules/defaultTheme.ts
@@ -1,0 +1,129 @@
+import * as t from "@babel/types";
+import type { Rule } from "eslint";
+
+export const ERRORS = {
+  variableDeclaration: "Do not use defaultTheme as value, use useTheme() hook or ThemeConsumer",
+  styled:
+    "Do not use defaultTheme directly inside styled components, either create defaultProps or consume the theme from with arrow function expression.",
+  import: "Do not name defaultTheme import as theme, please rename it to defaultTheme/themeDefault",
+  destructured: "Do not destructured defaultTheme, use useTheme() hook or ThemeConsumer",
+};
+
+const defaultThemeRule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Rule helps to avoid bad patterns of defaultTheme usage",
+      category: "Possible errors",
+      recommended: true,
+    },
+  },
+
+  // @ts-expect-error todo
+  create: (context: Rule.RuleContext) => {
+    let specifier = "";
+
+    return {
+      ImportDeclaration(node: t.ImportDeclaration) {
+        if (node.source.value === "@kiwicom/orbit-components/lib/defaultTheme") {
+          node.specifiers.forEach(s => {
+            if (t.isImportDefaultSpecifier(s)) {
+              if (s.local.name === "theme") {
+                context.report({
+                  // @ts-expect-error TODO
+                  node,
+                  message: ERRORS.import,
+                });
+              } else if (t.isImportDefaultSpecifier(s)) {
+                specifier = s.local.name;
+              }
+            }
+          });
+        }
+      },
+
+      /**
+       * Prevents:
+          const kek = {
+            activeColor: "red",
+            theme: defaultTheme.orbit.paletteBlueNormal,
+          }
+      */
+
+      VariableDeclaration(node: t.VariableDeclaration) {
+        node.declarations.forEach(n => {
+          if (t.isVariableDeclarator(n)) {
+            if (t.isObjectExpression(n.init)) {
+              n.init.properties.forEach(p => {
+                if (t.isProperty(p)) {
+                  if (t.isMemberExpression(p.value)) {
+                    if (
+                      t.isMemberExpression(p.value.object) &&
+                      t.isIdentifier(p.value.object.object)
+                    ) {
+                      if (specifier === p.value.object.object.name) {
+                        context.report({
+                          // @ts-expect-error TODO
+                          node: p,
+                          message: ERRORS.variableDeclaration,
+                        });
+                      }
+                    }
+                  }
+                }
+              });
+            }
+
+            /**
+              Prevents destructure of defaultTheme:
+                const {
+                  borderWidthCard,
+                  borderStyleCard,
+                  borderColorCard,
+                  borderRadiusNormal,
+                  spaceMedium,
+                } = defaultTheme.orbit;
+             */
+
+            if (t.isMemberExpression(n.init) && t.isObjectPattern(n.id)) {
+              if (t.isIdentifier(n.init.object)) {
+                if (specifier === n.init.object.name) {
+                  context.report({
+                    // @ts-expect-error TODO
+                    node,
+                    message: ERRORS.destructured,
+                  });
+                }
+              }
+            }
+          }
+        });
+      },
+
+      /**
+       * Prevents defaultTheme as literal inside styled component:
+          const Wrapper = styled.div`
+            background: ${defaultTheme.orbit.paletteWhite};
+          `
+       */
+
+      TemplateLiteral(node: t.TemplateLiteral) {
+        node.expressions.forEach(exp => {
+          if (t.isMemberExpression(exp)) {
+            if (t.isMemberExpression(exp.object) && t.isIdentifier(exp.object.object)) {
+              if (specifier === exp.object.object.name) {
+                context.report({
+                  // @ts-expect-error TODO
+                  node: exp,
+                  message: ERRORS.styled,
+                });
+              }
+            }
+          }
+        });
+      },
+    };
+  },
+};
+
+export default defaultThemeRule;


### PR DESCRIPTION
Added new rule, called it `default-theme`, as we discussed it earlier, that we should prevent some cases of wrong defaultTheme usage

 Orbit.kiwi: https://orbit-docs-feat-defaultTheme-eslint.surge.sh
 Storybook: https://orbit-feat-defaultTheme-eslint.surge.sh