### PR TITLE
fix(CallOutBanner): illustration type

### DIFF
--- a/packages/orbit-components/src/CallOutBanner/index.d.ts
+++ b/packages/orbit-components/src/CallOutBanner/index.d.ts
@@ -13,7 +13,7 @@ export interface Props {
   readonly onClick?: Common.Callback;
   readonly title: Common.Translation;
   readonly description?: Common.Translation;
-  readonly illustration?: React.ElementType<typeof Illustration>;
+  readonly illustration?: React.ReactElement<typeof Illustration>;
   readonly actions?: React.ReactNode;
   readonly children?: React.ReactNode;
 }


### PR DESCRIPTION
There is an error inside tsx file when `CallOutBanner` has `illustration` prop. Noticed during the creation of examples. 

 Orbit.kiwi: https://orbit-docs-fix-calloutbanner-ts-type.surge.sh
 Storybook: https://orbit-fix-calloutbanner-ts-type.surge.sh