### PR TITLE
feat(docs): add guidelines on TextLink colors

### DIFF
--- a/docs/src/documentation/03-components/01-action/textlink/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/01-action/textlink/01-guidelines.mdx
@@ -31,15 +31,6 @@ check out our [interactive guide on action components](/guides/using-button-type
   alt="Text: describes the link purpose and works best when short; icon: optionally visually supports the link."
 />
 
-## TextLink types
-
-Text links come in **two types** (primary and secondary) and **three
-sizes** (small, normal, and large).
-
-<ReactExample exampleId="TextLink-types" />
-
-<ReactExample exampleId="TextLink-sizes" />
-
 ## Behavior
 
 ### Use for navigation
@@ -55,7 +46,7 @@ use a different action component, such as a [button link](/components/action/but
 
 It should be clear from the link text exactly what happens when the user interacts with it.
 The text can be actionable, such as "Read all reviews",
-or descriptive of what is described at the link,
+or descriptive of what's described at the link,
 such as "[Kiwi.com Guarantee](https://www.kiwi.com/en/pages/guarantee)".
 
 The link stands out from the surrounding text.
@@ -111,8 +102,25 @@ to let users know a link opens in a new window/tab.
 ### Sizing
 
 Text links inherit their default size from their parent.
+You can override this size.
 
-### Primary color
+<ReactExample exampleId="TextLink-sizes" />
+
+### Color
+
+Text links should align with the color of text around them.
+Usually, this means using the default [primary color](#primary-color).
+
+When the text link is part of or next to [text with a different color](/components/text/#text-color),
+the text link can have its color align with other text.
+(It's always darker to make it clear it has an action.)
+
+<ReactExample exampleId="TextLink-types" />
+
+Do **_not_** use different colors for standalone text links.
+The colors aren't for emphasis or to draw attention.
+
+#### Primary color
 
 The primary color of text links is <InlineToken value="colorTextLinkPrimary" alternateName />.
 This is a darker color than other primary actions, such as primary [buttons](/components/action/button/).


### PR DESCRIPTION

 Orbit.kiwi: https://orbit-docs-docs-textlink-colors.surge.sh
 Storybook: https://orbit-docs-textlink-colors.surge.sh