### PR TITLE
feat(BaggageStepper): init

### DIFF
--- a/packages/orbit-components/src/BaggageStepper/README.md
+++ b/packages/orbit-components/src/BaggageStepper/README.md
@@ -1,0 +1,41 @@
+# BaggageStepper
+
+To implement BaggageStepper component into your project you'll need to add the import:
+
+```jsx
+import BaggageStepper from "@kiwicom/orbit-components/lib/BaggageStepper";
+```
+
+After adding import into your project you can use it simply like:
+
+```jsx
+<BaggageStepper />
+```
+
+## Props
+
+Table below contains all types of the props available in BaggageStepper component.
+
+| Name           | Type                        | Default | Description                                                                          |
+| :------------- | :-------------------------- | :------ | :----------------------------------------------------------------------------------- |
+| dataTest       | `string`                    |         | Optional prop for testing purposes.                                                  |
+| defaultValue   | `number`                    | `0`     | Specifies the value of the BaggageStepper. [See Functional specs](#functional-specs) |
+| disabled       | `boolean`                   | `false` | If `true`, the BaggageStepper will be disabled.                                      |
+| maxValue       | `number`                    | `∞`     | Specifies the maximum value for the BaggageStepper.                                  |
+| minValue       | `number`                    | `-∞`    | Specifies the minimum value for the BaggageStepper.                                  |
+| name           | `string`                    |         | The name for the BaggageStepper.                                                     |
+| onBlur         | `event => void \| Promise`  |         | Function for handling onBlur event.                                                  |
+| onChange       | `number => void \| Promise` |         | Function for handling onClick event.                                                 |
+| onFocus        | `event => void \| Promise`  |         | Function for handling onFocus event.                                                 |
+| step           | `number`                    | `1`     | Specifies the value of step to increment and decrement.                              |
+| titleDecrement | `string \| (any => string)` |         | Specifies `title` property on decrement `Button`.                                    |
+| titleIncrement | `string \| (any => string)` |         | Specifies `title` property on increment `Button`.                                    |
+| selected       | `boolean`                   |         | If `true`, the BaggageStepper will have selected styles.                             |
+
+## Functional specs
+
+- The prop `defaultValue` sets the default value when the component mounts. If you need to get the current value of the BaggageStepper, use an arrow function.
+
+```jsx
+<BaggageStepper onChange={value => doSomething(value)} />
+```

--- a/packages/orbit-components/src/BaggageStepper/Stepper.stories.js
+++ b/packages/orbit-components/src/BaggageStepper/Stepper.stories.js
@@ -1,0 +1,65 @@
+// @flow
+import * as React from "react";
+import { action } from "@storybook/addon-actions";
+import { text, number, boolean } from "@storybook/addon-knobs";
+
+import BaggageStepper from "./index";
+
+export default {
+  title: "BaggageStepper",
+};
+
+export const Default = (): React.Node => {
+  const titleIncrement = text("Title increment", "Add a passenger");
+  const titleDecrement = text("Title decrement", "Remove a passenger");
+
+  return (
+    <BaggageStepper
+      titleIncrement={titleIncrement}
+      titleDecrement={titleDecrement}
+      onChange={action("onChange")}
+    />
+  );
+};
+
+Default.story = {
+  parameters: {
+    info: "Some description about this type of BaggageStepper in general.",
+  },
+};
+
+export const Playground = (): React.Node => {
+  const min = number("minValue", 1);
+  const max = number("maxValue", 10);
+  const step = number("step", 2);
+  const defaultValue = number("defaultValue", 4);
+  const name = text("Name", "name");
+  const disabled = boolean("disabled", false);
+  const selected = boolean("selected", false);
+  const dataTest = text("dataTest", "test");
+  const titleIncrement = text("Title increment", "Add a passenger");
+  const titleDecrement = text("Title decrement", "Remove a passenger");
+  return (
+    <BaggageStepper
+      defaultValue={defaultValue}
+      step={step}
+      name={name}
+      maxValue={max}
+      minValue={min}
+      selected={selected}
+      disabled={disabled}
+      dataTest={dataTest}
+      titleIncrement={titleIncrement}
+      titleDecrement={titleDecrement}
+      onChange={action("onChange")}
+      onFocus={action("onFocus")}
+      onBlur={action("onBlur")}
+    />
+  );
+};
+
+Playground.story = {
+  parameters: {
+    info: "Here you can try BaggageStepper component with additional functionality.",
+  },
+};

--- a/packages/orbit-components/src/BaggageStepper/Stepper/Button.js
+++ b/packages/orbit-components/src/BaggageStepper/Stepper/Button.js
@@ -1,0 +1,60 @@
+// @flow
+import * as React from "react";
+
+import { BUTTON_STATES } from "../../primitives/ButtonPrimitive/common/consts";
+import getBoxShadow from "./helpers/getBoxShadow";
+import getPadding from "../../primitives/ButtonPrimitive/common/getPadding";
+import useTheme from "../../hooks/useTheme";
+import type { Props as PrimitiveProps } from "../../primitives/ButtonPrimitive";
+import ButtonPrimitive from "../../primitives/ButtonPrimitive";
+import { ICON_SIZE, BUTTON_SIZE } from "./consts";
+
+type Props = {|
+  +selected?: boolean,
+  ...PrimitiveProps,
+|};
+
+const Button = ({
+  selected,
+  iconLeft,
+  iconRight,
+  disabled,
+  height = BUTTON_SIZE,
+  width = BUTTON_SIZE,
+  children,
+  ...props
+}: Props): React.Node => {
+  const theme = useTheme();
+  const onlyIcon = Boolean(iconLeft && !children);
+  const padding = getPadding(onlyIcon, iconRight, iconLeft, "small", theme);
+  const wrappedBoxShadow = state => getBoxShadow({ state, disabled, theme, selected });
+
+  const boxShadow = {
+    boxShadow: wrappedBoxShadow(BUTTON_STATES.DEFAULT),
+    boxShadowHover: wrappedBoxShadow(BUTTON_STATES.HOVER),
+    boxShadowActive: wrappedBoxShadow(BUTTON_STATES.ACTIVE),
+    boxShadowFocus: wrappedBoxShadow(BUTTON_STATES.FOCUS),
+  };
+
+  return (
+    <ButtonPrimitive
+      circled
+      contentAlign="center"
+      icons={{
+        width: ICON_SIZE,
+        height: ICON_SIZE,
+        foreground: selected ? theme.orbit.paletteWhite : theme.orbit.paletteInkNormal,
+      }}
+      background={selected ? theme.orbit.paletteBlueNormal : theme.orbit.paletteCloudDark}
+      iconLeft={iconLeft}
+      height={height}
+      width={width}
+      disabled={disabled}
+      padding={padding}
+      {...props}
+      {...boxShadow}
+    />
+  );
+};
+
+export default Button;

--- a/packages/orbit-components/src/BaggageStepper/Stepper/consts.js
+++ b/packages/orbit-components/src/BaggageStepper/Stepper/consts.js
@@ -1,0 +1,3 @@
+// @flow
+export const ICON_SIZE = "10px";
+export const BUTTON_SIZE = "20px";

--- a/packages/orbit-components/src/BaggageStepper/Stepper/helpers/getBoxShadow.js
+++ b/packages/orbit-components/src/BaggageStepper/Stepper/helpers/getBoxShadow.js
@@ -1,0 +1,28 @@
+// @flow
+import convertHexToRgba from "@kiwicom/orbit-design-tokens/lib/convertHexToRgba";
+
+import type { Theme } from "../../../defaultTheme";
+import { BUTTON_STATES } from "../../../primitives/ButtonPrimitive/common/consts";
+
+type Args = {|
+  state: string,
+  disabled?: boolean,
+  theme: Theme,
+  selected?: boolean,
+|};
+
+const getButtonBoxShadow = ({ state, disabled, theme, selected }: Args): string | null => {
+  if (disabled) return null;
+
+  if (state === BUTTON_STATES.FOCUS) {
+    return `0 0 0 2px ${
+      selected
+        ? convertHexToRgba(theme.orbit.paletteBlueNormal, 30)
+        : convertHexToRgba(theme.orbit.paletteInkLight, 30)
+    }}`;
+  }
+
+  return null;
+};
+
+export default getButtonBoxShadow;

--- a/packages/orbit-components/src/BaggageStepper/Stepper/index.d.ts
+++ b/packages/orbit-components/src/BaggageStepper/Stepper/index.d.ts
@@ -9,7 +9,6 @@ import { SharedProps, Event } from "../index";
 declare module "@kiwicom/orbit-components/lib/StepperStateless";
 
 type InputEvent = Common.Event<React.KeyboardEvent<HTMLInputElement>>;
-
 export interface Props extends SharedProps {
   readonly value?: number | string | (() => string);
   readonly disabledIncrement?: boolean;
@@ -18,6 +17,7 @@ export interface Props extends SharedProps {
   readonly onDecrement?: Event;
   readonly onIncrement?: Event;
   readonly onChange?: InputEvent;
+  readonly selected?: boolean;
 }
 
 declare const StepperStateless: React.FunctionComponent<Props>;

--- a/packages/orbit-components/src/BaggageStepper/Stepper/index.js
+++ b/packages/orbit-components/src/BaggageStepper/Stepper/index.js
@@ -1,0 +1,116 @@
+// @flow
+import * as React from "react";
+import styled, { css } from "styled-components";
+
+import Button from "./Button";
+import Minus from "../../icons/Minus";
+import Plus from "../../icons/Plus";
+import defaultTheme from "../../defaultTheme";
+import type { StateLessProps } from "./index.js.flow";
+
+const StyledStepper = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  flex: 1 1 auto;
+`;
+
+const StyledStepperInput = styled.input`
+  ${({ theme }) => css`
+    width: 100%;
+    height: 22px;
+    padding: 0;
+    border: 0;
+    font-size: ${theme.orbit.fontSizeTextLarge};
+    font-weight: ${theme.orbit.fontWeightBold};
+    color: ${theme.orbit.paletteInkNormal};
+    text-align: center;
+    min-width: 0;
+
+    &:disabled {
+      background-color: transparent;
+    }
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    &:focus {
+      outline: none;
+    }
+  `}
+`;
+
+// $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198
+StyledStepperInput.defaultProps = {
+  theme: defaultTheme,
+};
+
+const StepperStateless = ({
+  selected,
+  disabled,
+  dataTest,
+  value,
+  name,
+  minValue,
+  maxValue,
+  onKeyDown,
+  onBlur,
+  onFocus,
+  onIncrement,
+  onDecrement,
+  titleIncrement,
+  titleDecrement,
+  disabledIncrement,
+  disabledDecrement,
+}: StateLessProps): React.Node => {
+  return (
+    <StyledStepper data-test={dataTest}>
+      <Button
+        selected={selected}
+        disabled={
+          disabled || disabledDecrement || (typeof value === "number" && value <= +minValue)
+        }
+        iconLeft={<Minus />}
+        onClick={ev => {
+          if (onDecrement && !disabled) {
+            onDecrement(ev);
+          }
+        }}
+        title={titleDecrement}
+      />
+      <StyledStepperInput
+        name={name}
+        disabled={disabled}
+        type="text"
+        value={value || 0}
+        min={minValue}
+        max={maxValue}
+        onKeyDown={ev => {
+          if (onKeyDown) {
+            onKeyDown(ev);
+          }
+        }}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        readOnly
+      />
+      <Button
+        selected={selected}
+        disabled={
+          disabled || disabledIncrement || (typeof value === "number" && value >= +maxValue)
+        }
+        iconLeft={<Plus />}
+        onClick={ev => {
+          if (onIncrement && !disabled) {
+            onIncrement(ev);
+          }
+        }}
+        title={titleIncrement}
+      />
+    </StyledStepper>
+  );
+};
+
+export default StepperStateless;

--- a/packages/orbit-components/src/BaggageStepper/Stepper/index.js.flow
+++ b/packages/orbit-components/src/BaggageStepper/Stepper/index.js.flow
@@ -1,0 +1,24 @@
+// @flow
+import * as React from "react";
+
+import type { SharedProps } from "../index";
+
+export type StateLessProps = {|
+  ...SharedProps,
+  +value: number | string | (() => string),
+  +disabledIncrement?: boolean,
+  +disabledDecrement?: boolean,
+  +onKeyDown?: (ev: SyntheticKeyboardEvent<HTMLInputElement>) => void | Promise<any>,
+  +onDecrement?: (
+    ev: SyntheticEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement>,
+  ) => void | Promise<any>,
+  +onIncrement?: (
+    ev: SyntheticEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement>,
+  ) => void | Promise<any>,
+  +onChange?: (SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
+  +selected?: boolean,
+|};
+
+export type StepperStatelessType = React.ComponentType<StateLessProps>;
+
+declare export default StepperStatelessType;

--- a/packages/orbit-components/src/BaggageStepper/__tests__/index.test.js
+++ b/packages/orbit-components/src/BaggageStepper/__tests__/index.test.js
@@ -1,0 +1,78 @@
+// @flow
+import * as React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import BaggageStepper from "../Stepper";
+
+describe("BaggageStepper", () => {
+  it("should have expected DOM output", () => {
+    const defaultValue = 2;
+    const name = "name";
+    const maxValue = 100;
+    const minValue = 1;
+    const dataTest = "test";
+    const onIncrement = jest.fn();
+    const onDecrement = jest.fn();
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const onKeyDown = jest.fn();
+    const IncrementLabel = "Increment";
+    const DecrementLabel = "Decrement";
+
+    render(
+      <BaggageStepper
+        value={defaultValue}
+        name={name}
+        maxValue={maxValue}
+        minValue={minValue}
+        dataTest={dataTest}
+        onDecrement={onDecrement}
+        onIncrement={onIncrement}
+        onFocus={onFocus}
+        onKeyDown={onKeyDown}
+        onBlur={onBlur}
+        titleIncrement={IncrementLabel}
+        titleDecrement={DecrementLabel}
+      />,
+    );
+
+    const input = screen.getByRole("textbox");
+    expect(screen.getByTestId(dataTest)).toBeInTheDocument();
+
+    fireEvent.keyDown(input, { keyCode: 40 });
+    fireEvent.keyDown(input, { keyCode: 38 });
+    expect(onKeyDown).toHaveBeenCalledTimes(2);
+
+    userEvent.click(screen.getByLabelText(IncrementLabel));
+    expect(onIncrement).toHaveBeenCalled();
+    userEvent.click(screen.getByLabelText(DecrementLabel));
+    expect(onDecrement).toHaveBeenCalled();
+
+    // $FlowFixMe
+    userEvent.tab(input);
+    expect(onFocus).toHaveBeenCalled();
+    fireEvent.blur(input);
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it("should have increment button disabled, if value is equal to maxValue", () => {
+    render(<BaggageStepper value={10} maxValue={10} titleIncrement="Increment" />);
+    expect(screen.getByLabelText("Increment")).toBeDisabled();
+  });
+
+  it("should have decrement button disabled, if value is equal to minValue", () => {
+    render(<BaggageStepper value={0} minValue={0} titleDecrement="Decrement" />);
+    expect(screen.getByLabelText("Decrement")).toBeDisabled();
+  });
+
+  it("should have disabled decrement button via prop", () => {
+    render(<BaggageStepper disabledDecrement value={5} titleDecrement="Decrement" />);
+    expect(screen.getByLabelText("Decrement")).toBeDisabled();
+  });
+
+  it("should have disabled increment button via prop", () => {
+    render(<BaggageStepper disabledIncrement value={5} maxValue={10} titleIncrement="Increment" />);
+    expect(screen.getByLabelText("Increment")).toBeDisabled();
+  });
+});

--- a/packages/orbit-components/src/BaggageStepper/index.d.ts
+++ b/packages/orbit-components/src/BaggageStepper/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for @kiwicom/orbit-components
+// Project: http://github.com/kiwicom/orbit
+
+import * as React from "react";
+
+import * as Common from "../common/common";
+
+declare module "@kiwicom/orbit-components/lib/BaggageStepper";
+
+type Title = string | ((param?: any) => string);
+// InputEvent
+export type Event = Common.Event<React.SyntheticEvent<HTMLInputElement>>;
+
+export interface SharedProps extends Common.Global {
+  readonly name?: string;
+  readonly disabled?: boolean;
+  readonly maxValue?: number;
+  readonly minValue?: number;
+  // Deviation from other BaggageStepper properties
+  readonly titleIncrement?: Title;
+  readonly titleDecrement?: Title;
+  // Deviation from common event format onChange
+  readonly onFocus?: Event;
+  readonly onBlur?: Event;
+}
+
+export interface Props extends SharedProps {
+  readonly defaultValue?: number;
+  readonly step?: number;
+  readonly selected?: boolean;
+  readonly onChange?: (value: number) => void | Promise<void>;
+}
+
+declare const BaggageStepper: React.FunctionComponent<Props>;
+
+export { BaggageStepper, BaggageStepper as default };

--- a/packages/orbit-components/src/BaggageStepper/index.js
+++ b/packages/orbit-components/src/BaggageStepper/index.js
@@ -1,0 +1,67 @@
+// @flow
+import * as React from "react";
+
+import Stepper from "./Stepper";
+import validateIncrement from "../utils/validateIncrement";
+import validateDecrement from "../utils/validateDecrement";
+import useStateWithCallback from "../hooks/useStateWithCallback";
+
+import type { Props } from "./index";
+
+const BaggageStepper = ({ onChange, defaultValue = 0, ...props }: Props): React.Node => {
+  const [value, setValue] = useStateWithCallback<number>(defaultValue, onChange);
+
+  const incrementCounter = () => {
+    const { maxValue = Number.POSITIVE_INFINITY, step = 1 } = props;
+
+    setValue(validateIncrement({ value, maxValue, step }));
+  };
+
+  const decrementCounter = () => {
+    const { minValue = Number.NEGATIVE_INFINITY, step = 1 } = props;
+
+    setValue(validateDecrement({ value, minValue, step }));
+  };
+
+  const handleKeyDown = (ev: SyntheticKeyboardEvent<HTMLInputElement>) => {
+    if (ev.keyCode === 40) {
+      ev.preventDefault();
+      decrementCounter();
+    }
+    if (ev.keyCode === 38) {
+      ev.preventDefault();
+      incrementCounter();
+    }
+  };
+
+  const {
+    onBlur,
+    onFocus,
+    disabled,
+    name,
+    dataTest,
+    minValue,
+    maxValue,
+    titleIncrement,
+    titleDecrement,
+  } = props;
+  return (
+    <Stepper
+      disabled={disabled}
+      dataTest={dataTest}
+      value={value}
+      name={name}
+      minValue={minValue}
+      maxValue={maxValue}
+      onKeyDown={handleKeyDown}
+      onBlur={onBlur}
+      onFocus={onFocus}
+      onIncrement={incrementCounter}
+      onDecrement={decrementCounter}
+      titleIncrement={titleIncrement}
+      titleDecrement={titleDecrement}
+    />
+  );
+};
+
+export default BaggageStepper;

--- a/packages/orbit-components/src/BaggageStepper/index.js.flow
+++ b/packages/orbit-components/src/BaggageStepper/index.js.flow
@@ -1,0 +1,29 @@
+// @flow
+/*
+  DOCUMENTATION: https://orbit.kiwi/components/stepper/
+*/
+import * as React from "react";
+
+import type { Globals } from "../common/common.js.flow";
+
+export type SharedProps = {|
+  ...Globals,
+  +name?: string,
+  +disabled?: boolean,
+  +selected?: boolean,
+  +maxValue?: number,
+  +minValue?: number,
+  +titleIncrement?: string | (any => string),
+  +titleDecrement?: string | (any => string),
+  +onChange?: (value: number) => void | Promise<any>,
+  +onFocus?: (ev: SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
+  +onBlur?: (ev: SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,
+|};
+
+export type Props = {|
+  ...SharedProps,
+  +defaultValue?: number,
+  +step?: number,
+|};
+
+declare export default React.ComponentType<Props>;


### PR DESCRIPTION
`BaggageStepper` for Baggage. Core functionality is copied from the original `Stepper`, adjusted with custom button via primitive, because of the size/box-shadow

dev: [ORBIT-1760](https://jira.kiwi.com/browse/ORBIT-1760)
design: [ORBIT-1745](https://jira.kiwi.com/browse/ORBIT-1745) 
slack discussion: [here](https://skypicker.slack.com/archives/CAMS40F7B/p1619443241298700?thread_ts=1618819835.251800&cid=CAMS40F7B)

 Storybook: https://orbit-feat-kulibabamstepper.surge.sh