### PR TITLE
ci: improve speed of size GitHub workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "orbit-design-tokens": "yarn workspace @kiwicom/orbit-design-tokens",
     "orbit-kiwi": "yarn workspace @kiwicom/orbit.kiwi",
     "build": "yarn orbit-design-tokens build && yarn orbit-components build",
-    "build-ci": "lerna bootstrap && yarn build",
+    "build-ci": "lerna bootstrap && lerna run --scope @kiwicom/orbit-components build:size",
     "postinstall": "lerna run postinstall --stream",
     "prettier:test": "prettier --check '**/*.md'",
     "eslint:ci": "eslint-config-prettier index.js index.ts && eslint . --report-unused-disable-directives",

--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -9,6 +9,7 @@
     "prepublishOnly": "yarn build && pinst --disable",
     "postpublish": "pinst --enable",
     "build": "yarn clean && yarn build:icons && yarn build:iconFont && yarn build:typeFiles && yarn build:lib && yarn build:module && yarn build:umd && yarn build:storybook",
+    "build:size": "yarn clean && yarn build:icons && yarn build:lib",
     "babel-base": "babel src --ignore **/*.stories.js,**/*.test.js,**/*.storyshot.js,**/__examples__/*.js,**/examples.js",
     "build:lib": "yarn babel-base --out-dir lib && yarn copy:lib",
     "build:module": "yarn babel-base --env-name esm --out-dir es && yarn copy:module",


### PR DESCRIPTION
This builds strictly what is necessary for measuring size, seems to reduce the duration by about 4m.

 Storybook: https://orbit-ci-faster-compressed-size.surge.sh