### PR TITLE
fix: use default theme for examples

### DIFF
--- a/docs/src/components/ReactExample/Preview.tsx
+++ b/docs/src/components/ReactExample/Preview.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import Frame, { FrameContextConsumer } from "react-frame-component";
 import styled, { StyleSheetManager, css } from "styled-components";
 import { LivePreview } from "react-live";
-import { Stack } from "@kiwicom/orbit-components";
+import { Stack, ThemeProvider, defaultTheme } from "@kiwicom/orbit-components";
 
 type BgType = "white" | "dark" | "grid";
 interface Props {
@@ -89,7 +89,9 @@ const Preview = ({ background = "white", width, minHeight }: Props) => {
             <StyleSheetManager target={document.head}>
               <Stack justify="center" align="center">
                 <StyledPreviewWrapper ref={measuredRef} width={width}>
-                  <LivePreview />
+                  <ThemeProvider theme={defaultTheme}>
+                    <LivePreview />
+                  </ThemeProvider>
                 </StyledPreviewWrapper>
               </Stack>
             </StyleSheetManager>


### PR DESCRIPTION
Examples currently inherit the theme from orbit.kiwi, but we should use the default theme so that they always look the same.

Did I do it correctly?

 Storybook: https://orbit-docs-examples-default-theme.surge.sh