### PR TITLE
fix(examples): omit types for react-live

### DIFF
--- a/docs/plugins/sandbox/gatsby-node.js
+++ b/docs/plugins/sandbox/gatsby-node.js
@@ -1,4 +1,4 @@
-const { getScope } = require("./helpers");
+const { getScope, omitTypes } = require("./helpers");
 
 exports.onCreateNode = async ({ node, actions, loadNodeContent }) => {
   if (node.sourceInstanceName === "examples" && node.internal.type === "File") {
@@ -10,6 +10,7 @@ exports.onCreateNode = async ({ node, actions, loadNodeContent }) => {
     const value = relativeDirectory.split("/").slice(-1).concat(name.toLowerCase()).join("-");
 
     const { content } = node.internal;
+
     const example = content.match(/(?<=example:)([\s\S]*)(?=,+[\W]+info)/gim);
 
     const scope = getScope(content);
@@ -23,7 +24,7 @@ exports.onCreateNode = async ({ node, actions, loadNodeContent }) => {
     createNodeField({
       node,
       name: "example",
-      value: example ? example[0] : "",
+      value: example ? omitTypes(example[0]) : "",
     });
 
     createNodeField({

--- a/docs/plugins/sandbox/helpers.js
+++ b/docs/plugins/sandbox/helpers.js
@@ -1,5 +1,6 @@
-const { types: t } = require("@babel/core");
+const { types: t, traverse } = require("@babel/core");
 const { parse } = require("@babel/parser");
+const { default: generate } = require("@babel/generator");
 
 const getCode = str =>
   parse(str, {
@@ -31,6 +32,21 @@ const getScope = example => {
   return scope;
 };
 
+/* react-live can't have types inside example, this helper removes the types for react-live */
+const omitTypes = example => {
+  const ast = getCode(example);
+
+  traverse(ast, {
+    TSTypeAnnotation: path => {
+      path.remove();
+    },
+  });
+
+  const { code } = generate(ast);
+  return code;
+};
+
 module.exports = {
   getScope,
+  omitTypes,
 };


### PR DESCRIPTION
react-live can't have types inside. Left the types inside examples and omited them via ast remove.

 Orbit.kiwi: https://orbit-docs-docs-omittypes-to-react-live.surge.sh
 Storybook: https://orbit-docs-omittypes-to-react-live.surge.sh