### PR TITLE
fix(TextLink): called twice when stopPropagation specified

### DIFF
--- a/packages/orbit-components/src/TextLink/__tests__/index.test.js
+++ b/packages/orbit-components/src/TextLink/__tests__/index.test.js
@@ -25,6 +25,17 @@ describe("#TextLink", () => {
     expect(onClick).toHaveBeenCalled();
   });
 
+  it("should execute onClick method once when stopPropagation", () => {
+    const onClick = jest.fn();
+    render(
+      <TextLink onClick={onClick} stopPropagation>
+        {title}
+      </TextLink>,
+    );
+    userEvent.click(screen.getByText(title));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
   it("should render with props", () => {
     const dataTestLeftIcon = "leftIcon";
     const dataTestRightIcon = "rightIcon";

--- a/packages/orbit-components/src/TextLink/index.js
+++ b/packages/orbit-components/src/TextLink/index.js
@@ -119,7 +119,6 @@ const TextLink = ({
   const onClickHandler = ev => {
     if (stopPropagation) {
       ev.stopPropagation();
-      if (onClick) onClick(ev);
     }
     if (onClick) onClick(ev);
   };


### PR DESCRIPTION
Fixed #2853 
 Orbit.kiwi: https://orbit-docs-fix-textlink-click.surge.sh
 Storybook: https://orbit-fix-textlink-click.surge.sh