### PR TITLE
chore: remove unnecessary TypeScript config file

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "jsx": "react"
-  }
-}


### PR DESCRIPTION
It causes an error and doesn't appear to help anything. It was accidentally merged in #2914.

 Storybook: https://orbit-docs-remove-tsconfig.surge.sh