### PR TITLE
feat(tokens): add specific spacing tokens for components

### DIFF
--- a/packages/orbit-components/src/Tag/index.js
+++ b/packages/orbit-components/src/Tag/index.js
@@ -66,6 +66,9 @@ CloseContainer.defaultProps = {
 export const StyledTag = styled.div`
   ${({ theme, actionable }) => css`
     font-family: ${theme.orbit.fontFamily};
+    /*
+      Don't do this, hard to track.
+    */
     color: ${resolveColor({
       selected: "paletteWhite",
       removable: "paletteBlueDarker",

--- a/packages/orbit-design-tokens/src/dictionary/build.ts
+++ b/packages/orbit-design-tokens/src/dictionary/build.ts
@@ -34,7 +34,7 @@ const build = () => {
   });
   StyleDictionary.registerTransformGroup({
     name: "xml/tokens",
-    transforms: ["attribute/nov", "name/nov/camel"],
+    transforms: ["attribute/nov", "attribute/spacing", "name/nov/camel", "value/xml"],
   });
   StyleDictionary.registerTransformGroup({
     name: "json/documentation-tokens",
@@ -100,7 +100,13 @@ const build = () => {
       "xml/tokens": {
         transformGroup: "xml/tokens",
         buildPath: "lib/",
-        files: [{ destination: "index.xml", format: "xml/tokens", filter: isNotInternal }],
+        files: [
+          {
+            destination: "index.xml",
+            format: "xml/tokens",
+            filter: isNotInternal,
+          },
+        ],
       },
     },
   });

--- a/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/alert-deprecated.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/alert-deprecated.json
@@ -1,0 +1,18 @@
+{
+  "component": {
+    "padding": {
+      "alert": {
+        "type": "size",
+        "value": "{foundation.space.four-x}",
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      },
+      "alert-with-icon": {
+        "type": "size",
+        "value": "{foundation.space.three-x}",
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      }
+    }
+  }
+}

--- a/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/badge-deprecated.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/badge-deprecated.json
@@ -1,0 +1,19 @@
+{
+  "component": {
+    "padding": {
+      "badge": {
+        "type": "size",
+        "category": "spacing",
+        "value": null,
+        "attributes": {
+          "spacing": {
+            "top-bottom": 0,
+            "left-right": "{foundation.space.two-x}"
+          }
+        },
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      }
+    }
+  }
+}

--- a/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/button/button-large-padding.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/button/button-large-padding.json
@@ -1,0 +1,120 @@
+{
+  "component": {
+    "button": {
+      "large": {
+        "padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": 28
+            }
+          }
+        },
+        "both-icons-padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": "{foundation.space.four-x}"
+            }
+          }
+        },
+        "left-icon-padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": 28,
+              "bottom": 0,
+              "left": "{foundation.space.four-x}"
+            }
+          }
+        },
+        "right-icon-padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": "{foundation.space.four-x}",
+              "bottom": 0,
+              "left": 28
+            }
+          }
+        }
+      }
+    },
+    "padding": {
+      "button": {
+        "large": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": 28
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.large.padding}",
+          "deprecated-version": "1.0.0"
+        },
+        "large-with-icons": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": "{foundation.space.four-x}"
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.large.both-icons-padding}",
+          "deprecated-version": "1.0.0"
+        },
+        "large-with-left-icon": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": 28,
+              "bottom": 0,
+              "left": "{foundation.space.four-x}"
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.large.left-icon-padding}",
+          "deprecated-version": "1.0.0"
+        },
+        "large-with-right-icon": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": "{foundation.space.four-x}",
+              "bottom": 0,
+              "left": 28
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.large.right-icon-padding}",
+          "deprecated-version": "1.0.0"
+        }
+      }
+    }
+  }
+}

--- a/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/button/button-normal-padding.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/button/button-normal-padding.json
@@ -1,0 +1,120 @@
+{
+  "component": {
+    "button": {
+      "normal": {
+        "padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": "{foundation.space.four-x}"
+            }
+          }
+        },
+        "both-icons-padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": "{foundation.space.three-x}"
+            }
+          }
+        },
+        "left-icon-padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": "{foundation.space.four-x}",
+              "bottom": 0,
+              "left": "{foundation.space.three-x}"
+            }
+          }
+        },
+        "right-icon-padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": "{foundation.space.three-x}",
+              "bottom": 0,
+              "left": "{foundation.space.four-x}"
+            }
+          }
+        }
+      }
+    },
+    "padding": {
+      "button": {
+        "normal": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": "{foundation.space.four-x}"
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.normal.padding}",
+          "deprecated-version": "1.0.0"
+        },
+        "normal-with-icons": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": "{foundation.space.three-x}"
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.normal.both-icons-padding}",
+          "deprecated-version": "1.0.0"
+        },
+        "normal-with-left-icon": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": "{foundation.space.four-x}",
+              "bottom": 0,
+              "left": "{foundation.space.three-x}"
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.normal.left-icon-padding}",
+          "deprecated-version": "1.0.0"
+        },
+        "normal-with-right-icon": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": "{foundation.space.three-x}",
+              "bottom": 0,
+              "left": "{foundation.space.four-x}"
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.normal.right-icon-padding}",
+          "deprecated-version": "1.0.0"
+        }
+      }
+    }
+  }
+}

--- a/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/button/button-padding.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/button/button-padding.json
@@ -1,0 +1,23 @@
+{
+  "component": {
+    "button": {
+      "without-text": {
+        "padding": {
+          "type": "size",
+          "value": "0"
+        }
+      }
+    },
+    "padding": {
+      "button": {
+        "without-text": {
+          "type": "size",
+          "value": "0",
+          "deprecated": true,
+          "deprecated-replace": "{component.button.without-text.padding}",
+          "deprecated-version": "1.0.0"
+        }
+      }
+    }
+  }
+}

--- a/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/button/button-small-padding.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/button/button-small-padding.json
@@ -1,0 +1,120 @@
+{
+  "component": {
+    "button": {
+      "small": {
+        "padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": "{foundation.space.three-x}"
+            }
+          }
+        },
+        "both-icons-padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": "{foundation.space.two-x}"
+            }
+          }
+        },
+        "left-icon-padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": "{foundation.space.three-x}",
+              "bottom": 0,
+              "left": "{foundation.space.two-x}"
+            }
+          }
+        },
+        "right-icon-padding": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": "{foundation.space.two-x}",
+              "bottom": 0,
+              "left": "{foundation.space.three-x}"
+            }
+          }
+        }
+      }
+    },
+    "padding": {
+      "button": {
+        "small": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": "{foundation.space.three-x}"
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.small.padding}",
+          "deprecated-version": "1.0.0"
+        },
+        "small-with-icons": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top-bottom": 0,
+              "left-right": "{foundation.space.two-x}"
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.small.both-icons-padding}",
+          "deprecated-version": "1.0.0"
+        },
+        "small-with-left-icon": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": "{foundation.space.three-x}",
+              "bottom": 0,
+              "left": "{foundation.space.two-x}"
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.small.left-icon-padding}",
+          "deprecated-version": "1.0.0"
+        },
+        "small-with-right-icon": {
+          "type": "size",
+          "category": "spacing",
+          "value": null,
+          "attributes": {
+            "spacing": {
+              "top": 0,
+              "right": "{foundation.space.two-x}",
+              "bottom": 0,
+              "left": "{foundation.space.three-x}"
+            }
+          },
+          "deprecated": true,
+          "deprecated-replace": "{component.button.small.right-icon-padding}",
+          "deprecated-version": "1.0.0"
+        }
+      }
+    }
+  }
+}

--- a/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/table-deprecated.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/component-specific/table-deprecated.json
@@ -1,0 +1,104 @@
+{
+  "component": {
+    "background": {
+      "table": {
+        "type": "color",
+        "value": "{foundation.palette.white.normal}",
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      },
+      "table-even": {
+        "type": "color",
+        "value": "{foundation.palette.cloud.light}",
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      },
+      "table-hover": {
+        "type": "color",
+        "value": "{foundation.palette.cloud.normal}",
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      },
+      "table-shadow": {
+        "left": {
+          "type": "color",
+          "value": "linear-gradient(to left, transparent, rgba(186, 199, 213, 23))",
+          "internal-comment": "We don't want to maintain and define linear-gradient type and function for it right now, and the tokens is deprecated therefore it's stored as a static value",
+          "deprecated": true,
+          "deprecated-version": "1.0.0"
+        },
+        "right": {
+          "type": "color",
+          "value": "linear-gradient(to right, transparent, rgba(186, 199, 213, 23))",
+          "internal-comment": "We don't want to maintain and define linear-gradient type and function for it right now, and the tokens is deprecated therefore it's stored as a static value",
+          "deprecated": true,
+          "deprecated-version": "1.0.0"
+        }
+      }
+    },
+    "border-color": {
+      "table": {
+        "type": "color",
+        "value": "{foundation.palette.cloud.normal}",
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      },
+      "table-cell": {
+        "type": "color",
+        "value": "{foundation.palette.ink.lighter}",
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      },
+      "table-head": {
+        "type": "color",
+        "value": "{foundation.palette.ink.lighter}",
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      }
+    },
+    "color-text": {
+      "table": {
+        "type": "color",
+        "value": "{foundation.palette.ink.light}",
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      }
+    },
+    "font-weight": {
+      "table-head": {
+        "type": "font-weight",
+        "value": "{foundation.font-weight.bold}",
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      }
+    },
+    "padding": {
+      "table": {
+        "type": "size",
+        "category": "spacing",
+        "value": null,
+        "attributes": {
+          "spacing": {
+            "top-bottom": "{foundation.space.three-x}",
+            "left-right": "{foundation.space.four-x}"
+          }
+        },
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      },
+      "table-compact": {
+        "type": "size",
+        "category": "spacing",
+        "value": null,
+        "attributes": {
+          "spacing": {
+            "top-bottom": "{foundation.space.two-x}",
+            "left-right": "{foundation.space.three-x}"
+          }
+        },
+        "deprecated": true,
+        "deprecated-version": "1.0.0"
+      }
+    }
+  }
+}

--- a/packages/orbit-design-tokens/src/dictionary/formatters/xml-tokens.ts
+++ b/packages/orbit-design-tokens/src/dictionary/formatters/xml-tokens.ts
@@ -1,10 +1,33 @@
 import xml from "xml";
+import _ from "lodash";
 import { Property } from "style-dictionary";
 
+import { isSpacing } from "../utils/is";
+import { flattenSpacing } from "../utils/string";
+
+const getSpacingValue = (name, spacing) => {
+  return flattenSpacing(name, spacing).join(" ");
+};
+
+const getTokenValue = prop => {
+  if (isSpacing(prop)) {
+    const {
+      attributes: { spacing },
+      name,
+    } = prop;
+    return getSpacingValue(name, spacing);
+  }
+  return prop.value;
+};
+
 const xmlFactory = properties => {
-  const designTokens = properties.map(({ value: { value }, name }) => ({
-    token: [{ name }, { value }],
-  }));
+  const designTokens = _.map(properties, prop => {
+    const value = getTokenValue(prop);
+    const { name } = prop;
+    return {
+      token: [{ name }, { value }],
+    };
+  });
   return xml(
     { designTokens },
     {

--- a/packages/orbit-design-tokens/src/dictionary/transforms/values/index.ts
+++ b/packages/orbit-design-tokens/src/dictionary/transforms/values/index.ts
@@ -19,7 +19,6 @@ export const sizeJavascript = {
   type: "value",
   matcher: isSize,
   transformer: ({ value }: Property): Value => {
-    if (value === "auto") return stringify(value);
     return pixelized(value);
   },
 };
@@ -31,6 +30,19 @@ export const durationJavascript = {
   transformer: ({ value }: Property): Value => {
     const normalizedValue = Number(value);
     return stringify(`${normalizedValue / 1000}s`);
+  },
+};
+
+/*
+  Transforms sizes to pixel value for XML platform.
+  The result is without explicit quote marks.
+ */
+export const sizeXML = {
+  name: "value/size/xml",
+  type: "value",
+  matcher: isSize,
+  transformer: ({ value }: Property): Value => {
+    return pixelized(value, false);
   },
 };
 
@@ -61,6 +73,16 @@ export const valueJavascript = {
     if (isDuration(prop)) return durationJavascript.transformer(prop);
     if (isZIndex(prop) || isBreakpoint(prop) || isModifier(prop)) return Number(prop.value);
     return stringify(prop.value);
+  },
+};
+
+export const valueXML = {
+  name: "value/xml",
+  type: "value",
+  matcher: ({ attributes: { aliased } }: Property): boolean => !aliased,
+  transformer: (prop: Property): Value => {
+    if (isSize(prop)) return sizeJavascript.transformer(prop);
+    return prop.value;
   },
 };
 

--- a/packages/orbit-design-tokens/src/dictionary/utils/__tests__/determinate.test.ts
+++ b/packages/orbit-design-tokens/src/dictionary/utils/__tests__/determinate.test.ts
@@ -6,15 +6,15 @@ import {
 
 describe("determinate utils", () => {
   it("determinateUpperFirst should return proper value", () => {
-    expect(determinateUpperFirst("javascript")("test")).toEqual("test");
-    expect(determinateUpperFirst("typescript")("test")).toEqual("Test");
+    expect(determinateUpperFirst("javascript")("test")).toBe("test");
+    expect(determinateUpperFirst("typescript")("test")).toBe("Test");
   });
   it("determinateObjectPropertyAlias should return proper value", () => {
-    expect(determinateObjectPropertyAlias("javascript")("test")).toEqual("test");
-    expect(determinateObjectPropertyAlias("typescript")("test")).toEqual("test:Test");
+    expect(determinateObjectPropertyAlias("javascript")("test")).toBe("test");
+    expect(determinateObjectPropertyAlias("typescript")("test")).toBe("test:Test");
   });
   it("determinateExport should return proper value", () => {
-    expect(determinateExport("javascript")("test")).toEqual(" export default test");
-    expect(determinateExport("typescript")("test")).toEqual("declare export default Test");
+    expect(determinateExport("javascript")("test")).toBe(" export default test");
+    expect(determinateExport("typescript")("test")).toBe("declare export default Test");
   });
 });

--- a/packages/orbit-design-tokens/src/dictionary/utils/__tests__/is.test.ts
+++ b/packages/orbit-design-tokens/src/dictionary/utils/__tests__/is.test.ts
@@ -6,6 +6,9 @@ import {
   isZIndex,
   isBreakpoint,
   isSize,
+  isSpacingWithTwoValues,
+  isSpacingWithThreeValues,
+  isSpacingWithFourValues,
   isBoxShadow,
   isModifier,
   isDuration,
@@ -29,26 +32,24 @@ const tokenPlaceholder = ({ type, internal }) => ({
 
 describe("is utils", () => {
   it("isColor should return expected", () => {
-    expect(isColor(tokenPlaceholder({ type: "color", internal: true }))).toEqual(true);
-    expect(isColor(tokenPlaceholder({ type: "spacing", internal: true }))).toEqual(false);
+    expect(isColor(tokenPlaceholder({ type: "color", internal: true }))).toBe(true);
+    expect(isColor(tokenPlaceholder({ type: "spacing", internal: true }))).toBe(false);
   });
   it("isBorderRadius should return expected", () => {
-    expect(isBorderRadius(tokenPlaceholder({ type: "color", internal: true }))).toEqual(false);
-    expect(isBorderRadius(tokenPlaceholder({ type: "border-radius", internal: true }))).toEqual(
-      true,
-    );
+    expect(isBorderRadius(tokenPlaceholder({ type: "color", internal: true }))).toBe(false);
+    expect(isBorderRadius(tokenPlaceholder({ type: "border-radius", internal: true }))).toBe(true);
   });
   it("isZIndex should return expected", () => {
-    expect(isZIndex(tokenPlaceholder({ type: "color", internal: true }))).toEqual(false);
-    expect(isZIndex(tokenPlaceholder({ type: "z-index", internal: true }))).toEqual(true);
+    expect(isZIndex(tokenPlaceholder({ type: "color", internal: true }))).toBe(false);
+    expect(isZIndex(tokenPlaceholder({ type: "z-index", internal: true }))).toBe(true);
   });
   it("isBreakpoint should return expected", () => {
-    expect(isBreakpoint(tokenPlaceholder({ type: "color", internal: true }))).toEqual(false);
-    expect(isBreakpoint(tokenPlaceholder({ type: "breakpoint", internal: true }))).toEqual(true);
+    expect(isBreakpoint(tokenPlaceholder({ type: "color", internal: true }))).toBe(false);
+    expect(isBreakpoint(tokenPlaceholder({ type: "breakpoint", internal: true }))).toBe(true);
   });
   it("isSize should return expected", () => {
-    expect(isSize(tokenPlaceholder({ type: "color", internal: true }))).toEqual(false);
-    expect(isSize(tokenPlaceholder({ type: "size", internal: true }))).toEqual(true);
+    expect(isSize(tokenPlaceholder({ type: "color", internal: true }))).toBe(false);
+    expect(isSize(tokenPlaceholder({ type: "size", internal: true }))).toBe(true);
   });
   it("isBoxShadow should return expected", () => {
     expect(isBoxShadow(tokenPlaceholder({ type: "color", internal: true }))).toEqual(false);
@@ -63,11 +64,34 @@ describe("is utils", () => {
     expect(isDuration(tokenPlaceholder({ type: "duration", internal: false }))).toEqual(true);
   });
   it("isInternal should return expected", () => {
-    expect(isInternal(tokenPlaceholder({ type: "color", internal: true }))).toEqual(true);
-    expect(isInternal(tokenPlaceholder({ type: "color", internal: false }))).toEqual(false);
+    expect(isInternal(tokenPlaceholder({ type: "color", internal: true }))).toBe(true);
+    expect(isInternal(tokenPlaceholder({ type: "color", internal: false }))).toBe(false);
   });
   it("isNotInternal should return expected", () => {
-    expect(isNotInternal(tokenPlaceholder({ type: "color", internal: true }))).toEqual(false);
-    expect(isNotInternal(tokenPlaceholder({ type: "color", internal: false }))).toEqual(true);
+    expect(isNotInternal(tokenPlaceholder({ type: "color", internal: true }))).toBe(false);
+    expect(isNotInternal(tokenPlaceholder({ type: "color", internal: false }))).toBe(true);
+  });
+  it("isSpacingWithTwoValues should return expected", () => {
+    expect(isSpacingWithTwoValues(["top-bottom", "left-right"])).toBe(true);
+    expect(isSpacingWithTwoValues(["left-right", "top-bottom"])).toBe(true);
+    expect(isSpacingWithTwoValues(["left-right", "bottom-top"])).toBe(false);
+    expect(isSpacingWithTwoValues(["right-left", "top-bottom"])).toBe(false);
+    expect(isSpacingWithTwoValues(["top", "right", "bottom", "left"])).toBe(false);
+    expect(isSpacingWithTwoValues(["top", "left-right", "bottom"])).toBe(false);
+  });
+  it("isSpacingWithThreeValues should return expected", () => {
+    expect(isSpacingWithThreeValues(["top", "left-right", "bottom"])).toBe(true);
+    expect(isSpacingWithThreeValues(["bottom", "left-right", "top"])).toBe(true);
+    expect(isSpacingWithThreeValues(["left-right", "bottom", "top"])).toBe(true);
+    expect(isSpacingWithThreeValues(["left", "bottom", "top"])).toBe(false);
+    expect(isSpacingWithThreeValues(["right", "left", "bottom", "top"])).toBe(false);
+    expect(isSpacingWithThreeValues(["top-bottom", "left-right"])).toBe(false);
+  });
+  it("isSpacingWithFourValues should return expected", () => {
+    expect(isSpacingWithFourValues(["top", "right", "bottom", "left"])).toBe(true);
+    expect(isSpacingWithFourValues(["top", "left", "bottom", "right"])).toBe(true);
+    expect(isSpacingWithFourValues(["bottom", "left", "top", "right"])).toBe(true);
+    expect(isSpacingWithFourValues(["top-bottom", "left-right"])).toBe(false);
+    expect(isSpacingWithFourValues(["top", "left-right", "bottom"])).toBe(false);
   });
 });

--- a/packages/orbit-design-tokens/src/dictionary/utils/__tests__/string.test.ts
+++ b/packages/orbit-design-tokens/src/dictionary/utils/__tests__/string.test.ts
@@ -13,5 +13,8 @@ describe("string utils", () => {
     expect(pixelized("5")).toBe(`"5px"`);
     expect(pixelized(5)).toBe(`"5px"`);
     expect(pixelized(0)).toBe(`"0"`);
+    expect(pixelized("5", false)).toEqual(`5px`);
+    expect(pixelized(5, false)).toEqual(`5px`);
+    expect(pixelized(0, false)).toEqual(`0`);
   });
 });

--- a/packages/orbit-design-tokens/src/dictionary/utils/errorMessage.ts
+++ b/packages/orbit-design-tokens/src/dictionary/utils/errorMessage.ts
@@ -1,5 +1,8 @@
-export const errorValue = (name: string, value: string, type: string, toType: string): string =>
-  `Invalid value: '${name}: ${value}' is not a valid value for '${type}', cannot transform to '${toType}' \n`;
+export const spacingError = (name: string): string =>
+  `Unexpected value of spacing token ${name}. Please specify attributes.spacing object for the token.`;
+
+export const spacingErrorDefinition = (name: string): string =>
+  `Unexpected value of spacing token ${name}. Supported properties of the spacing object are { top, right, bottom, left }, { top, left-right, bottom } or { top-bottom, left-right}.`;
 
 export const errorTransform = (transform: string, neededTransform: string): string =>
   `Can't use transform '${transform}', because transform '${neededTransform}' is not being used. Add it into the transformGroup settings. \n`;

--- a/packages/orbit-design-tokens/src/dictionary/utils/is.ts
+++ b/packages/orbit-design-tokens/src/dictionary/utils/is.ts
@@ -1,6 +1,6 @@
 import { Property } from "style-dictionary";
 
-const isTypeOf = ({ type, attributes: { category } }: Property, typeName: string): boolean =>
+const isTypeOf = ({ type, category }: Property, typeName: string): boolean =>
   typeName === type || typeName === category;
 
 export const isColor = (prop: Property): boolean => isTypeOf(prop, "color");
@@ -17,6 +17,8 @@ export const isBoxShadow = (prop: Property): boolean => isTypeOf(prop, "box-shad
 
 export const isModifier = (prop: Property): boolean => isTypeOf(prop, "modifier");
 
+export const isSpacing = (prop: Property): boolean => isTypeOf(prop, "spacing");
+
 export const isDuration = (prop: Property): boolean => isTypeOf(prop, "duration");
 
 export const isInternal = ({ internal }: Property): boolean => !!internal;
@@ -24,3 +26,25 @@ export const isInternal = ({ internal }: Property): boolean => !!internal;
 export const isNotInternal = (token: Property): boolean => !isInternal(token);
 
 export const isDeprecated = ({ deprecated }: Property): boolean => deprecated != null;
+
+const getSpacingArray = spaceArray => {
+  const array = spaceArray.sort();
+  return [array, array.length];
+};
+
+export const isSpacingWithTwoValues = (spaceArray: Array<string>): boolean => {
+  const [[first, second], length] = getSpacingArray(spaceArray);
+  return length === 2 && first === "left-right" && second === "top-bottom";
+};
+
+export const isSpacingWithThreeValues = (spaceArray: Array<string>): boolean => {
+  const [[first, second, third], length] = getSpacingArray(spaceArray);
+  return length === 3 && first === "bottom" && second === "left-right" && third === "top";
+};
+
+export const isSpacingWithFourValues = (spaceArray: Array<string>): boolean => {
+  const [[first, second, third, fourth], length] = getSpacingArray(spaceArray);
+  return (
+    length === 4 && first === "bottom" && second === "left" && third === "right" && fourth === "top"
+  );
+};

--- a/packages/orbit-design-tokens/src/dictionary/utils/string.ts
+++ b/packages/orbit-design-tokens/src/dictionary/utils/string.ts
@@ -11,18 +11,19 @@ export const falsyString = (condition: boolean, string: string): string | undefi
 
 export const stringify = (value: string | number): string => `"${value}"`;
 
+const addStringified = (condition: boolean, value: string) =>
+  condition ? stringify(value) : value;
 /*
   Converts a string or number into string with pixels.
   The `${value}px` is applied only for value of type number, e.g. 24.
   Cases like "auto", "0" are being skipped because it's either redundant to specify the pixels, or unwanted.
   Second parameter is required boolean if it's needed to attach additional double quotes or not.
  */
-const isStringified = (condition: boolean, value: string) => (condition ? stringify(value) : value);
 export const pixelized = (value: string | number, stringified = true): string => {
   if (/^[0-9]*$/g.test(String(value)) && String(value) !== "0") {
-    return isStringified(stringified, `${value}px`);
+    return addStringified(stringified, `${value}px`);
   }
-  return isStringified(stringified, String(value));
+  return addStringified(stringified, String(value));
 };
 
 /*

--- a/packages/orbit-design-tokens/src/dictionary/utils/string.ts
+++ b/packages/orbit-design-tokens/src/dictionary/utils/string.ts
@@ -1,3 +1,8 @@
+import { Property, Value } from "style-dictionary";
+
+import { getValue } from "./get";
+import { isSpacingWithFourValues, isSpacingWithThreeValues, isSpacingWithTwoValues } from "./is";
+
 /*
   Returns string if condition is met.
  */
@@ -6,7 +11,41 @@ export const falsyString = (condition: boolean, string: string): string | undefi
 
 export const stringify = (value: string | number): string => `"${value}"`;
 
-export const pixelized = (value: string | number): string => {
-  if (value === 0) return stringify(value);
-  return stringify(`${value}px`);
+/*
+  Converts a string or number into string with pixels.
+  The `${value}px` is applied only for value of type number, e.g. 24.
+  Cases like "auto", "0" are being skipped because it's either redundant to specify the pixels, or unwanted.
+  Second parameter is required boolean if it's needed to attach additional double quotes or not.
+ */
+const isStringified = (condition: boolean, value: string) => (condition ? stringify(value) : value);
+export const pixelized = (value: string | number, stringified = true): string => {
+  if (/^[0-9]*$/g.test(String(value)) && String(value) !== "0") {
+    return isStringified(stringified, `${value}px`);
+  }
+  return isStringified(stringified, String(value));
+};
+
+/*
+  Function to flatten a spacing object.
+  If it doesn't match any of supporting formats it will die on an Error.
+ */
+export const flattenSpacing = (
+  name: string,
+  spacing: { [key: string]: Property },
+): Array<Value> => {
+  const spaceArr = Object.keys(spacing).sort();
+  const spacingValues = spaceArr.map(k => getValue(spacing[k]));
+  if (isSpacingWithTwoValues(spaceArr)) {
+    const [leftRight, topBottom] = spacingValues;
+    return [topBottom, leftRight];
+  }
+  if (isSpacingWithThreeValues(spaceArr)) {
+    const [bottom, leftRight, top] = spacingValues;
+    return [top, leftRight, bottom];
+  }
+  if (isSpacingWithFourValues(spaceArr)) {
+    const [bottom, left, right, top] = spacingValues;
+    return [top, right, bottom, left];
+  }
+  throw new Error(`Unexpected value of spacing token ${name}. Please double check its definition.`);
 };

--- a/packages/orbit-design-tokens/src/js/__tests__/transparentColor.test.ts
+++ b/packages/orbit-design-tokens/src/js/__tests__/transparentColor.test.ts
@@ -5,10 +5,10 @@ const testColor = (R: number, G: number, B: number, A?: number) =>
 
 describe("transparentColor", () => {
   it("should transparentize properly", () => {
-    expect(transparentColor("white", 50)).toEqual(testColor(255, 255, 255, 0.5));
-    expect(transparentColor("#00A991", 20)).toEqual(testColor(0, 169, 145, 0.2));
-    expect(transparentColor("#00A991", 99)).toEqual(testColor(0, 169, 145, 0.99));
-    expect(transparentColor(testColor(0, 169, 145, 0.99), 10)).toEqual(testColor(0, 169, 145, 0.1));
-    expect(transparentColor(testColor(0, 169, 145), 10)).toEqual(testColor(0, 169, 145, 0.1));
+    expect(transparentColor("white", 50)).toBe(testColor(255, 255, 255, 0.5));
+    expect(transparentColor("#00A991", 20)).toBe(testColor(0, 169, 145, 0.2));
+    expect(transparentColor("#00A991", 99)).toBe(testColor(0, 169, 145, 0.99));
+    expect(transparentColor(testColor(0, 169, 145, 0.99), 10)).toBe(testColor(0, 169, 145, 0.1));
+    expect(transparentColor(testColor(0, 169, 145), 10)).toBe(testColor(0, 169, 145, 0.1));
   });
 });


### PR DESCRIPTION
Added first batch of spacing tokens – mostly for Button and Alert.
The spacing have to be defined separately from the value attribute. It gets compiled/flatten in the formatters directly.