### PR TITLE
improve: add script for deleting gatsby cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dev": "yarn workspace @kiwicom/orbit-components storybook",
     "dev:docs": "yarn workspace @kiwicom/orbit.kiwi dev",
     "dev:test": "cross-env NODE_ENV=loki yarn dev",
+    "clean:docs": "lerna run --scope @kiwicom/orbit.kiwi clean",
     "publish-packages": "gulp publish",
     "orbit-kiwi:build": "yarn install --frozen-lockfile && yarn bootstrap && yarn build && yarn orbit-kiwi build"
   },


### PR DESCRIPTION
In certain cases, for example after changing images, old versions stay cached, so we need to delete Gatsby's cache.
 Orbit.kiwi: https://orbit-docs-clean-docs-script.surge.sh
 Storybook: https://orbit-clean-docs-script.surge.sh