### PR TITLE
fix(Slider): add TypeScript declaration for calculateOf util

### DIFF
--- a/packages/orbit-components/src/Slider/index.d.ts
+++ b/packages/orbit-components/src/Slider/index.d.ts
@@ -7,10 +7,10 @@ import * as Common from "../common/common";
 
 declare module "@kiwicom/orbit-components/lib/Slider";
 
-type Label = string | string[];
-type Value = number | number[];
-type Callback = (value: Value) => void | Promise<void>;
-type Data = number[];
+export type Label = string | string[];
+export type Value = number | number[];
+export type Data = number[];
+export type Callback = (value: Value) => void | Promise<void>;
 
 export interface Props extends Common.Global {
   readonly minValue?: number;

--- a/packages/orbit-components/src/Slider/index.js.flow
+++ b/packages/orbit-components/src/Slider/index.js.flow
@@ -2,7 +2,7 @@
 import * as React from "react";
 
 import type { Translation, Globals } from "../common/common.js.flow";
-import type { Data } from "./components/Histogram/index";
+import type { Data } from "./components/Histogram";
 
 export type Value = number | number[];
 

--- a/packages/orbit-components/src/Slider/utils/calculateCountOf.d.ts
+++ b/packages/orbit-components/src/Slider/utils/calculateCountOf.d.ts
@@ -1,0 +1,6 @@
+import { Value, Data } from "..";
+
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+declare const CalculateCountOf: (data: Data, value: Value, min: number) => [number, number];
+
+export default CalculateCountOf;


### PR DESCRIPTION
added declaration export, this util is used inside of one of the examples
 Orbit.kiwi: https://orbit-docs-fix-add-export-for-slider-util.surge.sh
 Storybook: https://orbit-fix-add-export-for-slider-util.surge.sh