### PR TITLE
fix(ButtonPrimitive): remove redundant size property

### DIFF
--- a/packages/orbit-components/src/Button/index.d.ts
+++ b/packages/orbit-components/src/Button/index.d.ts
@@ -3,7 +3,7 @@
 
 import * as React from "react";
 
-import { ButtonCommonProps } from "../primitives/ButtonPrimitive/index";
+import { ButtonCommonProps, Size } from "../primitives/ButtonPrimitive/index";
 
 declare module "@kiwicom/orbit-components/lib/Button";
 
@@ -11,6 +11,7 @@ type Type = "primary" | "secondary" | "critical" | "primarySubtle" | "criticalSu
 
 export interface Props extends ButtonCommonProps {
   readonly type?: Type;
+  readonly size?: Size;
 }
 
 declare const Button: React.FunctionComponent<Props>;

--- a/packages/orbit-components/src/Button/index.js
+++ b/packages/orbit-components/src/Button/index.js
@@ -14,7 +14,7 @@ import type { Props } from "./index";
 const Button: React.AbstractComponent<Props, HTMLButtonElement> = React.forwardRef<
   Props,
   HTMLButtonElement,
->(({ type = TYPE_OPTIONS.PRIMARY, disabled = false, ...props }, ref) => {
+>(({ type = TYPE_OPTIONS.PRIMARY, size, disabled = false, ...props }, ref) => {
   const theme = useTheme();
   const propsWithTheme = { theme, ...props };
   const commonProps = getCommonProps(propsWithTheme);

--- a/packages/orbit-components/src/Button/index.js.flow
+++ b/packages/orbit-components/src/Button/index.js.flow
@@ -4,7 +4,7 @@
 */
 import * as React from "react";
 
-import type { ButtonCommonProps } from "../primitives/ButtonPrimitive";
+import type { ButtonCommonProps, Size } from "../primitives/ButtonPrimitive";
 
 export type Type =
   | "primary"
@@ -16,6 +16,7 @@ export type Type =
 
 export type Props = {|
   +type?: Type,
+  +size?: Size,
   ...ButtonCommonProps,
 |};
 

--- a/packages/orbit-components/src/ButtonLink/index.d.ts
+++ b/packages/orbit-components/src/ButtonLink/index.d.ts
@@ -4,7 +4,7 @@
 import * as React from "react";
 
 import * as Common from "../common/common";
-import { ButtonCommonProps } from "../primitives/ButtonPrimitive/index";
+import { ButtonCommonProps, Size } from "../primitives/ButtonPrimitive/index";
 
 declare module "@kiwicom/orbit-components/lib/ButtonLink";
 
@@ -13,6 +13,7 @@ type Type = "primary" | "secondary" | "critical";
 export interface Props extends Common.Global, Common.Ref, Common.SpaceAfter, ButtonCommonProps {
   readonly compact?: boolean;
   readonly type?: Type;
+  readonly size?: Size;
 }
 
 declare const ButtonLink: React.FunctionComponent<Props>;

--- a/packages/orbit-components/src/ButtonLink/index.js
+++ b/packages/orbit-components/src/ButtonLink/index.js
@@ -14,7 +14,7 @@ import type { Props } from "./index";
 const ButtonLink: React.AbstractComponent<Props, HTMLButtonElement> = React.forwardRef<
   Props,
   HTMLButtonElement,
->(({ type = TYPES.PRIMARY, compact = false, ...props }, ref) => {
+>(({ type = TYPES.PRIMARY, size, compact = false, ...props }, ref) => {
   const theme = useTheme();
   const propsWithTheme = { theme, ...props };
   const commonProps = getButtonLinkCommonProps({ ...propsWithTheme, compact });

--- a/packages/orbit-components/src/ButtonLink/index.js.flow
+++ b/packages/orbit-components/src/ButtonLink/index.js.flow
@@ -4,13 +4,14 @@
 */
 import * as React from "react";
 
-import type { ButtonCommonProps } from "../primitives/ButtonPrimitive";
+import type { ButtonCommonProps, Size } from "../primitives/ButtonPrimitive";
 
 export type Type = "primary" | "secondary" | "critical";
 
 export type Props = {|
   +compact?: boolean,
   +type?: Type,
+  +size?: Size,
   ...ButtonCommonProps,
 |};
 

--- a/packages/orbit-components/src/SocialButton/index.d.ts
+++ b/packages/orbit-components/src/SocialButton/index.d.ts
@@ -3,7 +3,7 @@
 
 import * as React from "react";
 
-import { ButtonCommonProps } from "../primitives/ButtonPrimitive/index";
+import { ButtonCommonProps, Size } from "../primitives/ButtonPrimitive/index";
 
 declare module "@kiwicom/orbit-components/lib/Button";
 
@@ -11,8 +11,9 @@ export type Type = "apple" | "facebook" | "google" | "twitter";
 
 type OmittedButtonCommonProps = Omit<ButtonCommonProps, "iconLeft" | "iconRight" | "circled">;
 
-type Props = {
+export type Props = {
   readonly type?: Type;
+  readonly size?: Size;
 } & OmittedButtonCommonProps;
 
 declare const SocialButton: React.RefForwardingComponent<HTMLButtonElement, Props>;

--- a/packages/orbit-components/src/SocialButton/index.js
+++ b/packages/orbit-components/src/SocialButton/index.js
@@ -15,7 +15,7 @@ import type { Props } from "./index";
 const SocialButton: React.AbstractComponent<Props, HTMLButtonElement> = React.forwardRef<
   Props,
   HTMLButtonElement,
->(({ type = TYPE_OPTIONS.APPLE, disabled = false, ...props }, ref) => {
+>(({ type = TYPE_OPTIONS.APPLE, disabled = false, size, ...props }, ref) => {
   const theme = useTheme();
   const propsWithTheme = { theme, ...props };
   const commonProps = getCommonProps(propsWithTheme);

--- a/packages/orbit-components/src/SocialButton/index.js.flow
+++ b/packages/orbit-components/src/SocialButton/index.js.flow
@@ -4,12 +4,13 @@
 */
 import * as React from "react";
 
-import type { ButtonCommonProps } from "../primitives/ButtonPrimitive";
+import type { ButtonCommonProps, Size } from "../primitives/ButtonPrimitive";
 
 export type Type = "apple" | "facebook" | "google" | "twitter";
 
 export type Props = {|
   +type?: Type,
+  +size?: Size,
   ...$Diff<
     ButtonCommonProps,
     {| +iconLeft?: React.Node, +iconRight?: React.Node, +circled?: boolean |},

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/README.md
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/README.md
@@ -54,20 +54,11 @@ Table below contains all types of the props available in ButtonPrimitive compone
 | padding          | `string`                   |            | The inner padding of the ButtonPrimitive.                                                                                                                      |
 | rel              | `string`                   |            | Specifies the rel of an element. [See Functional specs](#functional-specs)                                                                                     |
 | role             | `string`                   |            | Specifies the role of an element.                                                                                                                              |
-| size             | [`enum`](#enum)            | `"normal"` | The size of the ButtonPrimitive.                                                                                                                               |
 | spaceAfter       | `enum`                     |            | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
 | submit           | `boolean`                  | `false`    | If `true`, the ButtonPrimitive will have `type="submit"` attribute, otherwise `type="button"`.                                                                 |
 | title            | `string`                   |            | Adds `aria-label`.                                                                                                                                             |
 | tabIndex         | `string \| number`         | `"0"`      | Specifies the tab order of an element.                                                                                                                         |
 | width            | `string`                   |            | The width of the ButtonPrimitive. Can be any string - `100px`, `20%`.                                                                                          |
-
-### enum
-
-| size       |
-| :--------- |
-| `"small"`  |
-| `"normal"` |
-| `"large"`  |
 
 ### Icons
 

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.d.ts
@@ -5,6 +5,8 @@ import * as Common from "../../common/common";
 type inexactString = string | null | undefined;
 type functionReturningString = () => string;
 
+export type Size = "small" | "normal" | "large";
+
 export interface ButtonCommonProps extends Common.Global, Common.Ref, Common.SpaceAfter {
   readonly asComponent?: Common.Component;
   readonly ariaControls?: string;
@@ -23,7 +25,6 @@ export interface ButtonCommonProps extends Common.Global, Common.Ref, Common.Spa
   readonly onClick?: Common.Event<React.SyntheticEvent<HTMLButtonElement>>;
   readonly rel?: string;
   readonly role?: string;
-  readonly size?: Common.Size;
   readonly submit?: boolean;
   readonly contentAlign?: string | null;
   readonly contentWidth?: string | null;
@@ -82,7 +83,7 @@ export interface PrimitiveTypes extends HeightProps, Foreground, Background, Box
   readonly icons?: IconProps;
 }
 
-export type Props = Omit<ButtonCommonProps, "size"> & ButtonCommonProps & PrimitiveTypes;
+export type Props = ButtonCommonProps & PrimitiveTypes;
 
 declare const StyledButtonPrimitive: React.ComponentType<Props>;
 declare const Button: React.RefForwardingComponent<HTMLButtonElement, Props>;

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.js.flow
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.js.flow
@@ -32,7 +32,6 @@ export type ButtonCommonProps = {|
   +onClick?: (e: SyntheticEvent<HTMLButtonElement>) => void | Promise<any>,
   +rel?: string,
   +role?: string,
-  +size?: Size,
   +submit?: boolean,
   +title?: string | (any => string),
   +contentAlign?: ?string,
@@ -107,7 +106,6 @@ export type PrimitiveTypes = {|
 |};
 
 export type Props = {|
-  ...$Diff<ButtonCommonProps, { +size?: Size, ... }>,
   ...ButtonCommonProps,
   ...PrimitiveTypes,
 |};

--- a/packages/orbit-components/src/primitives/Primitives.stories.js
+++ b/packages/orbit-components/src/primitives/Primitives.stories.js
@@ -106,7 +106,6 @@ export const ButtonPrimitive = (): React.Node => {
   const loading = boolean("loading", false);
   const padding = text("padding", "0 10px 0 10px");
   const role = text("role", null);
-  const size = select("Size", Object.values(BUTTON_SIZES), BUTTON_SIZES.NORMAL);
   const spaceAfter = select("spaceAfter", [null, ...Object.values(SPACINGS_AFTER)]);
   const submit = boolean("submit", false);
   const title = text("title", null);
@@ -146,7 +145,6 @@ export const ButtonPrimitive = (): React.Node => {
       onClick={action("onClick")}
       padding={padding}
       role={role}
-      size={size}
       spaceAfter={spaceAfter}
       submit={submit}
       title={title}

--- a/packages/orbit-components/src/primitives/Primitives.stories.js
+++ b/packages/orbit-components/src/primitives/Primitives.stories.js
@@ -6,7 +6,6 @@ import { action } from "@storybook/addon-actions";
 import ButtonPrimitiveComponent from "./ButtonPrimitive";
 import * as Icons from "../icons";
 import { SIZE_OPTIONS } from "./IllustrationPrimitive/consts";
-import { SIZE_OPTIONS as BUTTON_SIZES } from "./ButtonPrimitive/common/consts";
 import SPACINGS_AFTER from "../common/getSpacingToken/consts";
 import BadgePrimitiveComponent from "./BadgePrimitive";
 import IllustrationPrimitiveComponent from "./IllustrationPrimitive";


### PR DESCRIPTION
Removed redundant property `size` from the ButtonPrimitive component. It didn't have any effect on the styles, because we use `fontSize` and `height` properties to setup CSS attributes related to actual size.
 Orbit.kiwi: https://orbit-docs-fix-buttonprimitive-size.surge.sh
 Storybook: https://orbit-fix-buttonprimitive-size.surge.sh