### PR TITLE
fix(ci): deploy storybook only, not build

### DIFF
--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -26,7 +26,7 @@
     "watch": "concurrently \"npm run build:lib -- --watch\" \"npm run build:module -- --watch\"",
     "eslint:check": "eslint . --report-unused-disable-directives",
     "fetch-translations": "babel-node config/fetchTranslations.js",
-    "deploy:storybook": "yarn build:storybook && yarn storybook-to-ghpages -e ./.out",
+    "deploy:storybook": "yarn storybook-to-ghpages -e ./.out",
     "deploy:surge": "yarn surge .out/",
     "deploy:updateURL": "yarn babel-node config/deploymentUtils.js updateLiveURL",
     "compile:ts": "yarn tsc"


### PR DESCRIPTION
Currently deploy command both builds and deploys. In the CI, we restore an artifact of the built Storybook, so it shouldn't need to build again.
 Orbit.kiwi: https://orbit-docs-fix-ci-deploy-storybook.surge.sh
 Storybook: https://orbit-fix-ci-deploy-storybook.surge.sh