### PR TITLE
fix(Wizard): increase clickable area of steps

### DIFF
--- a/packages/orbit-components/src/Wizard/CheckCircle.js
+++ b/packages/orbit-components/src/Wizard/CheckCircle.js
@@ -1,0 +1,21 @@
+// @flow
+import * as React from "react";
+
+import createIcon from "../Icon/createIcon";
+import type { Props } from "../Icon";
+
+/** modified version of Orbit's CheckCircle icon, so that we can make the checkmark white instead being a hole */
+
+const CheckCircle: React.ComponentType<Props> = createIcon(
+  <>
+    <circle cx="11.999" cy="12" r="12" />
+    <path
+      d="M7.734,12.802c-0.204,-0.214 -0.486,-0.335 -0.781,-0.335c-0.593,-0 -1.08,0.487 -1.08,1.08c0,0.277 0.107,0.545 0.298,0.745l3.087,3.294c0.442,0.462 1.186,0.443 1.602,-0.043l6.709,-8.445c0.165,-0.194 0.255,-0.441 0.255,-0.696c-0,-0.592 -0.487,-1.08 -1.08,-1.08c-0.312,0 -0.611,0.136 -0.815,0.372l-5.586,7.096c-0.091,0.115 -0.23,0.182 -0.377,0.182c-0.133,0 -0.261,-0.055 -0.351,-0.152l-1.881,-2.018Z"
+      fill="#fff"
+    />
+  </>,
+  "0 0 24 24",
+  "CheckCircle",
+);
+
+export default CheckCircle;

--- a/packages/orbit-components/src/Wizard/WizardStep.js
+++ b/packages/orbit-components/src/Wizard/WizardStep.js
@@ -112,20 +112,23 @@ StyledLabel.defaultProps = {
   theme: defaultTheme,
 };
 
-const StyledButtonWrapper = styled.div.attrs({ tabIndex: 0, role: "button" })`
-  ${({ theme }) => css`
+const StyledButtonWrapper = styled.div`
+  ${({ theme, active }) => css`
     cursor: pointer;
     padding: 0 ${theme.orbit.spaceXSmall};
 
-    &:hover,
-    &:focus {
-      ${StyledLabel} {
-        span {
-          text-decoration: underline;
-          color: ${theme.orbit.colorTextPrimary};
+    ${!active &&
+    css`
+      &:hover,
+      &:focus {
+        ${StyledLabel} {
+          span {
+            text-decoration: underline;
+            color: ${theme.orbit.colorTextPrimary};
+          }
         }
       }
-    }
+    `}
   `}
 `;
 // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198
@@ -196,10 +199,13 @@ const WizardStep = ({ dataTest, title, onClick }: Props): React.Node => {
       <StyledProgressBar status={status} nextStepStatus={nextStepStatus} />
       <StyledContent>
         <Stack flex direction="column" align="center">
-          {isActive || status === "disabled" ? (
+          {status === "disabled" ? (
             step
           ) : (
             <StyledButtonWrapper
+              active={isActive}
+              role="button"
+              tabIndex={0}
               aria-current={isActive ? "step" : "false"}
               onClick={event => {
                 event.currentTarget.blur();

--- a/packages/orbit-components/src/Wizard/WizardStep.js
+++ b/packages/orbit-components/src/Wizard/WizardStep.js
@@ -35,6 +35,15 @@ StyledContainer.defaultProps = {
   theme: defaultTheme,
 };
 
+const StyledContent = styled.div`
+  /* place above progress bar */
+  position: relative;
+`;
+// $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198
+StyledContent.defaultProps = {
+  theme: defaultTheme,
+};
+
 const StyledActiveMarker = styled.div`
   ${({ theme }) => css`
     position: absolute;
@@ -52,14 +61,14 @@ StyledActiveMarker.defaultProps = {
 };
 
 const StyledProgressBar = styled.div`
-  ${({ theme, status, nextStepStatus, iconHeight }) => css`
+  ${({ theme, status, nextStepStatus }) => css`
     position: relative;
     &:before,
     &:after {
       content: "";
       display: block;
       position: absolute;
-      top: ${parseFloat(iconHeight) / 2 - 1}px;
+      top: ${parseFloat(theme.orbit.heightIconSmall) / 2 - 1}px;
       width: 50%;
       height: 2px;
     }
@@ -82,37 +91,45 @@ StyledProgressBar.defaultProps = {
   theme: defaultTheme,
 };
 
-const StyledLink = styled.a`
+const StyledLabel = styled.div`
   ${({ theme, active }) => css`
     display: block;
-    text-decoration: none;
     span {
       display: block;
+      color: ${theme.orbit.colorTextSecondary};
     }
-    ${active
-      ? css`
-          span {
-            font-weight: ${theme.orbit.fontWeightMedium};
-          }
-        `
-      : // appear interactive only if it's not active
-        css`
-          cursor: pointer;
-          span {
-            color: ${theme.orbit.colorTextSecondary};
-          }
-          &:hover,
-          &:focus {
-            span {
-              color: ${theme.orbit.colorTextPrimary};
-              text-decoration: underline;
-            }
-          }
-        `}
+    ${active &&
+    css`
+      span {
+        font-weight: ${theme.orbit.fontWeightMedium};
+        color: ${theme.orbit.colorTextPrimary};
+      }
+    `}
   `};
 `;
 // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198
-StyledLink.defaultProps = {
+StyledLabel.defaultProps = {
+  theme: defaultTheme,
+};
+
+const StyledButtonWrapper = styled.div.attrs({ tabIndex: 0, role: "button" })`
+  ${({ theme }) => css`
+    cursor: pointer;
+    padding: 0 ${theme.orbit.spaceXSmall};
+
+    &:hover,
+    &:focus {
+      ${StyledLabel} {
+        span {
+          text-decoration: underline;
+          color: ${theme.orbit.colorTextPrimary};
+        }
+      }
+    }
+  `}
+`;
+// $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198
+StyledButtonWrapper.defaultProps = {
   theme: defaultTheme,
 };
 
@@ -127,9 +144,6 @@ const WizardStep = ({ dataTest, title, onClick }: Props): React.Node => {
     if (onChangeStep) onChangeStep(index);
   };
 
-  const iconWidth = parseFloat(theme.orbit.widthIconSmall) + 3.2;
-  const iconHeight = parseFloat(theme.orbit.heightIconSmall) + 3.2;
-
   if (isCompact) {
     return (
       <StyledContainer data-test={dataTest} isCompact={isCompact} status={status}>
@@ -138,7 +152,7 @@ const WizardStep = ({ dataTest, title, onClick }: Props): React.Node => {
           disabled={status === "disabled"}
           type="secondary"
           fullWidth
-          iconLeft={<WizardStepIcon width={iconWidth} height={iconHeight} />}
+          iconLeft={<WizardStepIcon />}
           ariaCurrent={isActive ? "step" : "false"}
           onClick={handleClick}
         >
@@ -154,46 +168,55 @@ const WizardStep = ({ dataTest, title, onClick }: Props): React.Node => {
     );
   }
 
-  return (
-    <StyledContainer data-test={dataTest} isCompact={isCompact} status={status}>
-      <StyledProgressBar status={status} nextStepStatus={nextStepStatus} iconHeight={iconHeight} />
-      <Stack direction="column" align="center" spacing="XSmall">
-        <WizardStepIcon width={iconWidth} height={iconHeight} />
-        <div
-          css={css`
-            padding: ${theme.orbit.paddingBadge};
-          `}
-        >
-          {status === "disabled" ? (
-            <Text as="div" type="secondary" size="small" align="center">
+  const step = (
+    <Stack direction="column" align="center" spacing="XSmall">
+      <WizardStepIcon />
+      <div
+        css={css`
+          padding: ${theme.orbit.paddingBadge};
+        `}
+      >
+        {status === "disabled" ? (
+          <Text as="div" type="secondary" size="small" align="center">
+            {title}
+          </Text>
+        ) : (
+          <StyledLabel active={isActive}>
+            <Text as="span" size="small" align="center">
               {title}
             </Text>
+          </StyledLabel>
+        )}
+      </div>
+    </Stack>
+  );
+
+  return (
+    <StyledContainer data-test={dataTest} isCompact={isCompact} status={status}>
+      <StyledProgressBar status={status} nextStepStatus={nextStepStatus} />
+      <StyledContent>
+        <Stack flex direction="column" align="center">
+          {isActive || status === "disabled" ? (
+            step
           ) : (
-            <div>
-              <StyledLink
-                active={isActive}
-                role="button"
-                tabIndex={0}
-                aria-current={isActive ? "step" : "false"}
-                onClick={event => {
-                  event.currentTarget.blur();
+            <StyledButtonWrapper
+              aria-current={isActive ? "step" : "false"}
+              onClick={event => {
+                event.currentTarget.blur();
+                handleClick(event);
+              }}
+              // keep focus for people who are navigating with the keyboard
+              onKeyDown={event => {
+                if (event.key === "Enter") {
                   handleClick(event);
-                }}
-                // keep focus for people who are navigating with the keyboard
-                onKeyDown={event => {
-                  if (event.key === "Enter") {
-                    handleClick(event);
-                  }
-                }}
-              >
-                <Text as="span" size="small" align="center">
-                  {title}
-                </Text>
-              </StyledLink>
-            </div>
+                }
+              }}
+            >
+              {step}
+            </StyledButtonWrapper>
           )}
-        </div>
-      </Stack>
+        </Stack>
+      </StyledContent>
     </StyledContainer>
   );
 };

--- a/packages/orbit-components/src/Wizard/WizardStepIcon.js
+++ b/packages/orbit-components/src/Wizard/WizardStepIcon.js
@@ -13,7 +13,7 @@ const StyledContainer = styled.div`
   ${({ theme, disabled, glow }) => css`
     width: ${theme.orbit.widthIconSmall};
     height: ${theme.orbit.heightIconSmall};
-    border-radius: 50%;
+    border-radius: ${theme.orbit.borderRadiusCircle};
     background: ${theme.orbit.paletteProductNormal};
     ${disabled &&
     css`

--- a/packages/orbit-components/src/Wizard/WizardStepIcon.js
+++ b/packages/orbit-components/src/Wizard/WizardStepIcon.js
@@ -4,125 +4,60 @@ import styled, { css } from "styled-components";
 import convertHexToRgba from "@kiwicom/orbit-design-tokens/lib/convertHexToRgba";
 
 import Text from "../Text";
-import CheckCircle from "../icons/CheckCircle";
+import CheckCircle from "./CheckCircle";
 import useTheme from "../hooks/useTheme";
 import defaultTheme from "../defaultTheme";
 import { WizardStepContext } from "./WizardContext";
 
-const centerMixin = css`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-`;
-
-const StyledCircle = styled.div`
-  ${({ theme, width, height, status, active, hasGlow }) => css`
-    width: ${Math.round(width)}px;
-    height: ${Math.round(height)}px;
-    ${centerMixin};
-    background: ${theme.orbit.paletteProductNormal};
+const StyledContainer = styled.div`
+  ${({ theme, disabled, glow }) => css`
+    width: ${theme.orbit.widthIconSmall};
+    height: ${theme.orbit.heightIconSmall};
     border-radius: 50%;
-    ${status === "completed" &&
-    css`
-      background: ${theme.orbit.paletteWhite};
-    `}
-    ${status === "disabled" &&
+    background: ${theme.orbit.paletteProductNormal};
+    ${disabled &&
     css`
       background: ${theme.orbit.paletteCloudNormalHover};
     `}
-    ${active &&
-    hasGlow &&
+    ${glow &&
     css`
       box-shadow: 0 0 0 4px ${convertHexToRgba(theme.orbit.paletteProductNormal, 20)};
-    `}
-  `}
-`;
-// $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198
-StyledCircle.defaultProps = {
-  theme: defaultTheme,
-};
+    `};
 
-const StyledTextContainer = styled.div`
-  ${({ width, height, checkboxWidth, checkboxHeight }) => css`
-    box-sizing: border-box;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: ${width}px;
-    height: ${height}px;
-    padding: ${Math.round((height - checkboxHeight) / 2)}px
-      ${Math.round((width - checkboxWidth) / 2)}px;
-  `}
+    svg {
+      display: block;
+    }
+  `};
 `;
 
 // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198
-StyledTextContainer.defaultProps = {
+StyledContainer.defaultProps = {
   theme: defaultTheme,
 };
 
-type Props = {|
-  +width: number,
-  +height: number,
-|};
-
-const WizardStepIcon = ({ width, height }: Props): React.Element<"div"> => {
+const WizardStepIcon = (): React.Node => {
   const { index, status, isCompact, isActive } = React.useContext(WizardStepContext);
   const theme = useTheme();
 
-  // account for additional inner spacing because of visual balance
-  const checkboxWidth = width * (5 / 6);
-  const checkboxHeight = height * (5 / 6);
-
-  /**
-   * We're explicitly rounding values in layout styles because browsers seem to
-   * be rounding them inconsistently horizontally vs vertically.
-   */
-
   return (
-    <div
-      css={css`
-        position: relative;
-      `}
-    >
-      <StyledCircle
-        width={checkboxWidth}
-        height={checkboxHeight}
-        status={status}
-        active={isActive}
-        hasGlow={!isCompact}
-      />
-      <div
-        css={css`
-          position: relative;
-          /* an exception where we resize CheckCircle to a nonstandard size for aesthetical reasons */
-          svg {
-            width: ${width}px;
-            height: ${height}px;
-            display: block;
-          }
-        `}
-      >
-        {status === "completed" ? (
-          <CheckCircle
-            ariaLabel="completed"
-            size="small"
-            customColor={theme.orbit.paletteProductNormal}
-          />
-        ) : (
-          <StyledTextContainer
-            width={width}
-            height={height}
-            checkboxWidth={checkboxWidth}
-            checkboxHeight={checkboxHeight}
-          >
-            <Text as="div" type={status === "disabled" ? "primary" : "white"} size="small">
-              {typeof index === "number" ? index + 1 : null}
-            </Text>
-          </StyledTextContainer>
-        )}
-      </div>
-    </div>
+    <StyledContainer disabled={status === "disabled"} glow={isActive && !isCompact}>
+      {status === "completed" ? (
+        <CheckCircle
+          ariaLabel="completed"
+          size="small"
+          customColor={theme.orbit.paletteProductNormal}
+        />
+      ) : (
+        <Text
+          as="div"
+          type={status === "disabled" ? "primary" : "white"}
+          size="small"
+          align="center"
+        >
+          {typeof index === "number" ? index + 1 : null}
+        </Text>
+      )}
+    </StyledContainer>
   );
 };
 

--- a/packages/orbit-components/src/Wizard/__tests__/loose.test.js
+++ b/packages/orbit-components/src/Wizard/__tests__/loose.test.js
@@ -28,9 +28,9 @@ describe("Wizard", () => {
         );
       };
       render(<MyApp />);
-      const customizeYourTripStep = screen.getByRole("button", { name: "Customize your trip" });
+      const customizeYourTripStep = screen.getByRole("button", { name: /Customize your trip/ });
       expect(customizeYourTripStep).toHaveAttribute("aria-current", "step");
-      const ticketFareStep = screen.getByRole("button", { name: "Ticket fare" });
+      const ticketFareStep = screen.getByRole("button", { name: /Ticket fare/ });
       userEvent.click(ticketFareStep);
       expect(ticketFareStep).toHaveAttribute("aria-current", "step");
     });


### PR DESCRIPTION
An additional refactor here is replacing the CheckCircle Orbit icon with a custom one in order to avoid the hack of placing the background circle and simplify the code for Wizard step icon.

 Storybook: https://orbit-feat-wizard-improvements.surge.sh