### PR TITLE
docs: render Sidenav in Portal

### DIFF
--- a/docs/src/components/Navbar.tsx
+++ b/docs/src/components/Navbar.tsx
@@ -15,15 +15,12 @@ const StyledWrapper = styled.header`
   z-index: 10;
   display: flex;
   align-items: center;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding: 0.5rem 0;
   ${mq.tablet(css`
-    padding-top: 1rem;
-    padding-bottom: 1rem;
+    padding: 1rem 0;
   `)}
   ${mq.desktop(css`
-    padding-top: 1.5rem;
-    padding-bottom: 1.5rem;
+    padding: 1.5rem 0;
   `)}
   background: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(5px);

--- a/docs/src/components/Navbar.tsx
+++ b/docs/src/components/Navbar.tsx
@@ -8,22 +8,8 @@ import Logo from "../images/orbit.svg";
 import LogoGlyph from "../images/orbit-glyph.svg";
 import Input from "./SearchInput";
 import Bookmarks from "./Bookmarks";
+import { HEADER_HEIGHT as SIDENAV_HEADER_HEIGHT, paddingMixin } from "./Sidenav";
 import { MAX_CONTENT_WIDTH, CONTENT_PADDING } from "../consts";
-import { StyledAsideHeader, StyledOpenButton as StyledSidenavToggle } from "./Sidenav";
-
-const CONTENT_HEIGHT = "52px"; // safely above the search input height
-const paddingMixin = css`
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  ${mediaQueries.tablet(css`
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-  `)}
-  ${mediaQueries.desktop(css`
-    padding-top: 1.5rem;
-    padding-bottom: 1.5rem;
-  `)}
-`;
 
 const StyledWrapper = styled.header`
   position: relative;
@@ -33,19 +19,6 @@ const StyledWrapper = styled.header`
   ${paddingMixin};
   background: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(5px);
-
-  ${StyledAsideHeader} {
-    height: ${CONTENT_HEIGHT};
-    ${paddingMixin};
-    box-sizing: content-box;
-  }
-
-  ${mediaQueries.tablet(css`
-    ${StyledSidenavToggle} {
-      padding: ${CONTENT_PADDING};
-      margin: -${CONTENT_PADDING} 0;
-    }
-  `)}
 `;
 
 const StyledInner = styled.div`
@@ -53,7 +26,7 @@ const StyledInner = styled.div`
   max-width: ${MAX_CONTENT_WIDTH};
   padding: 0 ${CONTENT_PADDING};
   box-sizing: content-box;
-  height: ${CONTENT_HEIGHT};
+  height: ${SIDENAV_HEADER_HEIGHT};
   margin: 0 auto;
   display: grid;
   grid-template-columns: min-content auto min-content;

--- a/docs/src/components/Navbar.tsx
+++ b/docs/src/components/Navbar.tsx
@@ -2,13 +2,12 @@ import React from "react";
 import styled, { css } from "styled-components";
 import { Link } from "gatsby";
 import { WindowLocation } from "@reach/router";
-import { mediaQueries, useMediaQuery } from "@kiwicom/orbit-components";
+import { useMediaQuery, mediaQueries as mq } from "@kiwicom/orbit-components";
 
 import Logo from "../images/orbit.svg";
 import LogoGlyph from "../images/orbit-glyph.svg";
 import Input from "./SearchInput";
 import Bookmarks from "./Bookmarks";
-import { HEADER_HEIGHT as SIDENAV_HEADER_HEIGHT, paddingMixin } from "./Sidenav";
 import { MAX_CONTENT_WIDTH, CONTENT_PADDING } from "../consts";
 
 const StyledWrapper = styled.header`
@@ -16,7 +15,16 @@ const StyledWrapper = styled.header`
   z-index: 10;
   display: flex;
   align-items: center;
-  ${paddingMixin};
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  ${mq.tablet(css`
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  `)}
+  ${mq.desktop(css`
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  `)}
   background: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(5px);
 `;
@@ -26,7 +34,7 @@ const StyledInner = styled.div`
   max-width: ${MAX_CONTENT_WIDTH};
   padding: 0 ${CONTENT_PADDING};
   box-sizing: content-box;
-  height: ${SIDENAV_HEADER_HEIGHT};
+  height: 52px;
   margin: 0 auto;
   display: grid;
   grid-template-columns: min-content auto min-content;

--- a/docs/src/components/Sidenav/index.tsx
+++ b/docs/src/components/Sidenav/index.tsx
@@ -1,56 +1,10 @@
 import * as React from "react";
 import styled, { css } from "styled-components";
-import { Portal, mediaQueries } from "@kiwicom/orbit-components";
+import { Portal, Drawer } from "@kiwicom/orbit-components";
 import Menu from "@kiwicom/orbit-components/lib/icons/MenuHamburger";
-import Close from "@kiwicom/orbit-components/lib/icons/Close";
 import mq from "@kiwicom/orbit-components/lib/utils/mediaQuery";
-import useClickOutside from "@kiwicom/orbit-components/lib/hooks/useClickOutside";
 
 import { CONTENT_PADDING } from "../../consts";
-
-interface WrapperProps {
-  width: number;
-  shown: boolean;
-}
-
-export const HEADER_HEIGHT = "52px"; // safely above the search input height
-export const paddingMixin = css`
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  ${mediaQueries.tablet(css`
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-  `)}
-  ${mediaQueries.desktop(css`
-    padding-top: 1.5rem;
-    padding-bottom: 1.5rem;
-  `)}
-`;
-
-const StyledAsideWrapper = styled.aside<WrapperProps>`
-  ${({ width, theme, shown }) => css`
-    background: ${theme.orbit.paletteWhite};
-    padding: 0 20px;
-    z-index: 100;
-    margin: 0;
-    display: block;
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    height: 100vh;
-    overflow-y: auto;
-    font-family: ${theme.orbit.fontFamily};
-    box-shadow: ${theme.orbit.boxShadowRaised};
-    visibility: ${shown ? `visible` : `hidden`};
-    transition: transform ${theme.orbit.durationFast} ease-in;
-    width: 100%;
-    right: 0;
-    transform: translate3d(${shown ? "0, 0, 0" : `100%, 0, 0`});
-    ${mq.largeMobile(css`
-      max-width: ${width}px;
-    `)};
-  `}
-`;
 
 export const StyledOpenButton = styled.button.attrs(({ className }) => ({
   className,
@@ -64,81 +18,32 @@ export const StyledOpenButton = styled.button.attrs(({ className }) => ({
     box-shadow: rgba(95, 115, 140, 0.3) 0px 0px 0px 3px;
   }
 
-  ${mediaQueries.tablet(css`
-    padding: ${CONTENT_PADDING};
-    margin: -${CONTENT_PADDING} 0;
+  ${mq.tablet(css`
+    padding: 1rem;
+    margin: -1rem;
+    margin-right: calc(${CONTENT_PADDING} / 2);
   `)}
 `;
 
-export const StyledAsideHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 1px solid ${({ theme }) => theme.orbit.paletteCloudLight};
-  height: ${HEADER_HEIGHT};
-  ${paddingMixin};
-  box-sizing: content-box;
-`;
-
-const StyledCloseButton = styled.button.attrs(({ className, tabIndex }) => ({
-  className,
-  tabindex: tabIndex,
-  "aria-label": "close",
-}))`
-  ${({ theme }) => css`
-    border-radius: ${theme.orbit.borderRadiusNormal};
-    padding: 10px;
-    &:focus {
-      outline: 0;
-      background: ${theme.orbit.backgroundButtonSecondary};
-      box-shadow: rgba(95, 115, 140, 0.3) 0px 0px 0px 3px;
-    }
-    &:hover {
-      background: ${theme.orbit.backgroundButtonSecondaryHover};
-      box-shadow: rgba(95, 115, 140, 0.3) 0px 0px 0px 3px;
-    }
-    transition: all ${theme.orbit.durationFast} ease-in;
-  `}
-`;
-
-const StyledContent = styled.div`
-  margin: 20px 0;
-`;
-
 interface Props {
-  width?: number;
+  width?: string;
   actions?: React.ReactNode;
   toggleIcon?: React.ReactNode;
   children: React.ReactNode;
 }
 
-const Sidenav = ({ width = 350, children, toggleIcon, actions }: Props) => {
+const Sidenav = ({ width = "350px", children, toggleIcon, actions }: Props) => {
   const [isShown, setShown] = React.useState(false);
-  const handleShown = () => setShown(prev => !prev);
-  const ref = React.useRef(null);
-  useClickOutside(ref, () => setShown(false));
 
   return (
     <>
-      <StyledOpenButton onClick={handleShown}>{toggleIcon || <Menu ariaHidden />}</StyledOpenButton>
-
+      <StyledOpenButton onClick={() => setShown(true)}>
+        {toggleIcon || <Menu ariaHidden />}
+      </StyledOpenButton>
       <Portal>
-        <StyledAsideWrapper
-          ref={ref}
-          width={width}
-          role="navigation"
-          aria-label="side navigation"
-          aria-hidden={!isShown}
-          shown={isShown}
-        >
-          <StyledAsideHeader>
-            {actions}
-            <StyledCloseButton tabIndex={isShown ? 0 : -1} onClick={handleShown}>
-              <Close ariaHidden />
-            </StyledCloseButton>
-          </StyledAsideHeader>
-          <StyledContent>{children}</StyledContent>
-        </StyledAsideWrapper>
+        <Drawer shown={isShown} width={width} actions={actions} onClose={() => setShown(false)}>
+          {children}
+        </Drawer>
       </Portal>
     </>
   );

--- a/docs/src/components/Sidenav/index.tsx
+++ b/docs/src/components/Sidenav/index.tsx
@@ -1,14 +1,31 @@
 import * as React from "react";
 import styled, { css } from "styled-components";
+import { Portal, mediaQueries } from "@kiwicom/orbit-components";
 import Menu from "@kiwicom/orbit-components/lib/icons/MenuHamburger";
 import Close from "@kiwicom/orbit-components/lib/icons/Close";
 import mq from "@kiwicom/orbit-components/lib/utils/mediaQuery";
 import useClickOutside from "@kiwicom/orbit-components/lib/hooks/useClickOutside";
 
+import { CONTENT_PADDING } from "../../consts";
+
 interface WrapperProps {
   width: number;
   shown: boolean;
 }
+
+export const HEADER_HEIGHT = "52px"; // safely above the search input height
+export const paddingMixin = css`
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  ${mediaQueries.tablet(css`
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  `)}
+  ${mediaQueries.desktop(css`
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  `)}
+`;
 
 const StyledAsideWrapper = styled.aside<WrapperProps>`
   ${({ width, theme, shown }) => css`
@@ -17,7 +34,7 @@ const StyledAsideWrapper = styled.aside<WrapperProps>`
     z-index: 100;
     margin: 0;
     display: block;
-    position: absolute;
+    position: fixed;
     top: 0;
     bottom: 0;
     height: 100vh;
@@ -46,6 +63,11 @@ export const StyledOpenButton = styled.button.attrs(({ className }) => ({
     outline: 0;
     box-shadow: rgba(95, 115, 140, 0.3) 0px 0px 0px 3px;
   }
+
+  ${mediaQueries.tablet(css`
+    padding: ${CONTENT_PADDING};
+    margin: -${CONTENT_PADDING} 0;
+  `)}
 `;
 
 export const StyledAsideHeader = styled.div`
@@ -53,7 +75,9 @@ export const StyledAsideHeader = styled.div`
   justify-content: space-between;
   align-items: center;
   border-bottom: 1px solid ${({ theme }) => theme.orbit.paletteCloudLight};
-  padding-left: 0 20px;
+  height: ${HEADER_HEIGHT};
+  ${paddingMixin};
+  box-sizing: content-box;
 `;
 
 const StyledCloseButton = styled.button.attrs(({ className, tabIndex }) => ({
@@ -97,22 +121,25 @@ const Sidenav = ({ width = 350, children, toggleIcon, actions }: Props) => {
   return (
     <>
       <StyledOpenButton onClick={handleShown}>{toggleIcon || <Menu ariaHidden />}</StyledOpenButton>
-      <StyledAsideWrapper
-        ref={ref}
-        width={width}
-        role="navigation"
-        aria-label="side navigation"
-        aria-hidden={!isShown}
-        shown={isShown}
-      >
-        <StyledAsideHeader>
-          {actions}
-          <StyledCloseButton tabIndex={isShown ? 0 : -1} onClick={handleShown}>
-            <Close ariaHidden />
-          </StyledCloseButton>
-        </StyledAsideHeader>
-        <StyledContent>{children}</StyledContent>
-      </StyledAsideWrapper>
+
+      <Portal>
+        <StyledAsideWrapper
+          ref={ref}
+          width={width}
+          role="navigation"
+          aria-label="side navigation"
+          aria-hidden={!isShown}
+          shown={isShown}
+        >
+          <StyledAsideHeader>
+            {actions}
+            <StyledCloseButton tabIndex={isShown ? 0 : -1} onClick={handleShown}>
+              <Close ariaHidden />
+            </StyledCloseButton>
+          </StyledAsideHeader>
+          <StyledContent>{children}</StyledContent>
+        </StyledAsideWrapper>
+      </Portal>
     </>
   );
 };

--- a/packages/orbit-components/src/index.js
+++ b/packages/orbit-components/src/index.js
@@ -58,7 +58,7 @@ export { default as Slider } from "./Slider";
 
 // Navigation components
 export { default as NavigationBar } from "./NavigationBar";
-export { default as NavigationDrawer } from "./Drawer";
+export { default as Drawer } from "./Drawer";
 export { default as LinkList } from "./LinkList";
 
 // Table


### PR DESCRIPTION
When scrolling while Sidenav is open, Sidenav would scroll along the content, so in order to make it fixed we need to render it in a portal.

Let me know if I'm overlooking something.

 Orbit.kiwi: https://orbit-docs-docs-sidenav-portal.surge.sh
 Storybook: https://orbit-docs-sidenav-portal.surge.sh