### PR TITLE
feat(Breadcrumbs): automatically get parent breadcrumb

### DIFF
--- a/packages/orbit-components/src/Breadcrumbs/Breadcrumbs.stories.js
+++ b/packages/orbit-components/src/Breadcrumbs/Breadcrumbs.stories.js
@@ -14,7 +14,7 @@ export default {
 };
 
 export const Default = (): React.Node => (
-  <Breadcrumbs onGoBack={action("onGoBack")}>
+  <Breadcrumbs>
     <BreadcrumbsItem href="https://kiwi.com" onClick={action("clicked")}>
       Kiwi.com
     </BreadcrumbsItem>

--- a/packages/orbit-components/src/Breadcrumbs/__tests__/index.test.js
+++ b/packages/orbit-components/src/Breadcrumbs/__tests__/index.test.js
@@ -1,6 +1,4 @@
 // @flow
-/* eslint-disable no-restricted-syntax */
-
 import * as React from "react";
 import { render, screen, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -13,70 +11,66 @@ import BreadcrumbsItem from "../BreadcrumbsItem";
 // inaccessible, so we're replacing <Hide> with a dummy component
 jest.mock("../../Hide", () => ({ children }) => children);
 
-describe("#Breadcrumbs", () => {
-  const dataTest = "test";
-  const onGoBack = jest.fn();
-  beforeEach(() => {
+describe("Breadcrumbs", () => {
+  it("should have expected DOM output", () => {
+    const dataTest = "test";
+    const onGoBack = jest.fn();
+
     render(
       <Breadcrumbs dataTest={dataTest} onGoBack={onGoBack}>
         <BreadcrumbsItem href="https://kiwi.com">Kiwi.com</BreadcrumbsItem>
       </Breadcrumbs>,
     );
-  });
-  afterEach(() => {
-    onGoBack.mockClear();
-  });
-  it("nav should contain label, role and data-test", () => {
+
     expect(screen.getByRole("navigation")).toBeInTheDocument();
     expect(screen.getByLabelText("Breadcrumb")).toBeInTheDocument();
     expect(screen.getByTestId(dataTest)).toBeInTheDocument();
-  });
-
-  it("ol should contain correct item type", () => {
     expect(screen.getByRole("list")).toHaveAttribute(
       "itemType",
       expect.stringContaining("BreadcrumbList"),
     );
-  });
 
-  it("children should contain active and contentKey", () => {
     expect(screen.getByRole("listitem")).toHaveAttribute("aria-current", "page");
     expect(document.querySelector("meta")).toHaveAttribute("content", "1");
-  });
-  it("should execute onGoBack", () => {
-    for (const backBtn of screen.getAllByRole("button", { name: "Back" })) {
-      userEvent.click(backBtn);
-    }
+
+    screen.getAllByRole("button", { name: "Back" }).forEach(link => {
+      userEvent.click(link);
+    });
 
     expect(onGoBack).toHaveBeenCalledTimes(2);
   });
 
   it("should render as a link when backHref is passed", () => {
     render(
-      <Breadcrumbs backHref="https://orbit.kiwi" dataTest={dataTest} onGoBack={onGoBack}>
+      <Breadcrumbs backHref="https://orbit.kiwi" dataTest="kek">
         <BreadcrumbsItem href="https://kiwi.com">Kiwi.com</BreadcrumbsItem>
       </Breadcrumbs>,
     );
 
-    for (const backLink of screen.getAllByRole("link", { name: "Back" })) {
+    screen.getAllByRole("link", { name: "Back" }).forEach(backLink => {
       expect(backLink).toHaveAttribute("href", "https://orbit.kiwi");
-    }
+    });
   });
 
-  it("should render as a link when backHref is passed without onGoBack", () => {
+  it("back link should have take parent link, if the onBackHref is not passed", () => {
     render(
-      <Breadcrumbs backHref="https://orbit.kiwi" dataTest={dataTest}>
+      <Breadcrumbs dataTest="kek">
         <BreadcrumbsItem href="https://kiwi.com">Kiwi.com</BreadcrumbsItem>
+        <BreadcrumbsItem href="https://wikipedia.org" onClick={jest.fn()}>
+          Wikipedia.org
+        </BreadcrumbsItem>
+        <BreadcrumbsItem href="https://reactjs.org">Reactjs.org</BreadcrumbsItem>
       </Breadcrumbs>,
     );
 
-    for (const backLink of screen.getAllByRole("link", { name: "Back" })) {
-      expect(backLink).toHaveAttribute("href", "https://orbit.kiwi");
-    }
+    expect(screen.getByRole("link", { name: "Back" })).toHaveAttribute(
+      "href",
+      "https://wikipedia.org",
+    );
   });
 });
 
-describe("Breadcrumbs", () => {
+describe("Breadcrumbs item", () => {
   const onClick = jest.fn();
   const url = "https://kiwi.com";
   const title = "Kiwi.com";

--- a/packages/orbit-components/src/Breadcrumbs/index.js
+++ b/packages/orbit-components/src/Breadcrumbs/index.js
@@ -60,7 +60,7 @@ const GoBackButton = ({ onClick, backHref }) => {
 
 const Breadcrumbs = (props: Props): React.Node => {
   const translate = useTranslate();
-  const links = React.useRef([]);
+  const links = [];
 
   const {
     children,
@@ -80,7 +80,7 @@ const Breadcrumbs = (props: Props): React.Node => {
           <StyledBreadcrumbsList itemScope itemType="http://schema.org/BreadcrumbList">
             {onGoBack || backHref ? <GoBackButton backHref={backHref} onClick={onGoBack} /> : null}
             {React.Children.map(children, (item, key) => {
-              links.current.push({
+              links.push({
                 index: key,
                 href: item.props.href,
                 onClick: item.props.onClick,
@@ -102,8 +102,8 @@ const Breadcrumbs = (props: Props): React.Node => {
           standAlone
           iconLeft={<ChevronLeft reverseOnRtl />}
           dataTest="BreadcrumbsBack"
-          onClick={getParent(links.current)?.onClick}
-          href={getParent(links.current)?.href}
+          onClick={onGoBack || getParent(links)?.onClick}
+          href={backHref || getParent(links)?.href}
         >
           {goBackTitle}
         </TextLink>

--- a/packages/orbit-components/src/Breadcrumbs/index.js
+++ b/packages/orbit-components/src/Breadcrumbs/index.js
@@ -60,6 +60,8 @@ const GoBackButton = ({ onClick, backHref }) => {
 
 const Breadcrumbs = (props: Props): React.Node => {
   const translate = useTranslate();
+  const links = React.useRef([]);
+
   const {
     children,
     dataTest,
@@ -68,6 +70,9 @@ const Breadcrumbs = (props: Props): React.Node => {
     spaceAfter,
     backHref,
   } = props;
+
+  const getParent = arr => (arr.length > 1 ? arr[arr.length - 2] : undefined);
+
   return (
     <>
       <Hide on={["smallMobile", "mediumMobile"]}>
@@ -75,6 +80,12 @@ const Breadcrumbs = (props: Props): React.Node => {
           <StyledBreadcrumbsList itemScope itemType="http://schema.org/BreadcrumbList">
             {onGoBack || backHref ? <GoBackButton backHref={backHref} onClick={onGoBack} /> : null}
             {React.Children.map(children, (item, key) => {
+              links.current.push({
+                index: key,
+                href: item.props.href,
+                onClick: item.props.onClick,
+              });
+
               if (React.isValidElement(item)) {
                 return React.cloneElement(item, {
                   active: key === React.Children.count(children) - 1,
@@ -87,17 +98,15 @@ const Breadcrumbs = (props: Props): React.Node => {
         </StyledBreadcrumbs>
       </Hide>
       <Hide on={["largeMobile", "tablet", "desktop", "largeDesktop"]}>
-        {onGoBack || backHref ? (
-          <TextLink
-            standAlone
-            iconLeft={<ChevronLeft reverseOnRtl />}
-            dataTest="BreadcrumbsBack"
-            onClick={onGoBack}
-            href={backHref}
-          >
-            {goBackTitle}
-          </TextLink>
-        ) : null}
+        <TextLink
+          standAlone
+          iconLeft={<ChevronLeft reverseOnRtl />}
+          dataTest="BreadcrumbsBack"
+          onClick={getParent(links.current)?.onClick}
+          href={getParent(links.current)?.href}
+        >
+          {goBackTitle}
+        </TextLink>
       </Hide>
     </>
   );


### PR DESCRIPTION
[discussion in plz-orbit](https://skypicker.slack.com/archives/CAMS40F7B/p1601040561004300). 

Checking the possibility to get the parent breadcrumb href/onClick, if the component does not have `onBackHref`

 Orbit.kiwi: https://orbit-docs-feat-breadcrumbs.surge.sh
 Storybook: https://orbit-feat-breadcrumbs.surge.sh