### PR TITLE
docs: fix breadcrumb links

### DIFF
--- a/docs/src/components/Breadcrumbs.tsx
+++ b/docs/src/components/Breadcrumbs.tsx
@@ -27,7 +27,7 @@ interface Props {
 const Breadcrumbs = ({ location }: Props) => {
   const createLink = (name: string, url: string) => ({
     name: name.replace(/-/g, " "),
-    url: url.split(",").join("/"),
+    url: `${url.split(",").join("/")}/`,
   });
 
   const { pathname } = location;


### PR DESCRIPTION
Links without slash break tab design, at least in development.

 Orbit.kiwi: https://orbit-docs-docs-fix-breadcrumbs-path.surge.sh
 Storybook: https://orbit-docs-fix-breadcrumbs-path.surge.sh