### PR TITLE
feat(eslint-plugin-orbit): rtl-utils rule

### DIFF
--- a/packages/eslint-plugin-orbit-components/__tests__/rtlUtils.test.ts
+++ b/packages/eslint-plugin-orbit-components/__tests__/rtlUtils.test.ts
@@ -1,0 +1,113 @@
+import ruleTester from "../ruleTester";
+import rtlUtils, { RightOrLeftError, SpacingError } from "../src/rules/rtlUtils";
+
+describe("theme-rtl", () => {
+  ruleTester.run("rtl-utils", rtlUtils, {
+    valid: [
+      {
+        code: `
+          import styled from 'styled-components';
+          import { right } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+            const StyledWrapper = styled.div\`
+              \${right}: 0;
+            \`
+          `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+          import { right } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+            const StyledWrapper = styled.div\`
+              \${({ someCustomProperty }) => someCustomProperty ? "right" : "left"};
+            \`
+          `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+          import { right } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+            const StyledWrapper = styled.div\`
+              margin-\${right}: \${({ theme }) => theme.orbit.spaceSmall};
+            \`
+          `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+          import { right } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+            const StyledWrapper = styled.div\`
+              margin-\${right}: \${({ theme }) => theme.orbit.spaceSmall};
+            \`
+          `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+          import { right } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+            const StyledWrapper = styled.div\`
+              padding: \${({ theme }) => rtlSpacing(\`\${theme.orbit.spaceSmall} 0 \${theme.orbit.spaceSmall}\`)};
+            \`
+          `,
+      },
+    ],
+    invalid: [
+      {
+        code: `
+          import styled from 'styled-components';
+            const DocumentWrapper = styled.div\`
+            width: 100%;
+            position: relative;
+            \${({ theme }) => (theme.rtl ? "right:" : "left:")} 7px;
+            \${mq.desktop(css\`
+              width: 30%;
+              \${({ theme }) => (theme.rtl ? "right:" : "left:")} 0;
+            \`)};
+          \`
+          `,
+        errors: [RightOrLeftError],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+            const StyledWrapper = styled.div\`
+            \${({ theme }) => (theme.rtl ? "margin-right:" : "margin-left:")} 7px;
+          \`
+          `,
+        errors: [RightOrLeftError],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+            const StyledWrapper = styled.div\`
+            \${({ theme }) => (theme.rtl ? "padding-right:" : "padding-left:")} 10px;
+          \`
+          `,
+        errors: [RightOrLeftError],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+            const StyledWrapper = styled.div\`
+              padding: \${({ theme }) => (theme.rtl ? "0 10px 0 0" : \`\${theme.orbit.spaceLarge} 0 0 0\`)};
+          \`
+          `,
+        errors: [SpacingError],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+            const StyledWrapper = styled.div\`
+              padding: \${({ theme }) => theme.rtl ? \`\${theme.orbit.spaceXLarge} 0 0 0px\` : "0 0 10px 0"};
+            \`;
+          `,
+        errors: [SpacingError],
+      },
+    ],
+  });
+});

--- a/packages/eslint-plugin-orbit-components/docs/rules/rtl-utils.md
+++ b/packages/eslint-plugin-orbit-components/docs/rules/rtl-utils.md
@@ -1,0 +1,68 @@
+# rtl-utils
+
+Prevents bad theme.rtl patterns. Users often make the same mistake, they tend to use `theme.rtl` to apply RTL styles like right/left position, margins, paddings. This rule should prevent such cases and enforce usage of our RTL utility functions.
+
+[Orbit RTL utility functions](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/utils/rtl);
+
+## Rule details
+
+The following patterns are considered errors:
+
+```jsx
+import styled from "styled-components";
+
+const DocumentWrapper = styled.div`
+  width: 100%;
+  position: relative;
+  ${({ theme }) => (theme.rtl ? "right:" : "left:")} 7px;
+  ${mq.desktop(css`
+    width: 30%;
+    ${({ theme }) => (theme.rtl ? "right:" : "left:")} 0;
+  `)};
+`;
+```
+
+```jsx
+import styled from "styled-components";
+
+const StyledWrapper = styled.div`
+  ${({ theme }) => (theme.rtl ? "margin-right:" : "margin-left:")} 7px;
+`;
+```
+
+```jsx
+import styled from "styled-components";
+
+const StyledWrapper = styled.div`
+  padding: ${({ theme }) => (theme.rtl ? `0 ${theme.orbit.spaceXLarge}px 0 0` : `0 0 0 ${theme.orbit.spaceXLarge}px)};
+`;
+```
+
+The following patterns are **not** considered errors:
+
+```jsx
+import styled from "styled-components";
+import { right } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+const StyledWrapper = styled.div`
+  ${right}: 0;
+`;
+```
+
+```jsx
+import styled from "styled-components";
+import { right } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+const StyledWrapper = styled.div`
+  margin-${right}: ${({ theme }) => theme.orbit.spaceSmall};
+`;
+```
+
+```jsx
+import styled from "styled-components";
+import { rtlSpacing } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+const StyledWrapper = styled.div`
+  padding: ${({ theme }) => rtlSpacing(`${theme.orbit.spaceSmall} 0 ${theme.orbit.spaceSmall})};
+`;
+```

--- a/packages/eslint-plugin-orbit-components/src/configs/recommended.ts
+++ b/packages/eslint-plugin-orbit-components/src/configs/recommended.ts
@@ -6,6 +6,7 @@ const recommended = {
     "orbit-components/prefer-single-destructure": "warn",
     "orbit-components/custom-colors": "warn",
     "orbit-components/default-theme": "error",
+    "orbit-components/rtl-utils": "error",
   },
 };
 

--- a/packages/eslint-plugin-orbit-components/src/index.ts
+++ b/packages/eslint-plugin-orbit-components/src/index.ts
@@ -4,6 +4,7 @@ import recommended from "./configs/recommended";
 import preferSingleDestructure from "./rules/preferSingleDestructure";
 import customColors from "./rules/customColors";
 import defaultTheme from "./rules/defaultTheme";
+import RtlUtils from "./rules/rtlUtils";
 
 export const rules = {
   "button-has-title": buttonHasTitle,
@@ -11,6 +12,7 @@ export const rules = {
   "prefer-single-destructure": preferSingleDestructure,
   "custom-colors": customColors,
   "default-theme": defaultTheme,
+  "rtl-utils": RtlUtils,
 };
 
 export const configs = {

--- a/packages/eslint-plugin-orbit-components/src/rules/rtlUtils.ts
+++ b/packages/eslint-plugin-orbit-components/src/rules/rtlUtils.ts
@@ -1,0 +1,85 @@
+import * as t from "@babel/types";
+import { Rule } from "eslint";
+
+export const RightOrLeftError =
+  "Do not use theme.rtl as the test value of conditional expression. Consider importing either left or right function from @kiwicom/orbit-components. See more on https://orbit.kiwi/utilities/right-to-left-languages/.";
+
+export const SpacingError =
+  "Do not use theme.rtl as the test value of conditional expression. Consider importing rtlSpacing function from @kiwicom/orbit-components. See more on https://orbit.kiwi/utilities/right-to-left-languages/.";
+
+const rtlUtils: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Prevents bad RTL patterns",
+      category: "Possible Errors",
+      recommended: true,
+    },
+  },
+
+  // @ts-expect-error TODO
+  create: (context: Rule.RuleContext) => {
+    let specifier = "";
+
+    return {
+      ImportDeclaration(node: t.ImportDeclaration) {
+        if (node.source.value === "styled-components") {
+          const def = node.specifiers.filter(s => t.isImportDefaultSpecifier(s));
+          specifier = def[0].local.name;
+        }
+      },
+
+      TaggedTemplateExpression(node: t.TaggedTemplateExpression) {
+        if (t.isMemberExpression(node.tag)) {
+          if (t.isIdentifier(node.tag.object) && node.tag.object.name === specifier) {
+            if (t.isTemplateLiteral(node.quasi)) {
+              node.quasi.expressions.forEach(e => {
+                if (t.isArrowFunctionExpression(e)) {
+                  if (t.isConditionalExpression(e.body)) {
+                    if (t.isMemberExpression(e.body.test) && t.isIdentifier(e.body.test.property)) {
+                      if (e.body.test.property.name === "rtl") {
+                        const { consequent } = e.body;
+                        // if it's literal value of which matches patterns
+                        // @ts-expect-error babel-types
+                        if (t.isLiteral(consequent) && consequent.value) {
+                          const regexWithProp = new RegExp(
+                            /left|right|margin-left|margin-right|padding-left|padding-right/g,
+                          );
+
+                          // @ts-expect-error babel-types
+                          if (consequent.value.match(regexWithProp)) {
+                            context.report({
+                              // @ts-expect-error TODO
+                              node: consequent,
+                              message: RightOrLeftError,
+                            });
+                          } else {
+                            context.report({
+                              // @ts-expect-error TODO
+                              node: consequent,
+                              message: SpacingError,
+                            });
+                          }
+                        }
+
+                        if (t.isTemplateLiteral(consequent)) {
+                          context.report({
+                            // @ts-expect-error TODO
+                            node: consequent,
+                            message: SpacingError,
+                          });
+                        }
+                      }
+                    }
+                  }
+                }
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rtlUtils;


### PR DESCRIPTION
The rule which should help enforce usage of our RTL utility functions and avoid mistakes like `$({theme}) => theme.rtl ? "right: " : "left: "}) 8px`

 Orbit.kiwi: https://orbit-docs-feat-rtl-rule.surge.sh
 Storybook: https://orbit-feat-rtl-rule.surge.sh