### PR TITLE
ci: add Figma token

### DIFF
--- a/.github/workflows/lint-prose.yml
+++ b/.github/workflows/lint-prose.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@master
       #
       - name: Vale
-        uses: errata-ai/vale-action@v1.3.0
+        uses: errata-ai/vale-action@v1.4.1
         with:
           files: '["docs/src/documentation", "docs/src/snippets"]'
           onlyAnnotateModifiedLines: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ env: # Set environment variables for every job and step in this workflow
   CLICOLOR: "1" # Enable colors for *NIX commands
   PY_COLORS: "1" # Enable colors for Python-based utilities
   FORCE_COLOR: "1" # Force colors in the terminal
+  FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
 
 jobs:
   build:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -12,6 +12,7 @@ env: # Set environment variables for every job and step in this workflow
   CLICOLOR: "1" # Enable colors for *NIX commands
   PY_COLORS: "1" # Enable colors for Python-based utilities
   FORCE_COLOR: "1" # Force colors in the terminal
+  FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
 
 jobs:
   build_test:


### PR DESCRIPTION
This should fix the problem of warnings in CI builds.

 Storybook: https://orbit-ci-figma-token.surge.sh