### PR TITLE
revert(Modal): revert CLS changes

### DIFF
--- a/packages/orbit-components/src/Modal/index.js
+++ b/packages/orbit-components/src/Modal/index.js
@@ -70,7 +70,6 @@ const ModalWrapper = styled.div`
   display: flex;
   align-items: flex-start;
   margin: 0 auto;
-
   position: fixed;
   width: 100%;
   border-top-left-radius: ${({ isMobileFullPage }) =>
@@ -78,10 +77,7 @@ const ModalWrapper = styled.div`
   border-top-right-radius: ${({ isMobileFullPage }) =>
     !isMobileFullPage && "12px"}; // TODO: create token
   transition: ${transition(["transform"], "normal", "ease-in-out")};
-  transform: translateY(
-    ${({ loaded, isMobileFullPage }) => (loaded ? !isMobileFullPage && "32px" : "100%")}
-  );
-
+  top: ${({ loaded, isMobileFullPage }) => (loaded ? !isMobileFullPage && "32px" : "100%")};
   ${onlyIE(css`
     /* IE flex bug, the content won't be centered if there is not 'height' property
     https://github.com/philipwalton/flexbugs/issues/231 */
@@ -90,7 +86,7 @@ const ModalWrapper = styled.div`
 
   ${media.largeMobile(css`
     position: relative;
-    transform: none;
+    top: 0;
     max-width: ${getSizeToken};
     align-items: center;
   `)};


### PR DESCRIPTION
There is a bug with the Modal fixed footer, got it from QA, they need to update the orbit version, so we need to release ASAP, there is also a separate icon bug, which was already fixed, that should be asap released. Did not find a quick solution for fixing that. I mean, it's Modal and even a small change here can lead to some bug :D 

CLS is an important thing ofc, but it can be fixed later. @silvenon wdy? if you can fix that quickly, use this PR, otherwise, we can create ticket for CLS and check more properly issues in all components, not just Modal. 


 Storybook: https://orbit-fix-modal-fixed-footer.surge.sh