### PR TITLE
feat(tokens): update deprecated white palette shades

### DIFF
--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/white.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/palette/white.json
@@ -2,32 +2,37 @@
   "global": {
     "palette": {
       "white": {
-        "normal": {
-          "type": "color",
-          "value": "{foundation.palette.white.normal}"
-        },
-        "hover": {
-          "type": "color",
-          "value": "{foundation.palette.white.normal-secondary}",
-          "deprecated": true,
-          "deprecated-replace": "{global.palette.white.normal-secondary}",
-          "deprecated-version": "1.0.0"
-        },
-        "normal-secondary": {
-          "type": "color",
-          "value": "{foundation.palette.white.normal-secondary}"
-        },
-        "active": {
-          "type": "color",
-          "value": "{foundation.palette.white.normal-tertiary}",
-          "deprecated": true,
-          "deprecated-replace": "{global.palette.white.normal-tertiary}",
-          "deprecated-version": "1.0.0"
-        },
-        "normal-tertiary": {
-          "type": "color",
-          "value": "{foundation.palette.white.normal-tertiary}"
-        }
+        "type": "color",
+        "value": "{foundation.palette.white.normal}",
+        "deprecated": true,
+        "deprecated-replace": "{global.palette.white-normal}",
+        "deprecated-version": "1.0.0"
+      },
+      "white-normal": {
+        "type": "color",
+        "value": "{foundation.palette.white.normal}"
+      },
+      "white-hover": {
+        "type": "color",
+        "value": "{foundation.palette.white.normal-secondary}",
+        "deprecated": true,
+        "deprecated-replace": "{global.palette.white-normal-secondary}",
+        "deprecated-version": "1.0.0"
+      },
+      "white-normal-secondary": {
+        "type": "color",
+        "value": "{foundation.palette.white.normal-secondary}"
+      },
+      "white-active": {
+        "type": "color",
+        "value": "{foundation.palette.white.normal-tertiary}",
+        "deprecated": true,
+        "deprecated-replace": "{global.palette.white-normal-tertiary}",
+        "deprecated-version": "1.0.0"
+      },
+      "white-normal-tertiary": {
+        "type": "color",
+        "value": "{foundation.palette.white.normal-tertiary}"
       }
     }
   }


### PR DESCRIPTION
It goes against the normal definition of other colors, but we need a way how to define all deprecated old names.