### PR TITLE
feat(Modal): add disableAnimation prop

### DIFF
--- a/packages/orbit-components/src/Modal/README.md
+++ b/packages/orbit-components/src/Modal/README.md
@@ -34,6 +34,7 @@ Table below contains all types of the props available in the Modal component.
 | preventOverlayClose | `boolean`                  |            | Property for preventing closing of modal when there is a action on overlay. BEWARE: This should be used only in very specials edge-cases! It breaks user experience.                                 |
 | hasCloseButton      | `boolean`                  | `true`     | Defines whether the Modal displays a close button. If you disable this, we recommend adding some kind of an alternative.                                                                             |
 | autoFocus           | `boolean`                  | `true`     | The autofocus attribute of the Modal, see [this docs](https://www.w3schools.com/tags/att_autofocus.asp).                                                                                             |
+| disableAnimation    | `boolean`                  | `false`    | Defines whether the Modal performs the slide in animation on mobile. If you want to improve your [CLS](https://web.dev/cls/) score, you might want to set this to `true`.                            |
 
 ### Modal enum
 

--- a/packages/orbit-components/src/Modal/index.d.ts
+++ b/packages/orbit-components/src/Modal/index.d.ts
@@ -21,6 +21,7 @@ export interface Props extends Common.Global {
   readonly isMobileFullPage?: boolean;
   readonly preventOverlayClose?: boolean;
   readonly hasCloseButton?: boolean;
+  readonly disableAnimation?: boolean;
 }
 
 type Instance = {

--- a/packages/orbit-components/src/Modal/index.js
+++ b/packages/orbit-components/src/Modal/index.js
@@ -76,8 +76,15 @@ const ModalWrapper = styled.div`
     !isMobileFullPage && "12px"}; // TODO: create token
   border-top-right-radius: ${({ isMobileFullPage }) =>
     !isMobileFullPage && "12px"}; // TODO: create token
-  transition: ${transition(["transform"], "normal", "ease-in-out")};
-  top: ${({ loaded, isMobileFullPage }) => (loaded ? !isMobileFullPage && "32px" : "100%")};
+  ${({ disableAnimation, loaded, isMobileFullPage }) =>
+    disableAnimation
+      ? css`
+          top: ${!isMobileFullPage && "32px"};
+        `
+      : css`
+          transition: ${transition(["top"], "normal", "ease-in-out")};
+          top: ${loaded ? !isMobileFullPage && "32px" : "100%"};
+        `}
   ${onlyIE(css`
     /* IE flex bug, the content won't be centered if there is not 'height' property
     https://github.com/philipwalton/flexbugs/issues/231 */
@@ -339,6 +346,7 @@ const Modal: React.AbstractComponent<Props, Instance> = React.forwardRef<Props, 
       isMobileFullPage = false,
       preventOverlayClose = false,
       hasCloseButton = true,
+      disableAnimation = false,
       dataTest,
     }: Props,
     ref,
@@ -471,11 +479,6 @@ const Modal: React.AbstractComponent<Props, Instance> = React.forwardRef<Props, 
       keyboardHandler(event);
     };
 
-    const handleResize = React.useCallback(() => {
-      setDimensions();
-      decideFixedFooter();
-    }, []);
-
     const handleClickOutside = (event: MouseEvent) => {
       const clickedOutside =
         onClose &&
@@ -590,21 +593,38 @@ const Modal: React.AbstractComponent<Props, Instance> = React.forwardRef<Props, 
       modalContent,
     }));
 
+    // eslint-disable-next-line consistent-return
     React.useEffect(() => {
-      const timer: TimeoutID = setTimeout(() => {
-        setLoaded(true);
+      if (disableAnimation) {
         decideFixedFooter();
         setDimensions();
         setFirstFocus();
-      }, 15);
+      } else {
+        const timer: TimeoutID = setTimeout(() => {
+          setLoaded(true);
+          decideFixedFooter();
+          setDimensions();
+          setFirstFocus();
+        }, 15);
 
+        return () => {
+          clearTimeout(timer);
+        };
+      }
+      // the Modal can only transition in on mount
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    React.useEffect(() => {
+      const handleResize = () => {
+        setDimensions();
+        decideFixedFooter();
+      };
       window.addEventListener("resize", handleResize);
-
       return () => {
-        clearTimeout(timer);
         window.removeEventListener("resize", handleResize);
       };
-    }, [handleResize]);
+    }, []);
 
     React.useEffect(() => {
       if (children !== prevChildren) {
@@ -635,6 +655,7 @@ const Modal: React.AbstractComponent<Props, Instance> = React.forwardRef<Props, 
           fixedFooter={fixedFooter}
           id={modalID}
           isMobileFullPage={isMobileFullPage}
+          disableAnimation={disableAnimation}
         >
           <ModalWrapperContent
             size={size}

--- a/packages/orbit-components/src/Modal/index.js.flow
+++ b/packages/orbit-components/src/Modal/index.js.flow
@@ -37,6 +37,7 @@ export type Props = {|
   +isMobileFullPage?: boolean,
   +preventOverlayClose?: boolean,
   +hasCloseButton?: boolean,
+  +disableAnimation?: boolean,
   ...Globals,
 |};
 


### PR DESCRIPTION
This prop is an escape hatch because Modal animation is currently implemented by transitioning the `top` CSS property, which results in a bad Cumulative Layout Shift score.

I wasn't sure whether to document it, as it's an escape hatch which we'll probably get rid of.

- [the original suggestion](https://skypicker.slack.com/archives/C9NJQS970/p1619528876094700?thread_ts=1619527814.093300&cid=C9NJQS970)

 Storybook: https://orbit-feat-modal-disable-animation.surge.sh