### PR TITLE
fix: prevent overflow in example preview

### DIFF
--- a/docs/src/components/ReactExample/Preview.tsx
+++ b/docs/src/components/ReactExample/Preview.tsx
@@ -49,7 +49,6 @@ const StyledFrame = styled(Frame)`
     width: 100%;
     min-height: ${minHeight}px;
     height: ${Number(height) + BOARD_HEIGHT}px;
-    padding: 0 16px;
     ${getBackground(background)};
   `};
 `;
@@ -59,7 +58,7 @@ const StyledPreviewWrapper = styled.div<{ width: number }>`
     max-width: ${width}px;
     width: 100%;
     overflow: scroll;
-    padding-top: ${theme.orbit.spaceXLarge};
+    padding: ${theme.orbit.spaceXLarge} ${theme.orbit.spaceMedium} ${theme.orbit.spaceXSmall};
   `};
 `;
 


### PR DESCRIPTION
In the Slider example dragging the Slider to either extreme causes an overflow, so moving padding to StyledPreviewWrapper instead avoids that.  Also, adding a small bottom padding avoids cutting off box shadow of the sliding head.

 Storybook: https://orbit-docs-preview-padding.surge.sh