### PR TITLE
feat(HorizontalScroll): add scroll-snap-type

### DIFF
--- a/packages/orbit-components/src/HorizontalScroll/HorizontalScroll.stories.js
+++ b/packages/orbit-components/src/HorizontalScroll/HorizontalScroll.stories.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from "react";
+import { select, number } from "@storybook/addon-knobs";
 
 import Box from "../Box";
 import Text from "../Text";
@@ -24,9 +25,52 @@ export const Default = (): React.Node => {
           height="full"
         >
           <Text size="large" weight="bold" as="div">
-            <div style={{ height: "50px", display: "flex", alignItems: "center" }}>{key}</div>
+            <div
+              style={{
+                height: "50px",
+                display: "flex",
+                alignItems: "center",
+              }}
+            >
+              {key}
+            </div>
           </Text>
         </Box>
+      ))}
+    </HorizontalScroll>
+  );
+};
+
+export const withScrollSnap = (): React.Node => {
+  const scrollSnapAlign = select("scrollSnapAlign", ["none", "start", "end", "center"], "start");
+  const scrollSnap = select("scrollSnapType", ["none", "inline", "mandatory", "proximity"]);
+  const scrollPadding = number("scrollPadding", 0);
+
+  return (
+    <HorizontalScroll scrollSnap={scrollSnap} scrollPadding={scrollPadding}>
+      {Array(...Array(10)).map((_, key) => (
+        <div
+          style={{
+            scrollSnapAlign,
+            width: "150px",
+            display: "flex",
+            justifyContent: "center",
+            height: "50px",
+            background: "#ccc",
+          }}
+        >
+          <Text size="large" weight="bold" as="div">
+            <div
+              style={{
+                height: "50px",
+                display: "flex",
+                alignItems: "center",
+              }}
+            >
+              {key}
+            </div>
+          </Text>
+        </div>
       ))}
     </HorizontalScroll>
   );

--- a/packages/orbit-components/src/HorizontalScroll/HorizontalScroll.stories.js
+++ b/packages/orbit-components/src/HorizontalScroll/HorizontalScroll.stories.js
@@ -43,7 +43,7 @@ export const Default = (): React.Node => {
 
 export const withScrollSnap = (): React.Node => {
   const scrollSnapAlign = select("scrollSnapAlign", ["none", "start", "end", "center"], "start");
-  const scrollSnap = select("scrollSnapType", ["none", "inline", "mandatory", "proximity"]);
+  const scrollSnap = select("scrollSnapType", ["none", "inline", "mandatory", "proximity"], "mandatory");
   const scrollPadding = number("scrollPadding", 0);
 
   return (

--- a/packages/orbit-components/src/HorizontalScroll/README.md
+++ b/packages/orbit-components/src/HorizontalScroll/README.md
@@ -19,12 +19,23 @@ After adding import into your project you can use it simply like:
 
 ## Props
 
-| Name      | Type                  | Required           | Default | Description                           |
-| --------- | --------------------- | ------------------ | ------- | ------------------------------------- |
-| minHeight | `number`              |                    |         | set minimal height                    |
-| dataTest  | `string`              |                    |         | prop for testing purposes             |
-| spacing   | [`Spacing`](#Spacing) |                    | "small" | the spacing between children elements |
-| children  | `React.ReactNode`     | :heavy_check_mark: |         | content of HorizontalScroll           |
+| Name          | Type                        | Required           | Default | Description                               |
+| ------------- | --------------------------- | ------------------ | ------- | ----------------------------------------- |
+| minHeight     | `number`                    |                    |         | set minimal height                        |
+| dataTest      | `string`                    |                    |         | prop for testing purposes                 |
+| spacing       | [`Spacing`](#Spacing)       |                    | "small" | the spacing between children elements     |
+| children      | `React.ReactNode`           | :heavy_check_mark: |         | content of HorizontalScroll               |
+| scrollSnap    | [`ScrollSnap`](#ScrollSnap) |                    | "none"  | set value for `scroll-snap-type` property |
+| scrollPadding | `number`                    |                    |         | set value for `scroll-padding` property   |
+
+# ScrollSnap
+
+| ScrollSnap    |
+| ------------- |
+| `"mandatory"` |
+| `"proximity"` |
+| `"inline"`    |
+| `"none"`      |
 
 # Spacing
 

--- a/packages/orbit-components/src/HorizontalScroll/index.d.ts
+++ b/packages/orbit-components/src/HorizontalScroll/index.d.ts
@@ -25,6 +25,8 @@ import * as Common from "../common/common";
   ```
 */
 
+type ScrollSnap = "mandatory" | "proximity" | "inline" | "none";
+
 export interface Props extends Common.Global {
   /** set minimal height */
   readonly minHeight?: number;
@@ -35,6 +37,8 @@ export interface Props extends Common.Global {
   readonly spacing?: Spacing;
   /** content of HorizontalScroll */
   readonly children: React.ReactNode;
+  readonly scrollSnap?: ScrollSnap;
+  readonly scrollPadding?: number;
 }
 
 declare const HorizontalScroll: React.FunctionComponent<Props>;

--- a/packages/orbit-components/src/HorizontalScroll/index.js
+++ b/packages/orbit-components/src/HorizontalScroll/index.js
@@ -17,7 +17,7 @@ const StyledWrapper = styled.div`
   `}
 `;
 
-const setSnap = ({ scrollSnap }: {| scrollSnap: ScrollSnap |}) => {
+const getSnap = ({ scrollSnap }: {| scrollSnap: ScrollSnap |}) => {
   if (scrollSnap === "mandatory") return "x mandatory";
   if (scrollSnap === "proximity") return "x proximity";
 

--- a/packages/orbit-components/src/HorizontalScroll/index.js
+++ b/packages/orbit-components/src/HorizontalScroll/index.js
@@ -1,14 +1,14 @@
 // @flow
 import * as React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import useScrollBox from "./useScroll";
 import Stack from "../Stack";
 
-import type { Props } from ".";
+import type { Props, ScrollSnap } from ".";
 
 const StyledWrapper = styled.div`
-  ${({ isDragging, minHeight }) => `
+  ${({ isDragging, minHeight }) => css`
     position: relative;
     width: 100%;
     min-height: ${minHeight}px;
@@ -17,22 +17,33 @@ const StyledWrapper = styled.div`
   `}
 `;
 
+const setSnap = ({ scrollSnap }: {| scrollSnap: ScrollSnap |}) => {
+  if (scrollSnap === "mandatory") return "x mandatory";
+  if (scrollSnap === "proximity") return "x proximity";
+
+  return scrollSnap;
+};
+
 const StyledOverflow = styled.div`
-  width: 100%;
-  height: 100%;
-  overflow-y: hidden;
-  overflow-x: scroll;
-  box-sizing: border-box;
-  -ms-overflow-style: none;
-  overflow: -moz-scrollbars-none;
-  scrollbar-width: none;
-  ::-webkit-scrollbar {
-    display: none;
-  }
+  ${({ isDragging, scrollPadding }) => css`
+    width: 100%;
+    height: 100%;
+    overflow-y: hidden;
+    overflow-x: scroll;
+    scroll-snap-type: ${isDragging ? "none" : setSnap};
+    scroll-padding: ${scrollPadding && `${scrollPadding}px`};
+    box-sizing: border-box;
+    -ms-overflow-style: none;
+    overflow: -moz-scrollbars-none;
+    scrollbar-width: none;
+    ::-webkit-scrollbar {
+      display: none;
+    }
+  `}
 `;
 
 const StyledContainer = styled.div`
-  ${({ isDragging }) => `
+  ${({ isDragging }) => css`
     height: 100%;
     display: inline-flex;
     pointer-events: ${isDragging && "none"};
@@ -42,6 +53,8 @@ const StyledContainer = styled.div`
 const HorizontalScroll = ({
   children,
   spacing = "small",
+  scrollSnap = "none",
+  scrollPadding,
   dataTest,
   minHeight,
   ...props
@@ -51,7 +64,12 @@ const HorizontalScroll = ({
 
   return (
     <StyledWrapper {...props} isDragging={isDragging} minHeight={minHeight} data-test={dataTest}>
-      <StyledOverflow ref={scrollWrapper}>
+      <StyledOverflow
+        ref={scrollWrapper}
+        scrollSnap={scrollSnap}
+        scrollPadding={scrollPadding}
+        isDragging={isDragging}
+      >
         <StyledContainer isDragging={isDragging}>
           <Stack inline spacing={spacing}>
             {children}

--- a/packages/orbit-components/src/HorizontalScroll/index.js.flow
+++ b/packages/orbit-components/src/HorizontalScroll/index.js.flow
@@ -4,11 +4,15 @@ import * as React from "react";
 import type { Spacing } from "../Stack";
 import type { Globals } from "../common/common.js.flow";
 
+export type ScrollSnap = "mandatory" | "proximity" | "inline" | "none";
+
 export type Props = {|
   ...Globals,
   +minHeight?: number,
   +spacing?: Spacing,
   +children: React.Node,
+  +scrollSnap?: ScrollSnap,
+  +scrollPadding?: number,
 |};
 
 declare export default React.ComponentType<Props>;


### PR DESCRIPTION
Added `scroll-snap-type` to `HorizontalScroll`. Two props, to turn it on and the type for the property. 
 Storybook: https://orbit-feat-horizontalscroll-snap.surge.sh