### PR TITLE
fix(ButtonLink): pass size prop to icons

### DIFF
--- a/packages/orbit-components/src/ButtonLink/index.js
+++ b/packages/orbit-components/src/ButtonLink/index.js
@@ -16,8 +16,8 @@ const ButtonLink: React.AbstractComponent<Props, HTMLButtonElement> = React.forw
   HTMLButtonElement,
 >(({ type = TYPES.PRIMARY, size, compact = false, ...props }, ref) => {
   const theme = useTheme();
-  const propsWithTheme = { theme, ...props };
-  const commonProps = getButtonLinkCommonProps({ ...propsWithTheme, size, compact });
+  const propsWithTheme = { theme, size, ...props };
+  const commonProps = getButtonLinkCommonProps({ ...propsWithTheme, compact });
   const buttonLinkStyles = getButtonLinkStyles({ type, theme, compact });
   const icons = getIconContainer({
     ...propsWithTheme,


### PR DESCRIPTION
[bug](https://monosnap.com/file/asMoM3jcJUIUfBD08RYa3Z8A5A5sSg), also [bug](https://monosnap.com/file/6IZ9ANOKVOAIF7IVLqOBqOM7juk3Mu)
 Storybook: https://orbit-fix-icon-size.surge.sh