### PR TITLE
fix: store URL metadata in Gatsby cache

### DIFF
--- a/docs/utils/document.js
+++ b/docs/utils/document.js
@@ -15,20 +15,17 @@ function getParentUrl(url) {
   return path.join(path.dirname(url), "/");
 }
 
-const metaFileDataMap = new Map();
-
-function getDocumentTrail(url, trail = []) {
+async function getDocumentTrail(cache, url, trail = []) {
   if (url === "/") {
     return trail;
   }
-  const { title } = metaFileDataMap.get(url);
-  return getDocumentTrail(getParentUrl(url), [{ name: title, url }, ...trail]);
+  const { title } = await cache.get(url);
+  return getDocumentTrail(cache, getParentUrl(url), [{ name: title, url }, ...trail]);
 }
 
 module.exports = {
   omitNumbers,
   getDocumentUrl,
-  metaFileDataMap,
   getParentUrl,
   getDocumentTrail,
 };


### PR DESCRIPTION
This (hopefully) fixes the problem of error caused by missing keys in `metaFileDataMap`, the assumption being that the data didn't get stored because those nodes got cached, and therefore skipped, so we're using the same API to store metadata, too. This assumption is based on the fact that the problem goes away after clearing Gatsby cache.

 Storybook: https://orbit-fix-metaFileDataMap-cache.surge.sh