### PR TITLE
fix: update React peer dependency versions

### DIFF
--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -65,8 +65,8 @@
   "author": "kiwi.com",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.14.0",
-    "react-dom": "^16.12.0",
+    "react": ">=16.14.0",
+    "react-dom": ">=16.12.0",
     "styled-components": "^4.4.1"
   },
   "dependencies": {


### PR DESCRIPTION
Popular packages like [downshift](https://github.com/downshift-js/downshift/blob/f18b031644105e4046b361c4e0109ed5494fbf1e/package.json#L66) do it like this, so I think it's a good idea.

Rel. #2858.

 Orbit.kiwi: https://orbit-docs-react-peer-dependency-version.surge.sh
 Storybook: https://orbit-react-peer-dependency-version.surge.sh