### PR TITLE
fix(docs): external icon

### DIFF
--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -152,6 +152,10 @@ export const dt = ({ children }: React.HTMLAttributes<HTMLElement>) => (
 
 export const inlineCode = InlineCode;
 
+const isKeyboardEvent = (e): e is React.KeyboardEvent => {
+  return (e as React.KeyboardEvent).getModifierState !== undefined;
+};
+
 export const a = function Anchor({
   children,
   href,
@@ -180,11 +184,13 @@ export const a = function Anchor({
         href={href}
         external={isExternal}
         iconRight={useExternalIcon && <NewWindow ariaLabel="Opens in new window" />}
-        onClick={event => {
+        onClick={(event: React.SyntheticEvent<HTMLLinkElement>) => {
           if (isExternal || !href) return;
 
           // Allows opening in a new tab with ctrl/cmd + click
-          if (event.metaKey || event.ctrlKey) return;
+          if (isKeyboardEvent(event)) {
+            if (event.metaKey || event.ctrlKey) return;
+          }
 
           event.preventDefault();
           navigate(href);

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -12,7 +12,7 @@ import {
   TableCell,
 } from "@kiwicom/orbit-components";
 import { NewWindow } from "@kiwicom/orbit-components/icons";
-import { navigate } from "gatsby";
+import { Link } from "gatsby";
 import { css } from "styled-components";
 
 import HeadingWithLink from "./components/HeadingWithLink";
@@ -152,9 +152,9 @@ export const dt = ({ children }: React.HTMLAttributes<HTMLElement>) => (
 
 export const inlineCode = InlineCode;
 
-const isKeyboardEvent = (e): e is React.KeyboardEvent => {
-  return (e as React.KeyboardEvent).getModifierState !== undefined;
-};
+const LinkForOrbitTextLink = ({ href, ...props }: { href: string }) => (
+  <Link to={href} {...props} />
+);
 
 export const a = function Anchor({
   children,
@@ -181,20 +181,11 @@ export const a = function Anchor({
       `}
     >
       <TextLink
+        // @ts-expect-error type declaration is not permissive enough
+        asComponent={isExternal ? "a" : LinkForOrbitTextLink}
         href={href}
         external={isExternal}
         iconRight={useExternalIcon && <NewWindow ariaLabel="Opens in new window" />}
-        onClick={(event: React.SyntheticEvent<HTMLLinkElement>) => {
-          if (isExternal || !href) return;
-
-          // Allows opening in a new tab with ctrl/cmd + click
-          if (isKeyboardEvent(event)) {
-            if (event.metaKey || event.ctrlKey) return;
-          }
-
-          event.preventDefault();
-          navigate(href);
-        }}
       >
         {children}
       </TextLink>

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -166,6 +166,13 @@ export const a = function Anchor({
           line-height: normal;
           /* TextLink's display as inline-flex cause long links to break paragraphs */
           display: inherit;
+          /* Ensure the icon stays inline */
+          span {
+            display: inline;
+            svg {
+              display: inline;
+            }
+          }
         }
       `}
     >

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -157,6 +157,7 @@ export const a = function Anchor({
   href,
 }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   const isExternal = useIsUrlExternal(href);
+  const useExternalIcon = isExternal && typeof children === "string";
   return (
     <span
       css={css`
@@ -171,7 +172,7 @@ export const a = function Anchor({
       <TextLink
         href={href}
         external={isExternal}
-        iconRight={isExternal && <NewWindow />}
+        iconRight={useExternalIcon && <NewWindow ariaLabel="Opens in new window" />}
         onClick={event => {
           if (isExternal || !href) return;
 

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -174,6 +174,10 @@ export const a = function Anchor({
         iconRight={isExternal && <NewWindow />}
         onClick={event => {
           if (isExternal || !href) return;
+
+          // Allows opening in a new tab with ctrl/cmd + click
+          if (event.metaKey || event.ctrlKey) return;
+
           event.preventDefault();
           navigate(href);
         }}


### PR DESCRIPTION
The fix for the icon being inline is maybe a little hacky. 🤷
 Orbit.kiwi: https://orbit-docs-fix-external-icon.surge.sh
 Storybook: https://orbit-fix-external-icon.surge.sh