### PR TITLE
fix(docs): enable ReactExample use

### DIFF
--- a/docs/src/components/DocLayout.tsx
+++ b/docs/src/components/DocLayout.tsx
@@ -96,7 +96,6 @@ export default function DocLayout({ children, description, location, path, tabs,
               )}
             </Box>
             {tabs && <Tabs activeTab={location.pathname} tabs={tabs} />}
-            <ReactExample exampleId="Wizard-default" />
             <ContentContainer padding="XLarge" elevation="raised">
               <MDXProvider
                 components={{
@@ -110,6 +109,7 @@ export default function DocLayout({ children, description, location, path, tabs,
                   GuidelinesSideBySide,
                   Do,
                   Dont,
+                  ReactExample,
                 }}
               >
                 {children}

--- a/docs/src/components/ReactExample/index.tsx
+++ b/docs/src/components/ReactExample/index.tsx
@@ -58,9 +58,11 @@ const ReactExample = ({ exampleId }: Props) => {
     `,
   );
 
-  const { fields } = allFile.nodes.find(n => n.fields.example_id === exampleId);
+  const example = allFile.nodes.find(n => n.fields.example_id === exampleId);
 
-  if (!fields) return <>{`Could not find example with ${exampleId} id`}</>;
+  if (!example) return <>{`Could not find example with the id: ${exampleId}`}</>;
+
+  const { fields } = example;
 
   const modules = fields.scope.reduce((acc, { name, path }) => {
     if (path.match(/@kiwicom\/orbit-components\/icons/)) {

--- a/docs/src/pages/mdx-examples.mdx
+++ b/docs/src/pages/mdx-examples.mdx
@@ -404,6 +404,8 @@ TODO.
   ]}
 />
 
-TODO.
+## React examples
+
+<ReactExample exampleId="Wizard-default" />
 
 [id]: ../images/rocket.jpg "Blast into Orbit"


### PR DESCRIPTION
and fix check for missing example
and add example use

The previous check failed as it's not possible to destructure something undefined.

 Orbit.kiwi: https://orbit-docs-fix-example-use.surge.sh
 Storybook: https://orbit-fix-example-use.surge.sh