### PR TITLE
fix(useIntersect): simplify `ref` type

### DIFF
--- a/packages/orbit-components/src/hooks/useIntersect/__typetests__/index.js
+++ b/packages/orbit-components/src/hooks/useIntersect/__typetests__/index.js
@@ -1,0 +1,14 @@
+// @flow
+import * as React from "react";
+
+import useIntersect from "..";
+
+export default function App() {
+  const { ref, entry } = useIntersect();
+  React.useEffect(() => {
+    if (entry && entry.intersectionRatio > 0) {
+      // do somthing
+    }
+  });
+  return <div ref={ref} />;
+}

--- a/packages/orbit-components/src/hooks/useIntersect/__typetests__/index.tsx
+++ b/packages/orbit-components/src/hooks/useIntersect/__typetests__/index.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+import useIntersect from "..";
+
+export default function App() {
+  const { ref, entry } = useIntersect();
+  React.useEffect(() => {
+    if (entry && entry.intersectionRatio > 0) {
+      // do somthing
+    }
+  });
+  return <div ref={ref} />;
+}

--- a/packages/orbit-components/src/hooks/useIntersect/index.d.ts
+++ b/packages/orbit-components/src/hooks/useIntersect/index.d.ts
@@ -1,7 +1,7 @@
 declare const useIntersect: (
   intersect?: IntersectionObserverInit,
 ) => {
-  ref: React.Dispatch<React.SetStateAction<null | Element>> | null;
+  ref: (el: Element | null) => void;
   entry: IntersectionObserverEntry | null;
 };
 

--- a/packages/orbit-components/src/hooks/useIntersect/index.js
+++ b/packages/orbit-components/src/hooks/useIntersect/index.js
@@ -1,10 +1,15 @@
 // @flow
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 
-export default ({ root = null, rootMargin, threshold = 0 }: IntersectionObserverOptions) => {
+import typeof UseIntersect from ".";
+
+const useIntersect: UseIntersect = ({ root = null, rootMargin, threshold = 0 } = {}) => {
   const [entry, updateEntry] = useState<IntersectionObserverEntry | null>(null);
   const [node, setNode] = useState<Element | null>(null);
 
+  const ref = useCallback((el: Element | null) => {
+    setNode(el);
+  }, []);
   const observer = useRef<null | IntersectionObserver>(null);
 
   useEffect(() => {
@@ -25,5 +30,7 @@ export default ({ root = null, rootMargin, threshold = 0 }: IntersectionObserver
     return () => currentObs?.disconnect();
   }, [node, root, rootMargin, threshold]);
 
-  return { ref: setNode, entry };
+  return { ref, entry };
 };
+
+export default useIntersect;

--- a/packages/orbit-components/src/hooks/useIntersect/index.js
+++ b/packages/orbit-components/src/hooks/useIntersect/index.js
@@ -2,10 +2,6 @@
 import { useState, useEffect, useRef } from "react";
 
 export default ({ root = null, rootMargin, threshold = 0 }: IntersectionObserverOptions) => {
-  if (typeof window === "undefined") {
-    return { ref: null, entry: null };
-  }
-
   const [entry, updateEntry] = useState<IntersectionObserverEntry | null>(null);
   const [node, setNode] = useState<Element | null>(null);
 

--- a/packages/orbit-components/src/hooks/useIntersect/index.js.flow
+++ b/packages/orbit-components/src/hooks/useIntersect/index.js.flow
@@ -1,8 +1,7 @@
 // @flow
-import * as React from "react";
 
 export type useIntersect = (
   intersect?: IntersectionObserverOptions,
-) => {| ref: React.Ref<Element>, entry: IntersectionObserverEntry | null |};
+) => {| ref: (Element | null) => void, entry: IntersectionObserverEntry | null |};
 
 declare export default useIntersect;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7203,7 +7203,7 @@ browserslist@4.10.0:
     node-releases "^1.1.52"
     pkg-up "^3.1.0"
 
-browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.12.2, browserslist@^4.14.5, browserslist@^4.16.1:
+browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.12.2, browserslist@^4.14.5, browserslist@^4.15.0, browserslist@^4.16.1:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.3.tgz#340aa46940d7db878748567c5dea24a48ddf3717"
   integrity sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==
@@ -7635,11 +7635,6 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, can
   version "1.0.30001183"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001183.tgz#7a57ba9d6584119bb5f2bc76d3cc47ba9356b3e2"
   integrity sha512-7JkwTEE1hlRKETbCFd8HDZeLiQIUcl8rC6JgNjvHCNaxOeNmQ9V4LvQXRUsKIV2CC73qKxljwVhToaA3kLRqTw==
-
-caniuse-lite@^1.0.30001165:
-  version "1.0.30001170"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz#0088bfecc6a14694969e391cc29d7eb6362ca6a7"
-  integrity sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA==
 
 capitalize@^2.0.3:
   version "2.0.3"
@@ -10258,11 +10253,6 @@ electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.649:
   version "1.3.653"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.653.tgz#1d98400eba330538a7fe169808c6bf9d83c44450"
   integrity sha512-LehOhcl74u9fkV9Un6WahJ+Xh+0FZLCCDnKYis1Olx1DX2ugRww5PJicE65OG8yznMj8EOQZRcz6FSV1xKxqsA==
-
-electron-to-chromium@^1.3.621:
-  version "1.3.633"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.633.tgz#16dd5aec9de03894e8d14a1db4cda8a369b9b7fe"
-  integrity sha512-bsVCsONiVX1abkWdH7KtpuDAhsQ3N3bjPYhROSAXE78roJKet0Y5wznA14JE9pzbwSZmSMAW6KiKYf1RvbTJkA==
 
 element-resize-detector@^1.2.1:
   version "1.2.1"
@@ -18321,7 +18311,7 @@ node-object-hash@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-2.1.2.tgz#10c79a43640b4659d06be201b27bc4e3d77ae9fc"
   integrity sha512-ltdyKf+VUyPHI/FUWC053xCm0Fs3LfUvsI5eqAmQJ6KZSoXAdTWkm6EWFfeTy5SyJTVptTdPn1X8C4EUwo0T1Q==
 
-node-releases@^1.1.52, node-releases@^1.1.67, node-releases@^1.1.70:
+node-releases@^1.1.52, node-releases@^1.1.70:
   version "1.1.70"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.70.tgz#66e0ed0273aa65666d7fe78febe7634875426a08"
   integrity sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==


### PR DESCRIPTION
The type of `ref` was too broad compared to the actual object. Now it reflects exactly what we're sending, and to confirm that types are working properly we added them to the source code, along with type tests. You can see that I also changed what we're actually sending as `ref` because I don't want people to be able to run `setState(prevState => {})`. Not that something bad could happen, but I want us to provide a specific API, without any unexpected extra stuff.

Also, I removed the SSR check which is seemingly unnecessary (correct me if I'm wrong). `useEffect` doesn't run on the server, so the check seemed overly cautious and it was technically breaking the rule of hooks. (Not sure why ESLint wasn't complaining about it before, though.)

Not sure what Yarn lockfile update was about, but it was there when I ran `yarn install`.

 Orbit.kiwi: https://orbit-docs-fix-use-intersect-type-definition.surge.sh
 Storybook: https://orbit-fix-use-intersect-type-definition.surge.sh