### PR TITLE
feat(eslint-plugin-orbit): useRtl rule

### DIFF
--- a/packages/eslint-plugin-orbit-components/__tests__/rtlUtils.test.ts
+++ b/packages/eslint-plugin-orbit-components/__tests__/rtlUtils.test.ts
@@ -1,7 +1,7 @@
 import ruleTester from "../ruleTester";
 import rtlUtils, { RightOrLeftError, SpacingError } from "../src/rules/rtlUtils";
 
-describe("theme-rtl", () => {
+describe("rtl-utils", () => {
   ruleTester.run("rtl-utils", rtlUtils, {
     valid: [
       {

--- a/packages/eslint-plugin-orbit-components/__tests__/useRtl.test.ts
+++ b/packages/eslint-plugin-orbit-components/__tests__/useRtl.test.ts
@@ -1,0 +1,188 @@
+import ruleTester from "../ruleTester";
+import useRtl, { ERROR_RTL_SPACING, ERROR_BORDER_RADIUS, errorBasic } from "../src/rules/useRtl";
+
+describe("use-rtl", () => {
+  ruleTester.run("use-rtl", useRtl, {
+    valid: [
+      {
+        code: `
+          import styled from 'styled-components';
+          import { right } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+          const StyledWrapper = styled.div\`
+              \${right}: 0;
+            \`
+          `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+          import { left } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+          const StyledWrapper = styled.div\`
+              margin-\${left}: 0;
+            \`
+          `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+          import { left } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+          const StyledWrapper = styled.div\`
+              margin-\${left}: 0;
+            \`
+          `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+              margin: 10px 15px 0 15px;
+            \`
+          `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+              margin: 10px 15px 3px;
+            \`
+          `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+              border-radius: 3px 3px 5px 5px;
+            \`
+          `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+          import { borderRadius } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+          const StyledWrapper = styled.div\`
+              border-radius: \${borderRadius("3px 3px 5px 5px")};
+            \`
+          `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+          import { textAlign } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+          const StyledWrapper = styled.div\`
+            text-align: \${textAlign("left")};
+          \`
+        `,
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+          import { translate3d } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+          const StyledWrapper = styled.div\`
+            transform: \${translate3d("400px, 0, 0")};
+          \`
+        `,
+      },
+    ],
+    invalid: [
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+              margin: 10px 15px 0 10px;
+            \`
+          `,
+        errors: [ERROR_RTL_SPACING],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+              margin: 10px 15px 0 10px;
+            \`
+          `,
+        errors: [ERROR_RTL_SPACING],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+            padding: 0 15px 3px 5px;
+          \`
+        `,
+        errors: [ERROR_RTL_SPACING],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+            border-radius: 3px 5px 4px 5px;
+          \`
+        `,
+        errors: [ERROR_BORDER_RADIUS],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+            border-radius: 3px 3px 4px 5px;
+          \`
+        `,
+        errors: [ERROR_BORDER_RADIUS],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+            text-align: left;
+          \`
+        `,
+        errors: [errorBasic("text-align", "left")],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+            right: 0;
+          \`
+        `,
+        errors: [errorBasic("right", "0")],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+            left: 0;
+          \`
+        `,
+        errors: [errorBasic("left", "0")],
+      },
+      {
+        code: `
+          import styled from 'styled-components';
+
+          const StyledWrapper = styled.div\`
+            transform: translate3d("400px, 0, 0");
+          \`
+        `,
+        errors: [errorBasic("transform", 'translate3d("400px, 0, 0")')],
+      },
+    ],
+  });
+});

--- a/packages/eslint-plugin-orbit-components/docs/rules/use-rtl.md
+++ b/packages/eslint-plugin-orbit-components/docs/rules/use-rtl.md
@@ -1,0 +1,96 @@
+# use-rtl
+
+This rule aim is to prevent RTL mistakes. User can forget about RTL and use only static values, this rule should help to avoid that.
+
+[Orbit RTL utility functions](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/utils/rtl);
+
+## Rule details
+
+The following patterns are considered errors:
+
+```jsx
+import styled from "styled-components";
+
+const StyledWrapper = styled.div`
+  margin-right: 15px;
+`;
+```
+
+```jsx
+import styled from "styled-components";
+
+const StyledWrapper = styled.div`
+  right: 0;
+`;
+```
+
+```jsx
+import styled from "styled-components";
+
+const StyledWrapper = styled.div`
+  border-radius: 3px 5px 4px 5px;
+`;
+```
+
+```jsx
+import styled from "styled-components";
+
+const StyledWrapper = styled.div`
+  text-align: left;
+`;
+```
+
+```jsx
+import styled from "styled-components";
+
+const StyledWrapper = styled.div`
+  transform: translate3d("400px, 0, 0");
+`;
+```
+
+The following patterns are **not** considered errors:
+
+```jsx
+import styled from "styled-components";
+import { right } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+const StyledWrapper = styled.div`
+  ${right}: 0;
+`;
+```
+
+```jsx
+import styled from "styled-components";
+import { right } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+const StyledWrapper = styled.div`
+  margin-${right}: 15px;
+`;
+```
+
+```jsx
+import styled from "styled-components";
+import { textAlign } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+const StyledWrapper = styled.div`
+  text-align: ${textAlign("left")};
+`;
+```
+
+```jsx
+import styled from "styled-components";
+import { borderRadius } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+const StyledWrapper = styled.div`
+  border-radius: ${borderRadius("3px 5px 6px 4px")};
+`;
+```
+
+```jsx
+import styled from "styled-components";
+import { translate3d } from "@kiwicom/orbit-components/lib/utils/rtl";
+
+const StyledWrapper = styled.div`
+  transform: ${translate3d("400px, 0, 0")};
+`;
+```

--- a/packages/eslint-plugin-orbit-components/src/configs/recommended.ts
+++ b/packages/eslint-plugin-orbit-components/src/configs/recommended.ts
@@ -8,6 +8,7 @@ const recommended = {
     "orbit-components/prefer-single-destructure": "warn",
     "orbit-components/rtl-utils": "error",
     "orbit-components/unnecessary-text": "error",
+    "orbit-components/use-rtl": "error",
   },
 };
 

--- a/packages/eslint-plugin-orbit-components/src/index.ts
+++ b/packages/eslint-plugin-orbit-components/src/index.ts
@@ -1,11 +1,12 @@
 import buttonHasTitle from "./rules/buttonHasTitle";
 import defaultTheme from "./rules/defaultTheme";
+import rtlUtils from "./rules/rtlUtils";
+import useRtl from "./rules/useRtl";
 import internal from "./configs/internal";
 import noCustomColors from "./rules/noCustomColors";
 import noCustomTypography from "./rules/noCustomTypography";
 import preferSingleDestructure from "./rules/preferSingleDestructure";
 import recommended from "./configs/recommended";
-import rtlUtils from "./rules/rtlUtils";
 import uniqueId from "./rules/uniqueId";
 import unnecessaryText from "./rules/unnecessaryText";
 
@@ -18,6 +19,7 @@ export const rules = {
   "rtl-utils": rtlUtils,
   "unique-id": uniqueId,
   "unnecessary-text": unnecessaryText,
+  "use-rtl": useRtl,
 };
 
 export const configs = {

--- a/packages/eslint-plugin-orbit-components/src/rules/useRtl.ts
+++ b/packages/eslint-plugin-orbit-components/src/rules/useRtl.ts
@@ -1,0 +1,126 @@
+import * as t from "@babel/types";
+import { Rule } from "eslint";
+
+export const ERROR_RTL_SPACING =
+  "Values for right and left edges are different. Use Orbit's rtlSpacing utility.";
+
+export const ERROR_BORDER_RADIUS =
+  "border-radius edge values are different. Use borderRadius utility.";
+
+export const errorBasic = (prop, value) =>
+  `Values for ${prop} and ${value} edges are different. Use Orbit's rtlSpacing utility. https://orbit.kiwi/utilities/right-to-left-languages/#rtlspacing`;
+
+const parseVals = str =>
+  str
+    .trim()
+    .split(" ")
+    .map(v => parseInt(v, 10));
+
+const rtlSpacingCheck = (str: string): boolean | void => {
+  const arr = parseVals(str);
+  // for instance: margin: 0 10px 20px 15px;
+  if (arr.length === 4) {
+    const vals = arr.filter((_, i) => i === 1 || i === 3);
+    return vals[0] !== vals[1];
+  }
+
+  return undefined;
+};
+
+const borderRadiusCheck = (str: string) => {
+  const arr = parseVals(str);
+
+  if (arr.length === 4) {
+    const isTopEqual = arr[0] === arr[1];
+    const isBottomEqual = arr[2] === arr[3];
+
+    // border-radius: 3px 3px 5px 5px;
+    if (isTopEqual && isBottomEqual) return undefined;
+    // border-radius: 3px 5px 5px 5px or 3px 3px 5px 6px;
+    if (!isTopEqual || !isBottomEqual) return true;
+
+    return true;
+  }
+
+  return undefined;
+};
+
+const useRtl: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Checks if the static literal values require RTL function",
+      category: "Possible Errors",
+      recommended: true,
+    },
+  },
+
+  // @ts-expect-error TODO
+  create: (context: Rule.RuleContext) => {
+    const basic = [
+      "right",
+      "left",
+      "text-align",
+      "padding-left",
+      "padding-right",
+      "margin-left",
+      "margin-right",
+    ];
+    const allowed = basic.concat(["padding", "margin", "border-radius", "transform"]);
+
+    return {
+      TemplateElement(node: t.TemplateElement) {
+        if (node.value.cooked) {
+          const properties = node.value.cooked
+            ?.replace(/\n/gm, "")
+            .trim()
+            .split(";")
+            .map(v => v.trim())
+            .filter(Boolean)
+            .map(p => p.split(":"))
+            .filter(([n]) => allowed.includes(n));
+
+          properties.forEach(([prop, value]) => {
+            if (prop === "margin" || prop === "padding") {
+              if (rtlSpacingCheck(value)) {
+                context.report({
+                  // @ts-expect-error todo
+                  node,
+                  message: ERROR_RTL_SPACING,
+                });
+              }
+            }
+
+            if (prop === "border-radius") {
+              if (borderRadiusCheck(value)) {
+                context.report({
+                  // @ts-expect-error todo
+                  node,
+                  message: ERROR_BORDER_RADIUS,
+                });
+              }
+            }
+
+            if (prop === "transform" && value.match(/translate3d/)) {
+              context.report({
+                // @ts-expect-error todo
+                node,
+                message: errorBasic(prop, value.trim()),
+              });
+            }
+
+            if (basic.includes(prop) && value) {
+              context.report({
+                // @ts-expect-error todo
+                node,
+                message: errorBasic(prop, value.trim()),
+              });
+            }
+          });
+        }
+      },
+    };
+  },
+};
+
+export default useRtl;

--- a/packages/orbit-components/src/utils/rtl/README.md
+++ b/packages/orbit-components/src/utils/rtl/README.md
@@ -135,7 +135,7 @@ Function `translate3d` switches the values for `transform` property.
 ```jsx
 import { translate3d } from "@kiwicom/orbit-components/lib/utils/rtl";
 
-const Compomnent = styled.div`
+const Component = styled.div`
   transform: ${translate3d("400px, 0, 0")};
 `;
 ```


### PR DESCRIPTION
As we discussed before. Create a separate rule for RTL literal values. 

 Orbit.kiwi: https://orbit-docs-feat-use-rtl.surge.sh
 Storybook: https://orbit-feat-use-rtl.surge.sh