### PR TITLE
ci: restore Vale check

### DIFF
--- a/.github/workflows/lint-prose.yml
+++ b/.github/workflows/lint-prose.yml
@@ -19,12 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
-#
-#      - name: Vale
-#        uses: errata-ai/vale-action@v1.3.0
-#        with:
-#          files: '["docs/src/documentation", "docs/src/snippets"]'
-#          onlyAnnotateModifiedLines: true
-#        env:
-#          # Required
-#          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      #
+      - name: Vale
+        uses: errata-ai/vale-action@v1.3.0
+        with:
+          files: '["docs/src/documentation", "docs/src/snippets"]'
+          onlyAnnotateModifiedLines: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The original issue seems fixed: https://github.com/errata-ai/vale-action/issues/33
 Orbit.kiwi: https://orbit-docs-fix-vale-version.surge.sh
 Storybook: https://orbit-fix-vale-version.surge.sh