### PR TITLE
docs: fix front page layout

### DIFF
--- a/docs/src/components/BrandedTile.tsx
+++ b/docs/src/components/BrandedTile.tsx
@@ -36,6 +36,7 @@ export default function BrandedTile({ title, linkContent, href, logo, color, chi
         color: ${theme.orbit.colorTextWhite};
         box-shadow: 0px 8px 24px 0px rgba(37, 42, 49, 0.16), 0px 4px 8px 0px rgba(37, 42, 49, 0.08);
         display: flex;
+        width: 100%;
         flex-direction: column;
       `}
     >

--- a/docs/src/components/BrandedTile.tsx
+++ b/docs/src/components/BrandedTile.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Heading, Stack, Inline } from "@kiwicom/orbit-components";
+import { Heading, Stack, Truncate, mediaQueries as mq } from "@kiwicom/orbit-components";
 import useTheme from "@kiwicom/orbit-components/lib/hooks/useTheme";
-import { css } from "styled-components";
+import styled, { css } from "styled-components";
 
 import ButtonLink from "./ButtonLink";
 import { ICON_SIZE } from "./Tile";
@@ -20,6 +20,51 @@ interface Props {
   children: React.ReactNode;
 }
 
+const StyledWrapper = styled.div<{ primary: string }>`
+  ${({ theme, primary }) => `
+    padding: 2rem;
+    border-radius: 1rem;
+    background: ${primary};
+    color: ${theme.orbit.colorTextWhite};
+    box-shadow: 0px 8px 24px 0px rgba(37, 42, 49, 0.16), 0px 4px 8px 0px rgba(37, 42, 49, 0.08);
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+  `};
+`;
+
+const StyledIcon = styled.div<{ secondary: string }>`
+  ${({ theme, secondary }) => css`
+    align-self: start;
+    flex-shrink: 0;
+    width: ${ICON_SIZE};
+    height: ${ICON_SIZE};
+    display: none;
+    background: ${secondary};
+    border-radius: ${theme.orbit.borderRadiusCircle};
+    ${mq.largeMobile(`
+      display: flex;
+    `)};
+  `}
+`;
+
+const StyledHeading = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 1;
+  h3 {
+    margin-top: 0;
+    line-height: ${ICON_SIZE};
+  }
+`;
+
+const StyledContent = styled.div`
+  display: flex;
+  flex-shrink: 1;
+  height: 100%;
+  margin: 0.5rem 0 1.5rem;
+`;
+
 export default function BrandedTile({ title, linkContent, href, logo, color, children }: Props) {
   const theme = useTheme();
 
@@ -27,78 +72,45 @@ export default function BrandedTile({ title, linkContent, href, logo, color, chi
   const content = typeof children !== "string" ? <Stack>{children}</Stack> : <p>{children}</p>;
   const colorPrimary = color === "product" ? theme.orbit.paletteProductDark : color.primary;
   const colorSecondary = color === "product" ? theme.orbit.paletteProductNormal : color.secondary;
+
   return (
-    <div
-      css={css`
-        padding: 2rem;
-        border-radius: 1rem;
-        background: ${colorPrimary};
-        color: ${theme.orbit.colorTextWhite};
-        box-shadow: 0px 8px 24px 0px rgba(37, 42, 49, 0.16), 0px 4px 8px 0px rgba(37, 42, 49, 0.08);
-        display: flex;
-        width: 100%;
-        flex-direction: column;
-      `}
-    >
-      <div
-        css={css`
-          flex: 1;
-          display: flex;
-          > * + * {
-            margin-left: 0.75rem;
-          }
-        `}
-      >
-        <div
-          css={css`
-            align-self: start;
-            flex-shrink: 0;
-            width: ${ICON_SIZE};
-            height: ${ICON_SIZE};
-            background: ${colorSecondary};
-            border-radius: ${theme.orbit.borderRadiusCircle};
-          `}
-        />
-        <div
-          css={css`
-            h3 {
-              margin-top: 0;
-              line-height: ${ICON_SIZE};
-            }
-          `}
-        >
+    <StyledWrapper primary={colorPrimary}>
+      <Stack inline>
+        <StyledIcon secondary={colorSecondary} />
+        <StyledHeading>
           <Heading inverted type="title2" as="h3">
             {title}
           </Heading>
-          <div
-            css={css`
-              margin: 0.5rem 0 1.5rem;
-            `}
-          >
-            {content}
-          </div>
-          <Inline justify="between" align="center">
-            <ButtonLink
-              {...(color === "product" ? { type: "primary" } : { color: colorSecondary })}
-              dark
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {linkContent}
-            </ButtonLink>
-            <div
-              css={css`
-                img {
-                  max-width: none;
-                }
-              `}
-            >
-              {logo}
-            </div>
-          </Inline>
+          <StyledContent>{content}</StyledContent>
+        </StyledHeading>
+      </Stack>
+      <Stack
+        inline
+        direction="column"
+        largeMobile={{ direction: "row" }}
+        align="center"
+        justify="between"
+      >
+        <ButtonLink
+          {...(color === "product" ? { type: "primary" } : { color: colorSecondary })}
+          dark
+          href={href}
+          target="_blank"
+          title={linkContent}
+          rel="noopener noreferrer"
+        >
+          {linkContent}
+        </ButtonLink>
+        <div
+          css={css`
+            img {
+              max-width: none;
+            }
+          `}
+        >
+          {logo}
         </div>
-      </div>
-    </div>
+      </Stack>
+    </StyledWrapper>
   );
 }

--- a/docs/src/components/Tile.tsx
+++ b/docs/src/components/Tile.tsx
@@ -11,6 +11,7 @@ export const ICON_SIZE = "2rem";
 interface Props {
   icon?: boolean;
   title: string;
+  fullWidth?: boolean;
   linkContent?: React.ReactNode;
   href?: string;
   children?: React.ReactNode;
@@ -48,7 +49,14 @@ function TileTitle({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function Tile({ href, icon, linkContent, title, children }: Props) {
+export default function Tile({
+  href,
+  icon,
+  linkContent,
+  title,
+  children,
+  fullWidth = true,
+}: Props) {
   const theme = useTheme();
 
   return (
@@ -59,6 +67,7 @@ export default function Tile({ href, icon, linkContent, title, children }: Props
         background: ${theme.orbit.paletteWhite};
         box-shadow: 0px 8px 24px 0px rgba(37, 42, 49, 0.16), 0px 4px 8px 0px rgba(37, 42, 49, 0.08);
         display: flex;
+        width: ${fullWidth && "100%"};
         ${children
           ? css`
               flex-direction: column;

--- a/docs/src/components/Tile.tsx
+++ b/docs/src/components/Tile.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "gatsby";
-import { Heading, Stack } from "@kiwicom/orbit-components";
+import { Heading, Stack, Hide, mediaQueries as mq } from "@kiwicom/orbit-components";
 import useTheme from "@kiwicom/orbit-components/lib/hooks/useTheme";
 import { css } from "styled-components";
 
@@ -82,12 +82,18 @@ export default function Tile({
         css={css`
           flex: 1;
           display: flex;
-          > * + * {
-            margin-left: 0.75rem;
-          }
+          ${mq.largeMobile(`
+            > * + * {
+              margin-left: 0.75rem;
+            };
+          `)};
         `}
       >
-        {icon && <TileIcon />}
+        {icon && (
+          <Hide on={["smallMobile", "mediumMobile"]}>
+            <TileIcon />
+          </Hide>
+        )}
         {children ? (
           <div>
             <TileTitle>{title}</TileTitle>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -177,8 +177,8 @@ export default function Home({ location }: Props) {
           `}
         >
           <Heading as="h2">Support</Heading>
-          <Stack flex direction="column" spacing="XLarge">
-            <Stack flex align="stretch">
+          <Stack flex direction="column">
+            <Stack flex direction="column" tablet={{ direction: "row" }} align="stretch">
               <BrandedTile
                 title="Report a bug"
                 href="https://github.com/kiwicom/orbit/issues/new/choose"
@@ -207,7 +207,7 @@ export default function Home({ location }: Props) {
                 get feedback from you.
               </BrandedTile>
             </Stack>
-            <Stack flex>
+            <Stack flex direction="column" tablet={{ direction: "row" }} align="stretch">
               <BrandedTile
                 title="Follow us on Twitter"
                 href="https://twitter.com/OrbitKiwi"
@@ -218,8 +218,8 @@ export default function Home({ location }: Props) {
                   secondary: "#179CE3",
                 }}
               >
-                Slack is Kiwi.com’s main platform for communication, so it’s only understandable
-                that everything important that is happening around Orbit is also on Slack.
+                Twitter is one of the main platform for sharing, everything important that is
+                happening around Orbit is published on Twitter
               </BrandedTile>
               <BrandedTile
                 title="Connect Orbit to Tequila"
@@ -234,28 +234,28 @@ export default function Home({ location }: Props) {
             </Stack>
           </Stack>
         </div>
-      </div>
 
-      <div
-        css={css`
-          > * + * {
-            margin-top: 2rem;
-          }
-        `}
-      >
-        <Heading as="h2">Resources</Heading>
-        <Tile
-          title="Figma library"
-          linkContent={<NewWindow />}
-          href="https://www.figma.com/@orbitbykiwi"
-          icon
-        />
-        <Tile
-          title="Orbit repository"
-          linkContent={<NewWindow />}
-          href="https://github.com/kiwicom/orbit"
-          icon
-        />
+        <div
+          css={css`
+            > * + * {
+              margin-top: 2rem;
+            }
+          `}
+        >
+          <Heading as="h2">Resources</Heading>
+          <Tile
+            title="Figma library"
+            linkContent={<NewWindow />}
+            href="https://www.figma.com/@orbitbykiwi"
+            icon
+          />
+          <Tile
+            title="Orbit repository"
+            linkContent={<NewWindow />}
+            href="https://github.com/kiwicom/orbit"
+            icon
+          />
+        </div>
       </div>
     </Layout>
   );

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -18,32 +18,6 @@ import TwitterLogo from "../images/twitter.svg";
 import srcTequila from "../images/tequila.png";
 import { MAX_CONTENT_WIDTH } from "../consts";
 
-function TileRow({ children }: { children: React.ReactNode }) {
-  return (
-    <Inline spacing="XLarge">
-      {React.Children.map(
-        children,
-        tile =>
-          React.isValidElement(tile) && (
-            <div
-              css={css`
-                flex: 1;
-                align-self: stretch;
-                display: flex;
-                flex-direction: column;
-                > :only-child {
-                  flex: 1;
-                }
-              `}
-            >
-              {tile}
-            </div>
-          ),
-      )}
-    </Inline>
-  );
-}
-
 interface Props {
   location: WindowLocation;
 }
@@ -98,7 +72,12 @@ export default function Home({ location }: Props) {
           </div>
         </>
 
-        <TileRow>
+        <Stack
+          flex
+          direction="column"
+          justify="between"
+          largeMobile={{ direction: "row", align: "stretch" }}
+        >
           <Tile
             title="Components"
             linkContent="See our components"
@@ -116,7 +95,7 @@ export default function Home({ location }: Props) {
           >
             Missing description for patterns card.
           </Tile>
-        </TileRow>
+        </Stack>
 
         <div
           css={css`
@@ -126,7 +105,7 @@ export default function Home({ location }: Props) {
           `}
         >
           <Heading as="h2">Foundation</Heading>
-          <TileRow>
+          <Stack flex direction="column" tablet={{ direction: "row", align: "stretch" }}>
             <Tile title="Colors" linkContent="Learn more" href="/foundation/color/" icon>
               Color is used to signal structure on a page, to highlight or emphasize...
             </Tile>
@@ -136,7 +115,7 @@ export default function Home({ location }: Props) {
             <Tile title="Spacings" linkContent="Learn more" icon>
               Consistent spacing makes an interface more clear and easy to scan.
             </Tile>
-          </TileRow>
+          </Stack>
           <div
             css={css`
               text-align: right;
@@ -156,7 +135,7 @@ export default function Home({ location }: Props) {
           `}
         >
           <Heading as="h2">Content</Heading>
-          <TileRow>
+          <Stack flex direction="column" tablet={{ direction: "row", align: "stretch" }}>
             <Tile
               title="Voice & tone"
               linkContent="Learn more"
@@ -177,7 +156,7 @@ export default function Home({ location }: Props) {
             <Tile title="Glossary" linkContent="Learn more" href="/kiwi-use/content/glossary/" icon>
               A list of most used words and phrases in Kiwi.com products.
             </Tile>
-          </TileRow>
+          </Stack>
           <div
             css={css`
               text-align: right;
@@ -198,89 +177,85 @@ export default function Home({ location }: Props) {
           `}
         >
           <Heading as="h2">Support</Heading>
-          <div>
-            <Stack spacing="XLarge">
-              <TileRow>
-                <BrandedTile
-                  title="Report a bug"
-                  href="https://github.com/kiwicom/orbit/issues/new/choose"
-                  linkContent="Report bug on GitHub"
-                  logo={<GitHubLogo />}
-                  color={{
-                    primary: "#252A31",
-                    secondary: "#515C6C",
-                  }}
-                >
-                  If you found any bugs in our components, report them on Github and we’ll fix them
-                  asap. It’s the highest priority to have Orbit working as expected.
-                </BrandedTile>
-                <BrandedTile
-                  title="Engage with us"
-                  href="https://spectrum.chat/orbit"
-                  linkContent="Go to Spectrum chat"
-                  logo={<SpectrumLogo />}
-                  color={{
-                    primary: "#330B94",
-                    secondary: "#7441F1",
-                  }}
-                >
-                  We aim to provide the best possible support for all designers and developers using
-                  Orbit. That’s why we an Orbit community on Spectrum – an open discussion platform
-                  to get feedback from you.
-                </BrandedTile>
-              </TileRow>
-              <TileRow>
-                <BrandedTile
-                  title="Follow us on Twitter"
-                  href="https://twitter.com/OrbitKiwi"
-                  linkContent="Go to Orbit.kiwi’s Twitter"
-                  logo={<TwitterLogo />}
-                  color={{
-                    primary: "#0989CF",
-                    secondary: "#179CE3",
-                  }}
-                >
-                  Slack is Kiwi.com’s main platform for communication, so it’s only understandable
-                  that everything important that is happening around Orbit is also on Slack.
-                </BrandedTile>
-                <BrandedTile
-                  title="Connect Orbit to Tequila"
-                  href="https://partners.kiwi.com"
-                  linkContent="Explore Tequila possibilities"
-                  logo={<img alt="Tequila logo" src={srcTequila} width={144} height={64} />}
-                  color="product"
-                >
-                  Tequila is an online B2B platform powered by Kiwi.com that allows anyone to access
-                  our content, technology, and services.
-                </BrandedTile>
-              </TileRow>
+          <Stack flex direction="column" spacing="XLarge">
+            <Stack flex align="stretch">
+              <BrandedTile
+                title="Report a bug"
+                href="https://github.com/kiwicom/orbit/issues/new/choose"
+                linkContent="Report bug on GitHub"
+                logo={<GitHubLogo />}
+                color={{
+                  primary: "#252A31",
+                  secondary: "#515C6C",
+                }}
+              >
+                If you found any bugs in our components, report them on Github and we’ll fix them
+                asap. It’s the highest priority to have Orbit working as expected.
+              </BrandedTile>
+              <BrandedTile
+                title="Engage with us"
+                href="https://spectrum.chat/orbit"
+                linkContent="Go to Spectrum chat"
+                logo={<SpectrumLogo />}
+                color={{
+                  primary: "#330B94",
+                  secondary: "#7441F1",
+                }}
+              >
+                We aim to provide the best possible support for all designers and developers using
+                Orbit. That’s why we an Orbit community on Spectrum – an open discussion platform to
+                get feedback from you.
+              </BrandedTile>
             </Stack>
-          </div>
+            <Stack flex>
+              <BrandedTile
+                title="Follow us on Twitter"
+                href="https://twitter.com/OrbitKiwi"
+                linkContent="Go to Orbit.kiwi’s Twitter"
+                logo={<TwitterLogo />}
+                color={{
+                  primary: "#0989CF",
+                  secondary: "#179CE3",
+                }}
+              >
+                Slack is Kiwi.com’s main platform for communication, so it’s only understandable
+                that everything important that is happening around Orbit is also on Slack.
+              </BrandedTile>
+              <BrandedTile
+                title="Connect Orbit to Tequila"
+                href="https://partners.kiwi.com"
+                linkContent="Explore Tequila possibilities"
+                logo={<img alt="Tequila logo" src={srcTequila} width={144} height={64} />}
+                color="product"
+              >
+                Tequila is an online B2B platform powered by Kiwi.com that allows anyone to access
+                our content, technology, and services.
+              </BrandedTile>
+            </Stack>
+          </Stack>
         </div>
+      </div>
 
-        <div
-          css={css`
-            > * + * {
-              margin-top: 2rem;
-            }
-          `}
-        >
-          <Heading as="h2">Resources</Heading>
-          <TileRow>
-            <Tile
-              title="Figma library"
-              linkContent={<NewWindow />}
-              href="https://www.figma.com/@orbitbykiwi"
-              icon
-            />
-            <Tile
-              title="Orbit repository"
-              linkContent={<NewWindow />}
-              href="https://github.com/kiwicom/orbit"
-              icon
-            />
-          </TileRow>
-        </div>
+      <div
+        css={css`
+          > * + * {
+            margin-top: 2rem;
+          }
+        `}
+      >
+        <Heading as="h2">Resources</Heading>
+        <Tile
+          title="Figma library"
+          linkContent={<NewWindow />}
+          href="https://www.figma.com/@orbitbykiwi"
+          icon
+        />
+        <Tile
+          title="Orbit repository"
+          linkContent={<NewWindow />}
+          href="https://github.com/kiwicom/orbit"
+          icon
+        />
       </div>
     </Layout>
   );


### PR DESCRIPTION
fixed visual bugs on the front page, now it should look better. For icons inside `Tile/BrandedTile` set `display: none` on smallMobile and mediumMobile, I suppose it just takes the space and we can turn it off for such small viewports. 

Another thing, that can be discussed is usage of relative values, we have a lot of `rems`, but we do not change the base value, it can be useful for reducing the margin/padding size for narrow viewports, i doubt that we have to have `32px` padding for Tile on `smallMobile`

 Orbit.kiwi: https://orbit-docs-fix-front-page.surge.sh
 Storybook: https://orbit-fix-front-page.surge.sh