### PR TITLE
feat(eslint-plugin-orbit): custom-styles

### DIFF
--- a/packages/eslint-plugin-orbit-components/__tests__/customColors.test.ts
+++ b/packages/eslint-plugin-orbit-components/__tests__/customColors.test.ts
@@ -1,0 +1,32 @@
+import ruleTester from "../ruleTester";
+import customColors from "../src/rules/customColors";
+
+describe("custom-colors", () => {
+  // @ts-expect-error TODO
+  ruleTester.run("custom-colors", customColors, {
+    valid: [
+      {
+        code: `
+            const Wrapper = styled.div\`
+              color: \${({theme}) => theme.orbit.colorTextPrimary};
+              background: \${({theme}) => theme.orbit.paletteWhite};
+            \`
+          `,
+      },
+    ],
+    invalid: [
+      {
+        code: `
+            const Wrapper = styled.div\`
+              color: #fff;
+              background: #808080;
+              \`
+          `,
+        errors: [
+          "color should be replaced with Orbit design token",
+          "background should be replaced with Orbit design token",
+        ],
+      },
+    ],
+  });
+});

--- a/packages/eslint-plugin-orbit-components/docs/rules/custom-colors.md
+++ b/packages/eslint-plugin-orbit-components/docs/rules/custom-colors.md
@@ -1,0 +1,23 @@
+# custom-colors
+
+Prevents inconsistencies between Orbit and custom colors
+
+## Rule details
+
+The following patterns are considered warnings:
+
+```jsx
+const StyledWrapper = styled.div`
+  color: #252a31;
+  background: #fff;
+`;
+```
+
+The following patterns are **not** considered warnings:
+
+```jsx
+const StyledWrapper = styled.div`
+  color: ${({theme}) => theme.orbit.colorTextPrimary};
+  background: ${({theme}) => theme.orbit.paletteWhite};
+`,
+```

--- a/packages/eslint-plugin-orbit-components/src/configs/recommended.ts
+++ b/packages/eslint-plugin-orbit-components/src/configs/recommended.ts
@@ -4,6 +4,7 @@ const recommended = {
     "orbit-components/button-has-title": "error",
     "orbit-components/unnecessary-text": "error",
     "orbit-components/prefer-single-destructure": "warn",
+    "orbit-components/custom-colors": "warn",
   },
 };
 

--- a/packages/eslint-plugin-orbit-components/src/index.ts
+++ b/packages/eslint-plugin-orbit-components/src/index.ts
@@ -2,11 +2,13 @@ import buttonHasTitle from "./rules/buttonHasTitle";
 import unnecessaryText from "./rules/unnecessaryText";
 import recommended from "./configs/recommended";
 import preferSingleDestructure from "./rules/preferSingleDestructure";
+import customColors from "./rules/customColors";
 
 export const rules = {
   "button-has-title": buttonHasTitle,
   "unnecessary-text": unnecessaryText,
   "prefer-single-destructure": preferSingleDestructure,
+  "custom-colors": customColors,
 };
 
 export const configs = {

--- a/packages/eslint-plugin-orbit-components/src/rules/customColors.ts
+++ b/packages/eslint-plugin-orbit-components/src/rules/customColors.ts
@@ -1,0 +1,42 @@
+import * as t from "@babel/types";
+import type { Rule } from "eslint";
+
+export default {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Prevents inconsistencies between Orbit and custom written colors",
+      category: "Possible Errors",
+      recommended: true,
+    },
+  },
+
+  create: (context: Rule.RuleContext) => {
+    const allowed = ["background", "background-color", "color"];
+
+    return {
+      TemplateElement(node: t.TemplateElement) {
+        if (node.value.cooked) {
+          const properties = node.value.cooked
+            ?.replace(/\n/gm, "")
+            .trim()
+            .split(";")
+            .map(v => v.trim())
+            .filter(Boolean)
+            .map(p => p.split(":"))
+            .filter(([n]) => allowed.includes(n));
+
+          properties.forEach(p => {
+            if (p[1]) {
+              context.report({
+                // @ts-expect-error TODO
+                node,
+                message: `${p[0]} should be replaced with Orbit design token`,
+              });
+            }
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Added eslint rule to check custom written styles, which should use our tokens. Did not provide individual error message for each property, so feel free to advice if you think it's needed. Currently checks next properties: `box-shadow`, `color`, `background`, `color`, `font-size`, `line-height`, `border-radius`, `z-index`. I think for `left` and `right` we should have separate rule.

 Orbit.kiwi: https://orbit-docs-feat-custom-colors-rule.surge.sh
 Storybook: https://orbit-feat-custom-colors-rule.surge.sh