### PR TITLE
fix/choice group filter width

### DIFF
--- a/packages/orbit-components/src/ChoiceGroup/components/FilterWrapper.js
+++ b/packages/orbit-components/src/ChoiceGroup/components/FilterWrapper.js
@@ -18,6 +18,7 @@ const hoverAndFocus = () => css`
 `;
 
 const StyledContentWrapper = styled.div`
+  box-sizing: border-box;
   width: 100%;
   padding-left: 4px;
   border-radius: 4px;


### PR DESCRIPTION
The default `content-box` box sizing causes this element to overflow because the total width becomes 100% + padding, which is 4px, instead of just 100%. This can be seen in the [story with filter](https://kiwicom.github.io/orbit/?path=/story/choicegroup--filter), and was reported [here](https://skypicker.slack.com/archives/CAMS40F7B/p1624872059121300).

In addition, I also removed an accidentally committed empty file.
 Storybook: https://orbit-fix-choice-group-filter-width.surge.sh