### PR TITLE
docs(sandbox): fix components with Portals inside sandbox

### DIFF
--- a/docs/src/__examples__/Dialog/CLOSING.tsx
+++ b/docs/src/__examples__/Dialog/CLOSING.tsx
@@ -10,6 +10,7 @@ export default {
           <Dialog
             title="Accept notifications?"
             description="Stay up to date with all travel possibilities."
+            insidePortal={false}
             primaryAction={
               <Button
                 onClick={() => {

--- a/docs/src/__examples__/Dialog/CLOSING.tsx
+++ b/docs/src/__examples__/Dialog/CLOSING.tsx
@@ -10,7 +10,7 @@ export default {
           <Dialog
             title="Accept notifications?"
             description="Stay up to date with all travel possibilities."
-            insidePortal={false}
+            renderInPortal={false}
             primaryAction={
               <Button
                 onClick={() => {

--- a/docs/src/__examples__/Dialog/DEFAULT.tsx
+++ b/docs/src/__examples__/Dialog/DEFAULT.tsx
@@ -10,6 +10,7 @@ export default {
           <Dialog
             title="Accept notifications?"
             description="Stay up to date with all travel possibilities."
+            insidePortal={false}
             primaryAction={
               <Button
                 onClick={() => {

--- a/docs/src/__examples__/Dialog/DEFAULT.tsx
+++ b/docs/src/__examples__/Dialog/DEFAULT.tsx
@@ -10,7 +10,7 @@ export default {
           <Dialog
             title="Accept notifications?"
             description="Stay up to date with all travel possibilities."
-            insidePortal={false}
+            renderInPortal={false}
             primaryAction={
               <Button
                 onClick={() => {

--- a/docs/src/__examples__/Dialog/DESTRUCTIVE.tsx
+++ b/docs/src/__examples__/Dialog/DESTRUCTIVE.tsx
@@ -10,6 +10,7 @@ export default {
           <Dialog
             title="Remove traveler?"
             description="You can't undo this."
+            insidePortal={false}
             primaryAction={
               <Button
                 onClick={() => {

--- a/docs/src/__examples__/Dialog/DESTRUCTIVE.tsx
+++ b/docs/src/__examples__/Dialog/DESTRUCTIVE.tsx
@@ -10,7 +10,7 @@ export default {
           <Dialog
             title="Remove traveler?"
             description="You can't undo this."
-            insidePortal={false}
+            renderInPortal={false}
             primaryAction={
               <Button
                 onClick={() => {

--- a/docs/src/__examples__/Dialog/ILLUSTRATION.tsx
+++ b/docs/src/__examples__/Dialog/ILLUSTRATION.tsx
@@ -11,6 +11,7 @@ export default {
             title="Add meal?"
             description="Enjoy a tasty meal on your journey."
             illustration={<Illustration name="Meal" alt="" />}
+            insidePortal={false}
             primaryAction={
               <Button
                 onClick={() => {

--- a/docs/src/__examples__/Dialog/ILLUSTRATION.tsx
+++ b/docs/src/__examples__/Dialog/ILLUSTRATION.tsx
@@ -11,7 +11,7 @@ export default {
             title="Add meal?"
             description="Enjoy a tasty meal on your journey."
             illustration={<Illustration name="Meal" alt="" />}
-            insidePortal={false}
+            renderInPortal={false}
             primaryAction={
               <Button
                 onClick={() => {

--- a/docs/src/__examples__/Popover/ACTIONS.tsx
+++ b/docs/src/__examples__/Popover/ACTIONS.tsx
@@ -10,6 +10,7 @@ export default {
     const [is4star, setIs4star] = React.useState(true);
     return (
       <Popover
+        renderInPortal={false}
         actions={
           <Stack direction="row" justify="end">
             <Button type="primarySubtle" onClick={() => setIsOpen(false)}>

--- a/docs/src/__examples__/Popover/ALIGN.tsx
+++ b/docs/src/__examples__/Popover/ALIGN.tsx
@@ -10,6 +10,7 @@ export default {
           Start
         </Heading>
         <Popover
+          renderInPortal={false}
           preferredAlign="start"
           content={
             <Stack spacing="small">
@@ -40,6 +41,7 @@ export default {
           Center
         </Heading>
         <Popover
+          renderInPortal={false}
           preferredAlign="center"
           content={
             <Stack spacing="small">
@@ -70,6 +72,7 @@ export default {
           End
         </Heading>
         <Popover
+          renderInPortal={false}
           preferredAlign="end"
           content={
             <Stack spacing="small">

--- a/docs/src/__examples__/Popover/CONTROLLED.tsx
+++ b/docs/src/__examples__/Popover/CONTROLLED.tsx
@@ -8,6 +8,7 @@ export default {
     return (
       <Stack spacing="XXLarge">
         <Popover
+          renderInPortal={false}
           opened={isOpen}
           content={
             <Stack spacing="small">

--- a/docs/src/__examples__/Popover/DEFAULT.tsx
+++ b/docs/src/__examples__/Popover/DEFAULT.tsx
@@ -5,6 +5,7 @@ import { QuestionCircle } from "@kiwicom/orbit-components/icons";
 export default {
   Example: () => (
     <Popover
+      renderInPortal={false}
       content={
         <Stack spacing="small">
           <ButtonLink

--- a/docs/src/__examples__/Popover/OTHER_CONTENT.tsx
+++ b/docs/src/__examples__/Popover/OTHER_CONTENT.tsx
@@ -9,6 +9,7 @@ export default {
     const [is4star, setIs4star] = React.useState(true);
     return (
       <Popover
+        renderInPortal={false}
         content={
           <Stack spacing="small">
             <ListChoice

--- a/docs/src/__examples__/Popover/OVERLAPPING.tsx
+++ b/docs/src/__examples__/Popover/OVERLAPPING.tsx
@@ -9,6 +9,7 @@ export default {
     return (
       <Stack>
         <Popover
+          renderInPortal={false}
           overlapped
           content={
             <Stack>

--- a/docs/src/__examples__/Popover/PASSENGERS.tsx
+++ b/docs/src/__examples__/Popover/PASSENGERS.tsx
@@ -9,6 +9,7 @@ export default {
     return (
       <Stack>
         <Popover
+          renderInPortal={false}
           content={
             <Stack>
               <Stack align="center">

--- a/docs/src/__examples__/Popover/POSITION.tsx
+++ b/docs/src/__examples__/Popover/POSITION.tsx
@@ -10,6 +10,7 @@ export default {
           Bottom
         </Heading>
         <Popover
+          renderInPortal={false}
           preferredPosition="bottom"
           content={
             <Stack spacing="small">
@@ -40,6 +41,7 @@ export default {
           Top
         </Heading>
         <Popover
+          renderInPortal={false}
           preferredPosition="top"
           content={
             <Stack spacing="small">

--- a/docs/src/__examples__/Popover/TRIGGER.tsx
+++ b/docs/src/__examples__/Popover/TRIGGER.tsx
@@ -5,6 +5,7 @@ import { ChevronDown } from "@kiwicom/orbit-components/icons";
 export default {
   Example: () => (
     <Popover
+      renderInPortal={false}
       content={
         <Stack spacing="small">
           <ButtonLink

--- a/docs/src/__examples__/Popover/WIDTH.tsx
+++ b/docs/src/__examples__/Popover/WIDTH.tsx
@@ -6,6 +6,7 @@ export default {
   Example: () => (
     <Stack>
       <Popover
+        renderInPortal={false}
         content={
           <Stack spacing="small">
             <ButtonLink
@@ -30,6 +31,7 @@ export default {
         <Button circled title="Help" iconLeft={<QuestionCircle />} />
       </Popover>
       <Popover
+        renderInPortal={false}
         width="400px"
         content={
           <Stack spacing="small">

--- a/docs/src/__examples__/Tooltip/ALIGN.tsx
+++ b/docs/src/__examples__/Tooltip/ALIGN.tsx
@@ -9,7 +9,7 @@ export default {
           Start
         </Heading>
         <Tooltip
-          insidePortal={false}
+          renderInPortal={false}
           preferredAlign="start"
           content={<Text>Select a flight before continuing.</Text>}
         >
@@ -23,7 +23,7 @@ export default {
           Center
         </Heading>
         <Tooltip
-          insidePortal={false}
+          renderInPortal={false}
           preferredAlign="center"
           content={<Text>Select a flight before continuing.</Text>}
         >
@@ -37,7 +37,7 @@ export default {
           End
         </Heading>
         <Tooltip
-          insidePortal={false}
+          renderInPortal={false}
           preferredAlign="end"
           content={<Text>Select a flight before continuing.</Text>}
         >

--- a/docs/src/__examples__/Tooltip/ALIGN.tsx
+++ b/docs/src/__examples__/Tooltip/ALIGN.tsx
@@ -8,7 +8,11 @@ export default {
         <Heading type="title3" as="h4">
           Start
         </Heading>
-        <Tooltip preferredAlign="start" content={<Text>Select a flight before continuing.</Text>}>
+        <Tooltip
+          insidePortal={false}
+          preferredAlign="start"
+          content={<Text>Select a flight before continuing.</Text>}
+        >
           <Button size="large" disabled>
             Book
           </Button>
@@ -18,7 +22,11 @@ export default {
         <Heading type="title3" as="h4">
           Center
         </Heading>
-        <Tooltip preferredAlign="center" content={<Text>Select a flight before continuing.</Text>}>
+        <Tooltip
+          insidePortal={false}
+          preferredAlign="center"
+          content={<Text>Select a flight before continuing.</Text>}
+        >
           <Button size="large" disabled>
             Book
           </Button>
@@ -28,7 +36,11 @@ export default {
         <Heading type="title3" as="h4">
           End
         </Heading>
-        <Tooltip preferredAlign="end" content={<Text>Select a flight before continuing.</Text>}>
+        <Tooltip
+          insidePortal={false}
+          preferredAlign="end"
+          content={<Text>Select a flight before continuing.</Text>}
+        >
           <Button size="large" disabled>
             Book
           </Button>

--- a/docs/src/__examples__/Tooltip/DEFAULT.tsx
+++ b/docs/src/__examples__/Tooltip/DEFAULT.tsx
@@ -3,7 +3,7 @@ import { Button, Text, Tooltip } from "@kiwicom/orbit-components";
 
 export default {
   Example: () => (
-    <Tooltip insidePortal={false} content={<Text>Select a flight before continuing.</Text>}>
+    <Tooltip renderInPortal={false} content={<Text>Select a flight before continuing.</Text>}>
       <Button disabled>Book</Button>
     </Tooltip>
   ),

--- a/docs/src/__examples__/Tooltip/DEFAULT.tsx
+++ b/docs/src/__examples__/Tooltip/DEFAULT.tsx
@@ -3,7 +3,7 @@ import { Button, Text, Tooltip } from "@kiwicom/orbit-components";
 
 export default {
   Example: () => (
-    <Tooltip content={<Text>Select a flight before continuing.</Text>}>
+    <Tooltip insidePortal={false} content={<Text>Select a flight before continuing.</Text>}>
       <Button disabled>Book</Button>
     </Tooltip>
   ),

--- a/docs/src/__examples__/Tooltip/INDICATION.tsx
+++ b/docs/src/__examples__/Tooltip/INDICATION.tsx
@@ -8,7 +8,7 @@ export default {
       <Text>
         If you&apos;re building a travel app, you should give{" "}
         <Tooltip
-          insidePortal={false}
+          renderInPortal={false}
           content={
             <Stack>
               <Heading inverted as="h3" type="title3">
@@ -25,7 +25,7 @@ export default {
       <Alert icon={<CheckCircle />} type="success">
         If you&apos;re building a travel app, you should give{" "}
         <Tooltip
-          insidePortal={false}
+          renderInPortal={false}
           content={
             <Stack>
               <Heading inverted as="h3" type="title3">
@@ -41,7 +41,7 @@ export default {
       </Alert>
       <Alert icon={<Visa />} type="warning">
         You{" "}
-        <Tooltip insidePortal={false} content={<Text>Check with your embassy.</Text>}>
+        <Tooltip renderInPortal={false} content={<Text>Check with your embassy.</Text>}>
           <Text>may need a visa</Text>
         </Tooltip>{" "}
         for your trip.
@@ -50,7 +50,7 @@ export default {
         The following text has a tooltip:{" "}
         <Tooltip
           removeUnderlinedText
-          insidePortal={false}
+          renderInPortal={false}
           content={
             <Stack>
               <Heading inverted as="h3" type="title3">

--- a/docs/src/__examples__/Tooltip/INDICATION.tsx
+++ b/docs/src/__examples__/Tooltip/INDICATION.tsx
@@ -8,6 +8,7 @@ export default {
       <Text>
         If you&apos;re building a travel app, you should give{" "}
         <Tooltip
+          insidePortal={false}
           content={
             <Stack>
               <Heading inverted as="h3" type="title3">
@@ -24,6 +25,7 @@ export default {
       <Alert icon={<CheckCircle />} type="success">
         If you&apos;re building a travel app, you should give{" "}
         <Tooltip
+          insidePortal={false}
           content={
             <Stack>
               <Heading inverted as="h3" type="title3">
@@ -39,7 +41,7 @@ export default {
       </Alert>
       <Alert icon={<Visa />} type="warning">
         You{" "}
-        <Tooltip content={<Text>Check with your embassy.</Text>}>
+        <Tooltip insidePortal={false} content={<Text>Check with your embassy.</Text>}>
           <Text>may need a visa</Text>
         </Tooltip>{" "}
         for your trip.
@@ -48,6 +50,7 @@ export default {
         The following text has a tooltip:{" "}
         <Tooltip
           removeUnderlinedText
+          insidePortal={false}
           content={
             <Stack>
               <Heading inverted as="h3" type="title3">

--- a/docs/src/__examples__/Tooltip/OTHER_CONTENT.tsx
+++ b/docs/src/__examples__/Tooltip/OTHER_CONTENT.tsx
@@ -6,6 +6,7 @@ export default {
     <Text>
       If you&apos;re building a travel app, you should give{" "}
       <Tooltip
+        insidePortal={false}
         content={
           <Stack>
             <img

--- a/docs/src/__examples__/Tooltip/OTHER_CONTENT.tsx
+++ b/docs/src/__examples__/Tooltip/OTHER_CONTENT.tsx
@@ -6,7 +6,7 @@ export default {
     <Text>
       If you&apos;re building a travel app, you should give{" "}
       <Tooltip
-        insidePortal={false}
+        renderInPortal={false}
         content={
           <Stack>
             <img

--- a/docs/src/__examples__/Tooltip/POSITION.tsx
+++ b/docs/src/__examples__/Tooltip/POSITION.tsx
@@ -8,7 +8,7 @@ export default {
         <Heading type="title3" as="h4">
           Right
         </Heading>
-        <Tooltip content={<Text>Select a flight before continuing.</Text>}>
+        <Tooltip insidePortal={false} content={<Text>Select a flight before continuing.</Text>}>
           <Button disabled>Book</Button>
         </Tooltip>
       </Stack>
@@ -16,7 +16,11 @@ export default {
         <Heading type="title3" as="h4">
           Left
         </Heading>
-        <Tooltip preferredPosition="left" content={<Text>Select a flight before continuing.</Text>}>
+        <Tooltip
+          insidePortal={false}
+          preferredPosition="left"
+          content={<Text>Select a flight before continuing.</Text>}
+        >
           <Button disabled>Book</Button>
         </Tooltip>
       </Stack>
@@ -25,6 +29,7 @@ export default {
           Bottom
         </Heading>
         <Tooltip
+          insidePortal={false}
           preferredPosition="bottom"
           content={<Text>Select a flight before continuing.</Text>}
         >
@@ -35,7 +40,11 @@ export default {
         <Heading type="title3" as="h4">
           Top
         </Heading>
-        <Tooltip preferredPosition="top" content={<Text>Select a flight before continuing.</Text>}>
+        <Tooltip
+          insidePortal={false}
+          preferredPosition="top"
+          content={<Text>Select a flight before continuing.</Text>}
+        >
           <Button disabled>Book</Button>
         </Tooltip>
       </Stack>

--- a/docs/src/__examples__/Tooltip/POSITION.tsx
+++ b/docs/src/__examples__/Tooltip/POSITION.tsx
@@ -8,7 +8,7 @@ export default {
         <Heading type="title3" as="h4">
           Right
         </Heading>
-        <Tooltip insidePortal={false} content={<Text>Select a flight before continuing.</Text>}>
+        <Tooltip renderInPortal={false} content={<Text>Select a flight before continuing.</Text>}>
           <Button disabled>Book</Button>
         </Tooltip>
       </Stack>
@@ -17,7 +17,7 @@ export default {
           Left
         </Heading>
         <Tooltip
-          insidePortal={false}
+          renderInPortal={false}
           preferredPosition="left"
           content={<Text>Select a flight before continuing.</Text>}
         >
@@ -29,7 +29,7 @@ export default {
           Bottom
         </Heading>
         <Tooltip
-          insidePortal={false}
+          renderInPortal={false}
           preferredPosition="bottom"
           content={<Text>Select a flight before continuing.</Text>}
         >
@@ -41,7 +41,7 @@ export default {
           Top
         </Heading>
         <Tooltip
-          insidePortal={false}
+          renderInPortal={false}
           preferredPosition="top"
           content={<Text>Select a flight before continuing.</Text>}
         >

--- a/docs/src/__examples__/Tooltip/SIZE.tsx
+++ b/docs/src/__examples__/Tooltip/SIZE.tsx
@@ -5,7 +5,7 @@ export default {
   Example: () => (
     <Stack direction="column">
       <Tooltip
-        insidePortal={false}
+        renderInPortal={false}
         size="small"
         content={
           <Text>
@@ -17,7 +17,7 @@ export default {
         <Button disabled>Book</Button>
       </Tooltip>
       <Tooltip
-        insidePortal={false}
+        renderInPortal={false}
         size="medium"
         content={
           <Text>

--- a/docs/src/__examples__/Tooltip/SIZE.tsx
+++ b/docs/src/__examples__/Tooltip/SIZE.tsx
@@ -5,6 +5,7 @@ export default {
   Example: () => (
     <Stack direction="column">
       <Tooltip
+        insidePortal={false}
         size="small"
         content={
           <Text>
@@ -16,6 +17,7 @@ export default {
         <Button disabled>Book</Button>
       </Tooltip>
       <Tooltip
+        insidePortal={false}
         size="medium"
         content={
           <Text>

--- a/packages/orbit-components/src/Dialog/README.md
+++ b/packages/orbit-components/src/Dialog/README.md
@@ -22,6 +22,7 @@ Table below contains all types of the props available in Dialog component.
 | Name              | Type                    | Description                                                                                          |
 | :---------------- | :---------------------- | :--------------------------------------------------------------------------------------------------- |
 | dataTest          | `string`                | Optional prop for testing purposes.                                                                  |
+| insidePortal      | `boolean`               | Optional prop, if set to `false` component is not rendered inside Portal, default is `true`          |
 | description       | `React.Node`            | Optional description of the main action that Dialog performs.                                        |
 | illustration      | `React.Node`            | Optional illustration of the Dialog.                                                                 |
 | **primaryAction** | `React.Node`            | Primary and required action that user can do with the Dialog.                                        |

--- a/packages/orbit-components/src/Dialog/README.md
+++ b/packages/orbit-components/src/Dialog/README.md
@@ -19,13 +19,13 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in Dialog component.
 
-| Name              | Type                    | Description                                                                                          |
-| :---------------- | :---------------------- | :--------------------------------------------------------------------------------------------------- |
-| dataTest          | `string`                | Optional prop for testing purposes.                                                                  |
-| insidePortal      | `boolean`               | Optional prop, if set to `false` component is not rendered inside Portal, default is `true`          |
-| description       | `React.Node`            | Optional description of the main action that Dialog performs.                                        |
-| illustration      | `React.Node`            | Optional illustration of the Dialog.                                                                 |
-| **primaryAction** | `React.Node`            | Primary and required action that user can do with the Dialog.                                        |
-| secondaryAction   | `React.Node`            | Optional, secondary action that user can perform - possibility to close the Dialog most of the time. |
-| onClose           | `() => void \| Promise` | The title of the Dialog - preferably the purpose of the main action.                                 |
-| **title**         | `React.Node`            | The title of the Dialog - preferably the purpose of the main action.                                 |
+| Name              | Type                    | Description                                                                                            |
+| :---------------- | :---------------------- | :----------------------------------------------------------------------------------------------------- |
+| dataTest          | `string`                | Optional prop for testing purposes.                                                                    |
+| renderInPortal    | `boolean`               | Optional prop, set it to `false` if you're rendering Dialog inside a custom portal, defaults to `true` |
+| description       | `React.Node`            | Optional description of the main action that Dialog performs.                                          |
+| illustration      | `React.Node`            | Optional illustration of the Dialog.                                                                   |
+| **primaryAction** | `React.Node`            | Primary and required action that user can do with the Dialog.                                          |
+| secondaryAction   | `React.Node`            | Optional, secondary action that user can perform - possibility to close the Dialog most of the time.   |
+| onClose           | `() => void \| Promise` | The title of the Dialog - preferably the purpose of the main action.                                   |
+| **title**         | `React.Node`            | The title of the Dialog - preferably the purpose of the main action.                                   |

--- a/packages/orbit-components/src/Dialog/index.d.ts
+++ b/packages/orbit-components/src/Dialog/index.d.ts
@@ -10,6 +10,7 @@ declare module "@kiwicom/orbit-components/lib/Dialog";
 export interface Props extends Common.Global {
   readonly title: React.ReactNode;
   readonly description?: React.ReactNode;
+  readonly insidePortal?: boolean;
   readonly illustration?: React.ReactNode;
   readonly primaryAction: React.ReactNode;
   readonly secondaryAction?: React.ReactNode;

--- a/packages/orbit-components/src/Dialog/index.d.ts
+++ b/packages/orbit-components/src/Dialog/index.d.ts
@@ -10,7 +10,7 @@ declare module "@kiwicom/orbit-components/lib/Dialog";
 export interface Props extends Common.Global {
   readonly title: React.ReactNode;
   readonly description?: React.ReactNode;
-  readonly insidePortal?: boolean;
+  readonly renderInPortal?: boolean;
   readonly illustration?: React.ReactNode;
   readonly primaryAction: React.ReactNode;
   readonly secondaryAction?: React.ReactNode;

--- a/packages/orbit-components/src/Dialog/index.js
+++ b/packages/orbit-components/src/Dialog/index.js
@@ -115,7 +115,7 @@ const Dialog = ({
   primaryAction,
   secondaryAction,
   onClose,
-  insidePortal = true,
+  renderInPortal = true,
   illustration,
 }: Props): React.Node => {
   const ref = React.useRef(null);
@@ -155,37 +155,7 @@ const Dialog = ({
 
   const dialogID = React.useMemo(() => randomID("dialog"), []);
 
-  return insidePortal ? (
-    <Portal renderInto="modals">
-      <StyledDialog
-        data-test={dataTest}
-        shown={shown}
-        onClick={handleClose}
-        tabIndex="0"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={dialogID}
-      >
-        <StyledDialogCenterWrapper>
-          <StyledDialogContent shown={shown} ref={ref} id={dialogID}>
-            {illustration && <IllustrationContainer>{illustration}</IllustrationContainer>}
-            <Stack spacing="XSmall" spaceAfter="medium">
-              {title && <Heading type="title3">{title}</Heading>}
-              {description && <Text type="secondary">{description}</Text>}
-            </Stack>
-            <Stack
-              direction="column-reverse"
-              spacing="XSmall"
-              largeMobile={{ direction: "row", justify: "end" }}
-            >
-              {secondaryAction && <StyledAction>{secondaryAction}</StyledAction>}
-              <StyledAction>{primaryAction}</StyledAction>
-            </Stack>
-          </StyledDialogContent>
-        </StyledDialogCenterWrapper>
-      </StyledDialog>
-    </Portal>
-  ) : (
+  const dialog = (
     <StyledDialog
       data-test={dataTest}
       shown={shown}
@@ -214,6 +184,8 @@ const Dialog = ({
       </StyledDialogCenterWrapper>
     </StyledDialog>
   );
+
+  return renderInPortal ? <Portal renderInto="modals">{dialog}</Portal> : dialog;
 };
 
 export default Dialog;

--- a/packages/orbit-components/src/Dialog/index.js
+++ b/packages/orbit-components/src/Dialog/index.js
@@ -115,6 +115,7 @@ const Dialog = ({
   primaryAction,
   secondaryAction,
   onClose,
+  insidePortal = true,
   illustration,
 }: Props): React.Node => {
   const ref = React.useRef(null);
@@ -154,7 +155,7 @@ const Dialog = ({
 
   const dialogID = React.useMemo(() => randomID("dialog"), []);
 
-  return (
+  return insidePortal ? (
     <Portal renderInto="modals">
       <StyledDialog
         data-test={dataTest}
@@ -184,6 +185,34 @@ const Dialog = ({
         </StyledDialogCenterWrapper>
       </StyledDialog>
     </Portal>
+  ) : (
+    <StyledDialog
+      data-test={dataTest}
+      shown={shown}
+      onClick={handleClose}
+      tabIndex="0"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={dialogID}
+    >
+      <StyledDialogCenterWrapper>
+        <StyledDialogContent shown={shown} ref={ref} id={dialogID}>
+          {illustration && <IllustrationContainer>{illustration}</IllustrationContainer>}
+          <Stack spacing="XSmall" spaceAfter="medium">
+            {title && <Heading type="title3">{title}</Heading>}
+            {description && <Text type="secondary">{description}</Text>}
+          </Stack>
+          <Stack
+            direction="column-reverse"
+            spacing="XSmall"
+            largeMobile={{ direction: "row", justify: "end" }}
+          >
+            {secondaryAction && <StyledAction>{secondaryAction}</StyledAction>}
+            <StyledAction>{primaryAction}</StyledAction>
+          </Stack>
+        </StyledDialogContent>
+      </StyledDialogCenterWrapper>
+    </StyledDialog>
   );
 };
 

--- a/packages/orbit-components/src/Dialog/index.js.flow
+++ b/packages/orbit-components/src/Dialog/index.js.flow
@@ -6,6 +6,7 @@ import type { Globals } from "../common/common.js.flow";
 export type Props = {|
   +title: React.Node,
   +description?: React.Node,
+  +insidePortal?: boolean,
   +illustration?: React.Node,
   +primaryAction: React.Node,
   +secondaryAction?: React.Node,

--- a/packages/orbit-components/src/Dialog/index.js.flow
+++ b/packages/orbit-components/src/Dialog/index.js.flow
@@ -6,7 +6,7 @@ import type { Globals } from "../common/common.js.flow";
 export type Props = {|
   +title: React.Node,
   +description?: React.Node,
-  +insidePortal?: boolean,
+  +renderInPortal?: boolean,
   +illustration?: React.Node,
   +primaryAction: React.Node,
   +secondaryAction?: React.Node,

--- a/packages/orbit-components/src/Popover/README.md
+++ b/packages/orbit-components/src/Popover/README.md
@@ -31,7 +31,7 @@ Table below contains all types of the props available in the Popover component.
 | preferredAlign    | [`enum`](#enum)         | `"start"`           | The preferred position to choose [See Functional specs](#functional-specs).                                  |
 | preferredPosition | [`enum`](#enum)         | `"bottom"`          | The preferred align to choose [See Functional specs](#functional-specs).                                     |
 | overlapped        | `boolean`               | `false`             | If `true`, the content of Popover will overlap the trigger children.                                         |
-| insidePortal      | `boolean`               | `true`              | If `false`, the content of Popover will not be rendered inside `Portal`                                      |
+| renderInPortal    | `boolean`               | `true`              | Optional prop, set it to `false` if you're rendering Popover inside a custom portal, defaults to `true`      |
 | width             | `string`                |                     | Width of popover, if not set the with is set to `auto`.                                                      |
 | onClose           | `() => void \| Promise` |                     | Function for handling onClose.                                                                               |
 | onOpen            | `() => void \| Promise` |                     | Function for handling onOpen.                                                                                |

--- a/packages/orbit-components/src/Popover/README.md
+++ b/packages/orbit-components/src/Popover/README.md
@@ -31,6 +31,7 @@ Table below contains all types of the props available in the Popover component.
 | preferredAlign    | [`enum`](#enum)         | `"start"`           | The preferred position to choose [See Functional specs](#functional-specs).                                  |
 | preferredPosition | [`enum`](#enum)         | `"bottom"`          | The preferred align to choose [See Functional specs](#functional-specs).                                     |
 | overlapped        | `boolean`               | `false`             | If `true`, the content of Popover will overlap the trigger children.                                         |
+| insidePortal      | `boolean`               | `true`              | If `false`, the content of Popover will not be rendered inside `Portal`                                      |
 | width             | `string`                |                     | Width of popover, if not set the with is set to `auto`.                                                      |
 | onClose           | `() => void \| Promise` |                     | Function for handling onClose.                                                                               |
 | onOpen            | `() => void \| Promise` |                     | Function for handling onOpen.                                                                                |

--- a/packages/orbit-components/src/Popover/index.d.ts
+++ b/packages/orbit-components/src/Popover/index.d.ts
@@ -28,6 +28,7 @@ export interface Props extends Common.Global {
   readonly actions?: React.ReactNode;
   readonly offset?: Offset;
   readonly onOpen?: Common.Callback;
+  readonly insidePortal?: boolean;
   readonly onClose?: Common.Callback;
 }
 declare class Popover extends React.Component<Props> {}

--- a/packages/orbit-components/src/Popover/index.d.ts
+++ b/packages/orbit-components/src/Popover/index.d.ts
@@ -28,7 +28,7 @@ export interface Props extends Common.Global {
   readonly actions?: React.ReactNode;
   readonly offset?: Offset;
   readonly onOpen?: Common.Callback;
-  readonly insidePortal?: boolean;
+  readonly renderInPortal?: boolean;
   readonly onClose?: Common.Callback;
 }
 declare class Popover extends React.Component<Props> {}

--- a/packages/orbit-components/src/Popover/index.js
+++ b/packages/orbit-components/src/Popover/index.js
@@ -29,7 +29,7 @@ const Popover = ({
   onOpen,
   fixed,
   actions,
-  insidePortal = true,
+  renderInPortal = true,
 }: Props): React.Node => {
   const theme = useTheme();
   const transitionLength = React.useMemo(() => parseFloat(theme.orbit.durationFast) * 1000, [
@@ -122,6 +122,26 @@ const Popover = ({
     setShownWithTimeout,
     setRenderWithTimeout,
   ]);
+
+  const popover = (
+    <PopoverContentWrapper
+      shown={shown}
+      offset={{ top: 0, left: 0, ...offset }}
+      width={width}
+      containerRef={container}
+      preferredPosition={preferredPosition}
+      preferredAlign={preferredAlign}
+      onClose={handleOut}
+      dataTest={dataTest}
+      noPadding={noPadding}
+      overlapped={overlapped}
+      fixed={fixed}
+      actions={actions}
+    >
+      {content}
+    </PopoverContentWrapper>
+  );
+
   return (
     <>
       <StyledPopoverChild
@@ -131,44 +151,7 @@ const Popover = ({
       >
         {children}
       </StyledPopoverChild>
-      {render &&
-        (insidePortal ? (
-          <Portal renderInto="popovers">
-            <PopoverContentWrapper
-              shown={shown}
-              offset={{ top: 0, left: 0, ...offset }}
-              width={width}
-              containerRef={container}
-              preferredPosition={preferredPosition}
-              preferredAlign={preferredAlign}
-              onClose={handleOut}
-              dataTest={dataTest}
-              noPadding={noPadding}
-              overlapped={overlapped}
-              fixed={fixed}
-              actions={actions}
-            >
-              {content}
-            </PopoverContentWrapper>
-          </Portal>
-        ) : (
-          <PopoverContentWrapper
-            shown={shown}
-            offset={{ top: 0, left: 0, ...offset }}
-            width={width}
-            containerRef={container}
-            preferredPosition={preferredPosition}
-            preferredAlign={preferredAlign}
-            onClose={handleOut}
-            dataTest={dataTest}
-            noPadding={noPadding}
-            overlapped={overlapped}
-            fixed={fixed}
-            actions={actions}
-          >
-            {content}
-          </PopoverContentWrapper>
-        ))}
+      {render && (renderInPortal ? <Portal renderInto="popovers">{popover}</Portal> : popover)}
     </>
   );
 };

--- a/packages/orbit-components/src/Popover/index.js
+++ b/packages/orbit-components/src/Popover/index.js
@@ -29,6 +29,7 @@ const Popover = ({
   onOpen,
   fixed,
   actions,
+  insidePortal = true,
 }: Props): React.Node => {
   const theme = useTheme();
   const transitionLength = React.useMemo(() => parseFloat(theme.orbit.durationFast) * 1000, [
@@ -130,8 +131,27 @@ const Popover = ({
       >
         {children}
       </StyledPopoverChild>
-      {render && (
-        <Portal renderInto="popovers">
+      {render &&
+        (insidePortal ? (
+          <Portal renderInto="popovers">
+            <PopoverContentWrapper
+              shown={shown}
+              offset={{ top: 0, left: 0, ...offset }}
+              width={width}
+              containerRef={container}
+              preferredPosition={preferredPosition}
+              preferredAlign={preferredAlign}
+              onClose={handleOut}
+              dataTest={dataTest}
+              noPadding={noPadding}
+              overlapped={overlapped}
+              fixed={fixed}
+              actions={actions}
+            >
+              {content}
+            </PopoverContentWrapper>
+          </Portal>
+        ) : (
           <PopoverContentWrapper
             shown={shown}
             offset={{ top: 0, left: 0, ...offset }}
@@ -148,8 +168,7 @@ const Popover = ({
           >
             {content}
           </PopoverContentWrapper>
-        </Portal>
-      )}
+        ))}
     </>
   );
 };

--- a/packages/orbit-components/src/Popover/index.js.flow
+++ b/packages/orbit-components/src/Popover/index.js.flow
@@ -48,6 +48,7 @@ export type Props = {|
   +fixed?: boolean,
   +actions?: React.Node,
   +offset?: Offset,
+  +insidePortal?: boolean,
   +onOpen?: () => void | Promise<any>,
   +onClose?: () => void | Promise<any>,
 |};

--- a/packages/orbit-components/src/Popover/index.js.flow
+++ b/packages/orbit-components/src/Popover/index.js.flow
@@ -48,7 +48,7 @@ export type Props = {|
   +fixed?: boolean,
   +actions?: React.Node,
   +offset?: Offset,
-  +insidePortal?: boolean,
+  +renderInPortal?: boolean,
   +onOpen?: () => void | Promise<any>,
   +onClose?: () => void | Promise<any>,
 |};

--- a/packages/orbit-components/src/Tooltip/README.md
+++ b/packages/orbit-components/src/Tooltip/README.md
@@ -18,19 +18,21 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the Tooltip component.
 
-| Name                 | Type               | Default | Description                                                                                                       |
-| :------------------- | :----------------- | :------ | :---------------------------------------------------------------------------------------------------------------- |
-| **children**         | `React.Node`       |         | The reference element where the Tooltip will appear.                                                              |
-| **content**          | `React.Node`       |         | The content to display in the Tooltip.                                                                            |
-| dataTest             | `string`           |         | Optional prop for testing purposes.                                                                               |
-| enabled              | `boolean`          | `true`  | Enable render of tooltip                                                                                          |
-| block                | `boolean`          | `false` | Whether the children wrapper is inline or block. Useful when children need to take up the entire container width. |
-| preferredAlign       | [`enum`](#enum)    |         | The preferred align to choose [See Functional specs](#functional-specs)                                           |
-| preferredPosition    | [`enum`](#enum)    |         | The preferred position to choose [See Functional specs](#functional-specs)                                        |
-| removeUnderlinedText | `boolean`          |         | Removes underline on child component, when underline is not desired.                                              |
-| size                 | [`enum`](#enum)    |         | The maximum possible size of the Tooltip.                                                                         |
-| stopPropagation      | `boolean`          |         | If `true` the click event on children won't bubble. Useful when you use Tooltip inside another clickable element. |
-| tabIndex             | `string \| number` | `"0"`   | Specifies the tab order of an element                                                                             |
+| Name                 | Type            | Default | Description                                                                                                       |
+| :------------------- | :-------------- | :------ | :---------------------------------------------------------------------------------------------------------------- |
+| **children**         | `React.Node`    |         | The reference element where the Tooltip will appear.                                                              |
+| **content**          | `React.Node`    |         | The content to display in the Tooltip.                                                                            |
+| dataTest             | `string`        |         | Optional prop for testing purposes.                                                                               |
+| enabled              | `boolean`       | `true`  | Enable render of tooltip                                                                                          |
+| block                | `boolean`       | `false` | Whether the children wrapper is inline or block. Useful when children need to take up the entire container width. |
+| preferredAlign       | [`enum`](#enum) |         | The preferred align to choose [See Functional specs](#functional-specs)                                           |
+| preferredPosition    | [`enum`](#enum) |         | The preferred position to choose [See Functional specs](#functional-specs)                                        |
+| removeUnderlinedText | `boolean`       |         | Removes underline on child component, when underline is not desired.                                              |
+| size                 | [`enum`](#enum) |         | The maximum possible size of the Tooltip.                                                                         |
+| stopPropagation      | `boolean`       |         | If `true` the click event on children won't bubble. Useful when you use Tooltip inside another clickable element. |
+| insidePortal         | `boolean`       | `true`  | If `false` the Tooltip will not rendered with `Portal`                                                            |
+
+| tabIndex | `string \| number` | `"0"` | Specifies the tab order of an element |
 
 ## enum
 

--- a/packages/orbit-components/src/Tooltip/README.md
+++ b/packages/orbit-components/src/Tooltip/README.md
@@ -30,7 +30,7 @@ Table below contains all types of the props available in the Tooltip component.
 | removeUnderlinedText | `boolean`       |         | Removes underline on child component, when underline is not desired.                                              |
 | size                 | [`enum`](#enum) |         | The maximum possible size of the Tooltip.                                                                         |
 | stopPropagation      | `boolean`       |         | If `true` the click event on children won't bubble. Useful when you use Tooltip inside another clickable element. |
-| insidePortal         | `boolean`       | `true`  | If `false` the Tooltip will not rendered with `Portal`                                                            |
+| renderInPortal       | `boolean`       | `true`  | Optional prop, set it to `false` if you're rendering Tooltip inside a custom portal, defaults to `true`           |
 
 | tabIndex | `string \| number` | `"0"` | Specifies the tab order of an element |
 

--- a/packages/orbit-components/src/Tooltip/index.d.ts
+++ b/packages/orbit-components/src/Tooltip/index.d.ts
@@ -15,6 +15,7 @@ interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly content: React.ReactNode;
   readonly size?: Size;
+  readonly insidePortal?: boolean;
   readonly stopPropagation?: boolean;
   readonly preferredPosition?: Position;
   readonly preferredAlign?: Align;

--- a/packages/orbit-components/src/Tooltip/index.d.ts
+++ b/packages/orbit-components/src/Tooltip/index.d.ts
@@ -15,7 +15,7 @@ interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly content: React.ReactNode;
   readonly size?: Size;
-  readonly insidePortal?: boolean;
+  readonly renderInPortal?: boolean;
   readonly stopPropagation?: boolean;
   readonly preferredPosition?: Position;
   readonly preferredAlign?: Align;

--- a/packages/orbit-components/src/Tooltip/index.js
+++ b/packages/orbit-components/src/Tooltip/index.js
@@ -16,6 +16,7 @@ const Tooltip = ({
   size = SIZE_OPTIONS.SMALL,
   content,
   preferredPosition,
+  insidePortal,
   preferredAlign,
   stopPropagation = false,
   removeUnderlinedText,
@@ -29,6 +30,7 @@ const Tooltip = ({
       enabled={enabled}
       content={content}
       size={size}
+      insidePortal={insidePortal}
       preferredPosition={preferredPosition}
       preferredAlign={preferredAlign}
       stopPropagation={stopPropagation}

--- a/packages/orbit-components/src/Tooltip/index.js
+++ b/packages/orbit-components/src/Tooltip/index.js
@@ -16,7 +16,7 @@ const Tooltip = ({
   size = SIZE_OPTIONS.SMALL,
   content,
   preferredPosition,
-  insidePortal,
+  renderInPortal = true,
   preferredAlign,
   stopPropagation = false,
   removeUnderlinedText,
@@ -30,7 +30,7 @@ const Tooltip = ({
       enabled={enabled}
       content={content}
       size={size}
-      insidePortal={insidePortal}
+      renderInPortal={renderInPortal}
       preferredPosition={preferredPosition}
       preferredAlign={preferredAlign}
       stopPropagation={stopPropagation}

--- a/packages/orbit-components/src/Tooltip/index.js.flow
+++ b/packages/orbit-components/src/Tooltip/index.js.flow
@@ -43,7 +43,7 @@ export type Props = {|
   +children?: React.Node,
   +content: React.Node,
   +size?: Sizes,
-  +insidePortal?: boolean,
+  +renderInPortal?: boolean,
   +stopPropagation?: boolean,
   +preferredPosition?: Positions,
   +preferredAlign?: Aligns,

--- a/packages/orbit-components/src/Tooltip/index.js.flow
+++ b/packages/orbit-components/src/Tooltip/index.js.flow
@@ -43,6 +43,7 @@ export type Props = {|
   +children?: React.Node,
   +content: React.Node,
   +size?: Sizes,
+  +insidePortal?: boolean,
   +stopPropagation?: boolean,
   +preferredPosition?: Positions,
   +preferredAlign?: Aligns,

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/README.md
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/README.md
@@ -24,6 +24,7 @@ Table below contains all types of the props available in the MobileDialogPrimiti
 | **content**          | `React.Node`       |         | The content to display in the MobileDialogPrimitive.                                                                            |
 | dataTest             | `string`           |         | Optional prop for testing purposes.                                                                                             |
 | enabled              | `boolean`          | `true`  | Enable render of MobileDialogPrimitive                                                                                          |
+| insidePortal         | `boolean`          | `true`  | If `false` the component will not rendered with `Portal`                                                                        |
 | block                | `boolean`          | `false` | Whether the children wrapper is inline or block. Useful when children need to take up the entire container width.               |
 | removeUnderlinedText | `boolean`          |         | Removes underline on child component, when underline is not desired.                                                            |
 | stopPropagation      | `boolean`          |         | If `true` the click event on children won't bubble. Useful when you use MobileDialogPrimitive inside another clickable element. |

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/README.md
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/README.md
@@ -24,7 +24,7 @@ Table below contains all types of the props available in the MobileDialogPrimiti
 | **content**          | `React.Node`       |         | The content to display in the MobileDialogPrimitive.                                                                            |
 | dataTest             | `string`           |         | Optional prop for testing purposes.                                                                                             |
 | enabled              | `boolean`          | `true`  | Enable render of MobileDialogPrimitive                                                                                          |
-| insidePortal         | `boolean`          | `true`  | If `false` the component will not rendered with `Portal`                                                                        |
+| renderInPortal       | `boolean`          | `true`  | Optional prop, set it to `false` if you're rendering `MobileDialogPrimitive` inside a custom portal, defaults to `true`         |
 | block                | `boolean`          | `false` | Whether the children wrapper is inline or block. Useful when children need to take up the entire container width.               |
 | removeUnderlinedText | `boolean`          |         | Removes underline on child component, when underline is not desired.                                                            |
 | stopPropagation      | `boolean`          |         | If `true` the click event on children won't bubble. Useful when you use MobileDialogPrimitive inside another clickable element. |

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.d.ts
@@ -12,7 +12,7 @@ export interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly enabled?: boolean;
   readonly tabIndex?: string | number;
-  readonly insidePortal?: boolean;
+  readonly renderInPortal?: boolean;
   readonly content: React.ReactNode;
   readonly stopPropagation?: boolean;
   readonly removeUnderlinedText?: boolean;

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.d.ts
@@ -12,6 +12,7 @@ export interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly enabled?: boolean;
   readonly tabIndex?: string | number;
+  readonly insidePortal?: boolean;
   readonly content: React.ReactNode;
   readonly stopPropagation?: boolean;
   readonly removeUnderlinedText?: boolean;

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js
@@ -12,7 +12,7 @@ import type { Props } from "./index";
 const MobileDialog = ({
   children,
   enabled = true,
-  insidePortal = true,
+  renderInPortal = true,
   tabIndex = "0",
   dataTest,
   content,
@@ -56,6 +56,17 @@ const MobileDialog = ({
 
   if (!enabled) return children;
 
+  const dialog = (
+    <DialogContent
+      dataTest={dataTest}
+      shown={shown}
+      dialogId={mobileDialogID}
+      onClose={handleOutMobile}
+    >
+      {content}
+    </DialogContent>
+  );
+
   return (
     <>
       <StyledTooltipChildren
@@ -70,27 +81,7 @@ const MobileDialog = ({
       </StyledTooltipChildren>
       {enabled &&
         render &&
-        (insidePortal ? (
-          <Portal renderInto="dialogs">
-            <DialogContent
-              dataTest={dataTest}
-              shown={shown}
-              dialogId={mobileDialogID}
-              onClose={handleOutMobile}
-            >
-              {content}
-            </DialogContent>
-          </Portal>
-        ) : (
-          <DialogContent
-            dataTest={dataTest}
-            shown={shown}
-            dialogId={mobileDialogID}
-            onClose={handleOutMobile}
-          >
-            {content}
-          </DialogContent>
-        ))}
+        (renderInPortal ? <Portal renderInto="dialogs">{dialog}</Portal> : dialog)}
     </>
   );
 };

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js
@@ -12,6 +12,7 @@ import type { Props } from "./index";
 const MobileDialog = ({
   children,
   enabled = true,
+  insidePortal = true,
   tabIndex = "0",
   dataTest,
   content,
@@ -67,8 +68,20 @@ const MobileDialog = ({
       >
         {children}
       </StyledTooltipChildren>
-      {enabled && render && (
-        <Portal renderInto="dialogs">
+      {enabled &&
+        render &&
+        (insidePortal ? (
+          <Portal renderInto="dialogs">
+            <DialogContent
+              dataTest={dataTest}
+              shown={shown}
+              dialogId={mobileDialogID}
+              onClose={handleOutMobile}
+            >
+              {content}
+            </DialogContent>
+          </Portal>
+        ) : (
           <DialogContent
             dataTest={dataTest}
             shown={shown}
@@ -77,8 +90,7 @@ const MobileDialog = ({
           >
             {content}
           </DialogContent>
-        </Portal>
-      )}
+        ))}
     </>
   );
 };

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js.flow
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js.flow
@@ -7,6 +7,7 @@ export type Props = {|
   enabled?: boolean,
   tabIndex?: string | number,
   children?: React.Node,
+  insidePortal?: boolean,
   content: React.Node,
   stopPropagation?: boolean,
   removeUnderlinedText?: boolean,

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js.flow
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.js.flow
@@ -7,7 +7,7 @@ export type Props = {|
   enabled?: boolean,
   tabIndex?: string | number,
   children?: React.Node,
-  insidePortal?: boolean,
+  renderInPortal?: boolean,
   content: React.Node,
   stopPropagation?: boolean,
   removeUnderlinedText?: boolean,

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/README.md
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/README.md
@@ -24,7 +24,7 @@ Table below contains all types of the props available in the TooltipPrimitive co
 | **content**          | `React.Node`       |         | The content to display in the TooltipPrimitive.                                                                            |
 | dataTest             | `string`           |         | Optional prop for testing purposes.                                                                                        |
 | enabled              | `boolean`          | `true`  | Enable render of tooltipPrimitive                                                                                          |
-| insidePortal         | `boolean`          | `true`  | If `false` the component will not rendered with `Portal`                                                                   |
+| renderInPortal       | `boolean`          | `true`  | Optional prop, set it to `false` if you're rendering TooltipPrimitive inside a custom portal, defaults to `true`           |
 | block                | `boolean`          | `false` | Whether the children wrapper is inline or block. Useful when children need to take up the entire container width.          |
 | preferredAlign       | [`enum`](#enum)    |         | The preferred align to choose [See Functional specs](#functional-specs)                                                    |
 | preferredPosition    | [`enum`](#enum)    |         | The preferred position to choose [See Functional specs](#functional-specs)                                                 |

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/README.md
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/README.md
@@ -24,6 +24,7 @@ Table below contains all types of the props available in the TooltipPrimitive co
 | **content**          | `React.Node`       |         | The content to display in the TooltipPrimitive.                                                                            |
 | dataTest             | `string`           |         | Optional prop for testing purposes.                                                                                        |
 | enabled              | `boolean`          | `true`  | Enable render of tooltipPrimitive                                                                                          |
+| insidePortal         | `boolean`          | `true`  | If `false` the component will not rendered with `Portal`                                                                   |
 | block                | `boolean`          | `false` | Whether the children wrapper is inline or block. Useful when children need to take up the entire container width.          |
 | preferredAlign       | [`enum`](#enum)    |         | The preferred align to choose [See Functional specs](#functional-specs)                                                    |
 | preferredPosition    | [`enum`](#enum)    |         | The preferred position to choose [See Functional specs](#functional-specs)                                                 |

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
@@ -22,6 +22,7 @@ interface Props extends Common.Global {
   readonly tabIndex?: string | number;
   readonly removeUnderlinedText?: boolean;
   readonly block?: boolean;
+  readonly insidePortal?: boolean;
 }
 
 declare const Tooltip: React.FunctionComponent<Props>;

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
@@ -22,7 +22,7 @@ interface Props extends Common.Global {
   readonly tabIndex?: string | number;
   readonly removeUnderlinedText?: boolean;
   readonly block?: boolean;
-  readonly insidePortal?: boolean;
+  readonly renderInPortal?: boolean;
 }
 
 declare const Tooltip: React.FunctionComponent<Props>;

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.js
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.js
@@ -41,6 +41,7 @@ const TooltipPrimitive = ({
   enabled = true,
   tabIndex = "0",
   dataTest,
+  insidePortal = true,
   size = SIZE_OPTIONS.SMALL,
   content,
   preferredPosition,
@@ -103,7 +104,7 @@ const TooltipPrimitive = ({
       >
         {children}
       </StyledTooltipChildren>
-      {enabled && render && (
+      {enabled && render && insidePortal ? (
         <Portal renderInto="tooltips">
           <TooltipContent
             parent={children}
@@ -121,6 +122,22 @@ const TooltipPrimitive = ({
             {content}
           </TooltipContent>
         </Portal>
+      ) : (
+        <TooltipContent
+          parent={children}
+          dataTest={dataTest}
+          shown={shown}
+          size={size}
+          tooltipId={tooltipId}
+          onClose={handleOut}
+          onCloseMobile={handleOutMobile}
+          onEnter={handleIn}
+          preferredPosition={preferredPosition}
+          preferredAlign={preferredAlign}
+          containerRef={container}
+        >
+          {content}
+        </TooltipContent>
       )}
     </>
   );

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.js
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.js
@@ -41,7 +41,7 @@ const TooltipPrimitive = ({
   enabled = true,
   tabIndex = "0",
   dataTest,
-  insidePortal = true,
+  renderInPortal = true,
   size = SIZE_OPTIONS.SMALL,
   content,
   preferredPosition,
@@ -86,6 +86,24 @@ const TooltipPrimitive = ({
 
   if (!enabled) return children;
 
+  const tooltip = (
+    <TooltipContent
+      parent={children}
+      dataTest={dataTest}
+      shown={shown}
+      size={size}
+      tooltipId={tooltipId}
+      onClose={handleOut}
+      onCloseMobile={handleOutMobile}
+      onEnter={handleIn}
+      preferredPosition={preferredPosition}
+      preferredAlign={preferredAlign}
+      containerRef={container}
+    >
+      {content}
+    </TooltipContent>
+  );
+
   return (
     <>
       <StyledTooltipChildren
@@ -104,41 +122,9 @@ const TooltipPrimitive = ({
       >
         {children}
       </StyledTooltipChildren>
-      {enabled && render && insidePortal ? (
-        <Portal renderInto="tooltips">
-          <TooltipContent
-            parent={children}
-            dataTest={dataTest}
-            shown={shown}
-            size={size}
-            tooltipId={tooltipId}
-            onClose={handleOut}
-            onCloseMobile={handleOutMobile}
-            onEnter={handleIn}
-            preferredPosition={preferredPosition}
-            preferredAlign={preferredAlign}
-            containerRef={container}
-          >
-            {content}
-          </TooltipContent>
-        </Portal>
-      ) : (
-        <TooltipContent
-          parent={children}
-          dataTest={dataTest}
-          shown={shown}
-          size={size}
-          tooltipId={tooltipId}
-          onClose={handleOut}
-          onCloseMobile={handleOutMobile}
-          onEnter={handleIn}
-          preferredPosition={preferredPosition}
-          preferredAlign={preferredAlign}
-          containerRef={container}
-        >
-          {content}
-        </TooltipContent>
-      )}
+      {enabled &&
+        render &&
+        (renderInPortal ? <Portal renderInto="tooltips">{tooltip}</Portal> : tooltip)}
     </>
   );
 };

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.js.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.js.flow
@@ -47,7 +47,7 @@ export type Props = {|
   +stopPropagation?: boolean,
   +preferredPosition?: Positions,
   +preferredAlign?: Aligns,
-  +insidePortal?: boolean,
+  +renderInPortal?: boolean,
   +enabled?: boolean,
   +tabIndex?: string | number,
   +removeUnderlinedText?: boolean,

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.js.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.js.flow
@@ -47,6 +47,7 @@ export type Props = {|
   +stopPropagation?: boolean,
   +preferredPosition?: Positions,
   +preferredAlign?: Aligns,
+  +insidePortal?: boolean,
   +enabled?: boolean,
   +tabIndex?: string | number,
   +removeUnderlinedText?: boolean,


### PR DESCRIPTION
We faced the problem inside our examples which are rendered inside a sandbox and rendered via `Portal`. Portals ignore the iframe document and render it inside the parent, normal document, but we need to show it inside Iframe. 

My first intention was to pass down the inner document to the `Portal`, so it will take the correct document, created the context `PortalProvider`, and tried to use the consumer inside `Portal` or components. Did not work. Seems like `react-live`   does not allow it, because other components did not have such an issue, only which are rendered as examples. 

so here is another solution, to add a prop to all components with `Portal`, which will turn off rendering in Portals. 
 Storybook: https://orbit-docs-portals-fix.surge.sh