### PR TITLE
improve: prettify fetched users

### DIFF
--- a/docs/plugins/contributors/gatsby-node.js
+++ b/docs/plugins/contributors/gatsby-node.js
@@ -1,6 +1,7 @@
 const { Octokit } = require("@octokit/rest");
 const path = require("path");
 const fs = require("fs-extra");
+const prettier = require("prettier");
 
 const { warnMissingAccessToken } = require("../../utils/warnings");
 
@@ -47,7 +48,11 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }, { r
         }),
       );
 
-      await fs.writeFile(path.join(__dirname, "fetchedUsers.json"), JSON.stringify(users));
+      const fetchedUsersContent = await prettier.format(JSON.stringify(users), {
+        ...(await prettier.resolveConfig(__dirname)),
+        parser: "json",
+      });
+      await fs.writeFile(path.join(__dirname, "fetchedUsers.json"), fetchedUsersContent);
 
       staticData.concat(users).forEach(u => {
         return createNode({


### PR DESCRIPTION
While the pre-commit hook takes care of this, it's very confusing to see the un-prettified file in the working tree. Now the JSON will be prettified as it's being written.

 Storybook: https://orbit-docs-prettify-fetched-users.surge.sh