### PR TITLE
fix(Wizard): remove incorrect React.ReactChildren

### DIFF
--- a/packages/orbit-components/src/Wizard/index.d.ts
+++ b/packages/orbit-components/src/Wizard/index.d.ts
@@ -8,7 +8,7 @@ export interface Props extends Common.Global {
   readonly completedSteps: number;
   readonly activeStep: number;
   readonly onChangeStep?: (stepIndex: number) => void | Promise<any>;
-  readonly children: React.ReactChildren;
+  readonly children: React.ReactNode;
 }
 
 declare const Wizard: React.FunctionComponent<Props>;


### PR DESCRIPTION
Incorrect type. It's not generic and causes an error inside `tsx` file when `Wizard` is used. 

 Orbit.kiwi: https://orbit-docs-fix-wizard-s.surge.sh
 Storybook: https://orbit-fix-wizard-s.surge.sh