### PR TITLE
chore: fix path to environment variables

### DIFF
--- a/docs/plugins/contributors/gatsby-node.js
+++ b/docs/plugins/contributors/gatsby-node.js
@@ -13,7 +13,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }, { r
   try {
     // eslint-disable-next-line import/no-extraneous-dependencies
     require("dotenv").config({
-      path: path.join(process.cwd(), `.env`),
+      path: path.join(process.cwd(), `../.env`),
     });
 
     const octokit = new Octokit({ auth: process.env.GH_TOKEN });


### PR DESCRIPTION
There is no need to have `docs/.env` when we can use root `.env`. This improves rate limit because without `docs/.env` the requests were not authenticated.

 Storybook: https://orbit-docs-fix-octokit-auth.surge.sh