### PR TITLE
chore(dependabot): forbidden access to tokens

### DIFF
--- a/.github/workflows/lint-prose.yml
+++ b/.github/workflows/lint-prose.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches-ignore:
       - master
-  pull_request:
+  pull_request_target:
     branches:
       - master
     paths:

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,6 +1,6 @@
 name: Compressed Size
 
-on: [pull_request]
+on: [pull_request_target]
 
 env: # Set environment variables for every job and step in this workflow
   CLICOLOR: "1" # Enable colors for *NIX commands

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     branches:
       - master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     branches:
       - master
 


### PR DESCRIPTION
Dependabot can't have access anymore on pull_request for tokens, that is why it's always failing.
Link to github issue: https://github.com/dependabot/dependabot-core/issues/3253

[I think this comment well describes the problem](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-799447007). 