### PR TITLE
feat(ChoiceGroup): increase rendering flexibility

### DIFF
--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -74,5 +74,8 @@
   "dependencies": {
     "@adeira/js": "^1.3.0",
     "@kiwicom/orbit-design-tokens": "^0.13.7"
+  },
+  "devDependencies": {
+    "react-window": "^1.8.6"
   }
 }

--- a/packages/orbit-components/src/ChoiceGroup/ChoiceGroup.stories.js
+++ b/packages/orbit-components/src/ChoiceGroup/ChoiceGroup.stories.js
@@ -95,22 +95,34 @@ WithError.story = {
 };
 
 export const RenderProp = (): React.Node => {
+  const boxShadowSize = "3px";
   return (
     <ChoiceGroup label="What was the reason for your cancellation?" onChange={() => {}}>
       {({ Container, Item, spacing }) => (
         <FixedSizeList
+          outerElementType={({ style, ...props }) => (
+            <div
+              style={{
+                // account for extra padding
+                top: `-${boxShadowSize}`,
+                left: `-${boxShadowSize}`,
+                ...style,
+              }}
+              {...props}
+            />
+          )}
           innerElementType={Container}
           height={150}
           itemCount={500}
           // computed height + top padding + spacing between items
-          itemSize={20 + 3 + parseInt(spacing, 10)}
+          itemSize={20 + parseInt(spacing, 10)}
         >
           {({ style, index }) => (
             <div
               style={{
-                // don't cut box shadow
-                paddingTop: "3px",
-                paddingLeft: "3px",
+                // don't cut focus box shadow
+                paddingTop: boxShadowSize,
+                paddingLeft: boxShadowSize,
                 ...style,
               }}
             >

--- a/packages/orbit-components/src/ChoiceGroup/ChoiceGroup.stories.js
+++ b/packages/orbit-components/src/ChoiceGroup/ChoiceGroup.stories.js
@@ -97,7 +97,7 @@ WithError.story = {
 export const RenderProp = (): React.Node => {
   const boxShadowSize = "3px";
   return (
-    <ChoiceGroup label="What was the reason for your cancellation?" onChange={() => {}}>
+    <ChoiceGroup label="What was the reason for your cancellation?" onChange={action("onChange")}>
       {({ Container, Item, spacing }) => (
         <FixedSizeList
           outerElementType={({ style, ...props }) => (

--- a/packages/orbit-components/src/ChoiceGroup/ChoiceGroup.stories.js
+++ b/packages/orbit-components/src/ChoiceGroup/ChoiceGroup.stories.js
@@ -2,6 +2,7 @@
 import * as React from "react";
 import { action } from "@storybook/addon-actions";
 import { text, select, boolean } from "@storybook/addon-knobs";
+import { FixedSizeList } from "react-window";
 
 import { LABEL_ELEMENTS, LABEL_SIZES } from "./consts";
 import Radio from "../Radio";
@@ -90,6 +91,44 @@ WithError.story = {
   parameters: {
     info:
       "You can try all possible configurations of this component. However, check Orbit.Kiwi for more detailed design guidelines.",
+  },
+};
+
+export const RenderProp = (): React.Node => {
+  return (
+    <ChoiceGroup label="What was the reason for your cancellation?" onChange={() => {}}>
+      {({ Container, Item, spacing }) => (
+        <FixedSizeList
+          innerElementType={Container}
+          height={150}
+          itemCount={500}
+          // computed height + top padding + spacing between items
+          itemSize={20 + 3 + parseInt(spacing, 10)}
+        >
+          {({ style, index }) => (
+            <div
+              style={{
+                // don't cut box shadow
+                paddingTop: "3px",
+                paddingLeft: "3px",
+                ...style,
+              }}
+            >
+              <Item>
+                <Radio label={`Option ${index}`} value={index} />
+              </Item>
+            </div>
+          )}
+        </FixedSizeList>
+      )}
+    </ChoiceGroup>
+  );
+};
+
+RenderProp.story = {
+  name: "Render prop",
+  parameters: {
+    info: "A virtual list, demonstrating a use case for passing function as children",
   },
 };
 

--- a/packages/orbit-components/src/ChoiceGroup/README.md
+++ b/packages/orbit-components/src/ChoiceGroup/README.md
@@ -21,18 +21,18 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the ChoiceGroup component.
 
-| Name              | Type                                                              | Default    | Description                                                                                                       |
-| :---------------- | :---------------------------------------------------------------- | :--------- | :---------------------------------------------------------------------------------------------------------------- |
-| dataTest          | `string`                                                          |            | Optional prop for testing purposes.                                                                               |
-| **children**      | `React.Node`                                                      |            | The content of the ChoiceGroup, normally **Radio** or **Checkbox**                                                |
-| error             | `Translation`                                                     |            | The error to display beneath the ChoiceGroup. Also, the Checkboxes/Radios will turn red when you pass some value. |
-| label             | `Translation`                                                     |            | Heading text of the ChoiceGroup                                                                                   |
-| labelAs           | [`enum`](#enum)                                                   | `"h4"`     | The element used to render the label into.                                                                        |
-| labelSize         | [`enum`](#enum)                                                   | `"normal"` | The size type of Heading.                                                                                         |
-| **onChange**      | `event => void \| Promise`                                        |            | Function for handling onChange event. [See Functional specs](#functional-specs)                                   |
-| filter            | `boolean`                                                         | `false`    | Changes visual appearance of child components, to contain background on hover and updates padding.                |
-| onOnlySelection   | `(event, {value: string, label: string}) => void \| Promise<any>` |            | Function for handling onOnlySelection, read more in Functional specs.                                             |
-| onlySelectionText | `Translation`                                                     |            | Property for passing translation string when you want to use the `onOnlySelection` callback.                      |
+| Name              | Type                                                              | Default               | Description                                                                                                       |
+| :---------------- | :---------------------------------------------------------------- | :-------------------- | :---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| dataTest          | `string`                                                          |                       | Optional prop for testing purposes.                                                                               |
+| **children**      | `React.Node                                                       | (args) => React.Node` |                                                                                                                   | The content of the ChoiceGroup, normally **Radio** or **Checkbox**. Pass a function for advanced usage, see "Render prop" in Storybook for an example. |
+| error             | `Translation`                                                     |                       | The error to display beneath the ChoiceGroup. Also, the Checkboxes/Radios will turn red when you pass some value. |
+| label             | `Translation`                                                     |                       | Heading text of the ChoiceGroup                                                                                   |
+| labelAs           | [`enum`](#enum)                                                   | `"h4"`                | The element used to render the label into.                                                                        |
+| labelSize         | [`enum`](#enum)                                                   | `"normal"`            | The size type of Heading.                                                                                         |
+| **onChange**      | `event => void \| Promise`                                        |                       | Function for handling onChange event. [See Functional specs](#functional-specs)                                   |
+| filter            | `boolean`                                                         | `false`               | Changes visual appearance of child components, to contain background on hover and updates padding.                |
+| onOnlySelection   | `(event, {value: string, label: string}) => void \| Promise<any>` |                       | Function for handling onOnlySelection, read more in Functional specs.                                             |
+| onlySelectionText | `Translation`                                                     |                       | Property for passing translation string when you want to use the `onOnlySelection` callback.                      |
 
 ### enum
 
@@ -43,6 +43,36 @@ Table below contains all types of the props available in the ChoiceGroup compone
 | `"h4"`       |
 | `"h5"`       |
 | `"h6"`       |
+
+### Passing a function as `children`
+
+If you need more control over how to render ChoiceGroup, for example using [`react-window`](https://github.com/bvaughn/react-window), you can pass a function to `children` instead of `React.Node`, which receives an object containing the following properties:
+
+- `Container` is the inner container where Radio/Checkbox elements are placed
+- `Item` is the component that should wrap Radio/Checkbox elements
+- `spacing` is the spacing between items, which you need to apply yourself
+
+This is a barebones example:
+
+```jsx
+<ChoiceGroup onChange={ev => doSomething(ev)}>
+  {({ Container, Item, spacing }) => (
+    <Container style={{ display: 'flex', flexDirection: 'column', gap: spacing }}>
+      <Item>
+        <Radio label="Reason one" value="two">
+      </Item>
+      <Item>
+        <Radio label="Reason two" value="two">
+      </Item>
+      <Item>
+        <Radio label="Reason three" value="three">
+      </Item>
+    </Container>
+  )}
+</ChoiceGroup>
+```
+
+For more realistic usage you can check out the "Render prop" example in Storybook.
 
 ## Functional specs
 

--- a/packages/orbit-components/src/ChoiceGroup/__tests__/index.test.js
+++ b/packages/orbit-components/src/ChoiceGroup/__tests__/index.test.js
@@ -46,4 +46,21 @@ describe("ChoiceGroup", () => {
     userEvent.click(screen.getByText("Only"));
     expect(onOnlySelection).toHaveBeenCalled();
   });
+
+  it("render prop", () => {
+    const onChange = jest.fn();
+    render(
+      <ChoiceGroup onChange={onChange}>
+        {({ Container, Item, spacing }) => (
+          <Container style={{ display: "flex", flexDirection: "column", gap: spacing }}>
+            <Item>
+              <Radio value="option" label="Option" />
+            </Item>
+          </Container>
+        )}
+      </ChoiceGroup>,
+    );
+    userEvent.click(screen.getByRole("radio", { name: "Option" }));
+    expect(onChange).toHaveBeenCalled();
+  });
 });

--- a/packages/orbit-components/src/ChoiceGroup/__typetests__/index.tsx
+++ b/packages/orbit-components/src/ChoiceGroup/__typetests__/index.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import ChoiceGroup from "..";
+import Checkbox from "../../Checkbox";
+
+export default function App() {
+  return (
+    <ChoiceGroup onChange={() => {}}>
+      {({ Container, Item, spacing }) => (
+        <Container style={{ display: "flex", flexDirection: "column", gap: spacing }}>
+          <Item>
+            <Checkbox value="option" label="Option" />
+          </Item>
+        </Container>
+      )}
+    </ChoiceGroup>
+  );
+}

--- a/packages/orbit-components/src/ChoiceGroup/index.d.ts
+++ b/packages/orbit-components/src/ChoiceGroup/index.d.ts
@@ -11,7 +11,13 @@ type Size = "normal" | "large";
 type Element = "h2" | "h3" | "h4" | "h5" | "h6";
 
 export interface Props extends Common.Global {
-  readonly children: React.ReactNode;
+  readonly children:
+    | React.ReactNode
+    | ((args: {
+        readonly Container: "div";
+        readonly Item: React.ComponentType<{ readonly children: React.ReactNode }>;
+        readonly spacing: string;
+      }) => React.ReactNode);
   readonly label?: Common.Translation;
   readonly labelSize?: Size;
   readonly labelAs?: Element;

--- a/packages/orbit-components/src/ChoiceGroup/index.js.flow
+++ b/packages/orbit-components/src/ChoiceGroup/index.js.flow
@@ -13,7 +13,13 @@ type LabelAs = "h2" | "h3" | "h4" | "h5" | "h6";
 export type Filters = {| label: string, value: string |};
 export type Props = {|
   ...Globals,
-  children: React.Node,
+  children:
+    | React.Node
+    | (({|
+        Container: "div",
+        Item: React.ComponentType<{| children: React.Node |}>,
+        spacing: string,
+      |}) => React.Node),
   label?: Translation,
   labelSize?: LabelSize,
   labelAs?: LabelAs,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17565,7 +17565,7 @@ memfs@^3.1.2, memfs@^3.2.0:
   dependencies:
     fs-monkey "1.0.3"
 
-memoize-one@^5.0.0:
+"memoize-one@>=3.1.1 <6", memoize-one@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
@@ -21307,6 +21307,14 @@ react-transition-group@^4.3.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-window@^1.8.6:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.6.tgz#d011950ac643a994118632665aad0c6382e2a112"
+  integrity sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react@^16.14.0, react@^16.8.3:
   version "16.14.0"


### PR DESCRIPTION
By accepting a function as `children` we're increasing the flexibility of rendering, for example now people can combine `react-window` with ChoiceGroup.

- [Slack request](https://skypicker.slack.com/archives/C9B1H0ACW/p1622462413007500)

 Storybook: https://orbit-feat-choice-group-flexibility.surge.sh