### PR TITLE
fix(useBoundingRect): fix TypeScript declaration

### DIFF
--- a/packages/orbit-components/src/hooks/useBoundingRect/__typetests__/index.js
+++ b/packages/orbit-components/src/hooks/useBoundingRect/__typetests__/index.js
@@ -1,0 +1,11 @@
+// @flow
+import * as React from "react";
+
+import useBoundingRect from "..";
+
+const Test: React.ComponentType<{||}> = () => {
+  const [, ref] = useBoundingRect({ height: null });
+  return <div ref={ref} />;
+};
+
+export default Test;

--- a/packages/orbit-components/src/hooks/useBoundingRect/__typetests__/index.tsx
+++ b/packages/orbit-components/src/hooks/useBoundingRect/__typetests__/index.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+
+import useBoundingRect from "..";
+
+export default function Test() {
+  const [, ref] = useBoundingRect<HTMLDivElement>({ height: null });
+  return <div ref={ref} />;
+}

--- a/packages/orbit-components/src/hooks/useBoundingRect/index.d.ts
+++ b/packages/orbit-components/src/hooks/useBoundingRect/index.d.ts
@@ -1,3 +1,5 @@
+import React from "react";
+
 type inexactNumber = number | undefined | null;
 
 type Dimensions = {
@@ -11,8 +13,8 @@ type Dimensions = {
   left: inexactNumber;
 };
 
-declare const UseBoundingRect: (
+declare function UseBoundingRect<T extends HTMLElement>(
   initialValue: Partial<Dimensions> | undefined | null,
-) => [Dimensions, { current: HTMLElement | undefined | null }];
+): [Dimensions, React.RefObject<T>];
 
 export { UseBoundingRect, UseBoundingRect as default };


### PR DESCRIPTION
BREAKING CHANGE: In TypeScript `useBoundingRect` now requires a type parameter based on which HTML element it measures:

```tsx
function App() {
  const [dimensions, ref] = useBoundingRect<HTMLDivElement>();
  return <div ref={ref} />;
}
```

 Orbit.kiwi: https://orbit-docs-fix-ts-use-bounding-rect.surge.sh
 Storybook: https://orbit-fix-ts-use-bounding-rect.surge.sh