### PR TITLE
improve: check only needed environment vars

### DIFF
--- a/docs/utils/warnings.js
+++ b/docs/utils/warnings.js
@@ -7,7 +7,7 @@ const warnMissingAccessToken = error => {
       "Don't forget to include the required scopes for the token: all repo scopes and read:org.",
       "After creating a token in GitHub, add it to a .env file in the root folder with GH_TOKEN=<YOUR TOKEN>",
     );
-  } else {
+  } else if (typeof error.missing === "undefined") {
     console.error(error);
     console.info(
       "You may have forgotten to include the repo and read:org scopes for your GitHub access token.",

--- a/docs/utils/warnings.js
+++ b/docs/utils/warnings.js
@@ -1,4 +1,11 @@
 const warnMissingAccessToken = error => {
+  if (typeof error.missing === "undefined") {
+    console.error(error);
+    console.info(
+      "You may have forgotten to include the repo and read:org scopes for your GitHub access token.",
+    );
+    return;
+  }
   if (error.missing.includes("GH_TOKEN")) {
     console.warn("Missing an access token for GitHub. Please create one.");
     console.info(
@@ -6,11 +13,6 @@ const warnMissingAccessToken = error => {
       "Create a personal access token: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token",
       "Don't forget to include the required scopes for the token: all repo scopes and read:org.",
       "After creating a token in GitHub, add it to a .env file in the root folder with GH_TOKEN=<YOUR TOKEN>",
-    );
-  } else if (typeof error.missing === "undefined") {
-    console.error(error);
-    console.info(
-      "You may have forgotten to include the repo and read:org scopes for your GitHub access token.",
     );
   }
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,11 +10,19 @@ const transform = require("through2").obj;
 const path = require("path");
 const dotenv = require("dotenv-safe");
 
-function configureDotenv(done) {
-  dotenv.config({
-    example: ".env.example",
-  });
-  done();
+function configureGitHubToken(done) {
+  try {
+    dotenv.config({
+      example: ".env.example",
+    });
+    done();
+  } catch (err) {
+    if (err.missing.includes("GH_TOKEN")) {
+      throw new Error(
+        "GitHub token is missing in the .env file, Lerna needs it to create GitHub releases.\nLearn how to create one: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token.",
+      );
+    }
+  }
 }
 
 async function previewChangelog(done) {
@@ -70,5 +78,5 @@ function publishPackages() {
 }
 
 module.exports = {
-  publish: series(configureDotenv, previewChangelog, publishPackages),
+  publish: series(configureGitHubToken, previewChangelog, publishPackages),
 };


### PR DESCRIPTION
Always check only for variables needed for performing that particular task, instead of checking for unnecessarily failing if someone doesn't have a variable needed for a task they never happen to perform.

 Orbit.kiwi: https://orbit-docs-improve-loading-env-variables.surge.sh
 Storybook: https://orbit-improve-loading-env-variables.surge.sh