### PR TITLE
feat(tokens): add global duration tokens

### DIFF
--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/duration.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/duration.json
@@ -1,0 +1,18 @@
+{
+  "global": {
+    "duration": {
+      "fast": {
+        "type": "duration",
+        "value": 150
+      },
+      "normal": {
+        "type": "duration",
+        "value": 300
+      },
+      "slow": {
+        "type": "duration",
+        "value": 400
+      }
+    }
+  }
+}

--- a/packages/orbit-design-tokens/src/dictionary/transforms/values/index.ts
+++ b/packages/orbit-design-tokens/src/dictionary/transforms/values/index.ts
@@ -1,6 +1,13 @@
 import { Property, Value } from "style-dictionary";
 
-import { isBorderRadius, isSize, isZIndex, isBreakpoint, isModifier } from "../../utils/is";
+import {
+  isBorderRadius,
+  isSize,
+  isZIndex,
+  isBreakpoint,
+  isModifier,
+  isDuration,
+} from "../../utils/is";
 import { errorTransform } from "../../utils/errorMessage";
 import { stringify, pixelized } from "../../utils/string";
 
@@ -14,6 +21,16 @@ export const sizeJavascript = {
   transformer: ({ value }: Property): Value => {
     if (value === "auto") return stringify(value);
     return pixelized(value);
+  },
+};
+
+export const durationJavascript = {
+  name: "value/duration/javascript",
+  type: "value",
+  matcher: isDuration,
+  transformer: ({ value }: Property): Value => {
+    const normalizedValue = Number(value);
+    return stringify(`${normalizedValue / 1000}s`);
   },
 };
 
@@ -41,6 +58,7 @@ export const valueJavascript = {
   transformer: (prop: Property): Value => {
     if (isSize(prop)) return sizeJavascript.transformer(prop);
     if (isBorderRadius(prop)) return borderRadiusJavascript.transformer(prop);
+    if (isDuration(prop)) return durationJavascript.transformer(prop);
     if (isZIndex(prop) || isBreakpoint(prop) || isModifier(prop)) return Number(prop.value);
     return stringify(prop.value);
   },

--- a/packages/orbit-design-tokens/src/dictionary/utils/__tests__/is.test.ts
+++ b/packages/orbit-design-tokens/src/dictionary/utils/__tests__/is.test.ts
@@ -7,7 +7,8 @@ import {
   isBreakpoint,
   isSize,
   isBoxShadow,
-  isModifier, isDuration,
+  isModifier,
+  isDuration,
 } from "../is";
 
 const tokenPlaceholder = ({ type, internal }) => ({

--- a/packages/orbit-design-tokens/src/dictionary/utils/__tests__/is.test.ts
+++ b/packages/orbit-design-tokens/src/dictionary/utils/__tests__/is.test.ts
@@ -7,7 +7,7 @@ import {
   isBreakpoint,
   isSize,
   isBoxShadow,
-  isModifier,
+  isModifier, isDuration,
 } from "../is";
 
 const tokenPlaceholder = ({ type, internal }) => ({
@@ -56,6 +56,10 @@ describe("is utils", () => {
   it("isModifier should return expected", () => {
     expect(isModifier(tokenPlaceholder({ type: "box-shadow", internal: true }))).toEqual(false);
     expect(isModifier(tokenPlaceholder({ type: "modifier", internal: true }))).toEqual(true);
+  });
+  it("isDuration should return expected", () => {
+    expect(isDuration(tokenPlaceholder({ type: "color", internal: true }))).toEqual(false);
+    expect(isDuration(tokenPlaceholder({ type: "duration", internal: false }))).toEqual(true);
   });
   it("isInternal should return expected", () => {
     expect(isInternal(tokenPlaceholder({ type: "color", internal: true }))).toEqual(true);

--- a/packages/orbit-design-tokens/src/dictionary/utils/is.ts
+++ b/packages/orbit-design-tokens/src/dictionary/utils/is.ts
@@ -17,6 +17,8 @@ export const isBoxShadow = (prop: Property): boolean => isTypeOf(prop, "box-shad
 
 export const isModifier = (prop: Property): boolean => isTypeOf(prop, "modifier");
 
+export const isDuration = (prop: Property): boolean => isTypeOf(prop, "duration");
+
 export const isInternal = ({ internal }: Property): boolean => !!internal;
 
 export const isNotInternal = (token: Property): boolean => !isInternal(token);


### PR DESCRIPTION
Added global tokens for duration – the same naming and values as in old version. The only difference that it won't be a part of foundation.