### PR TITLE
docs: add guides

### DIFF
--- a/.github/contribution/docs.md
+++ b/.github/contribution/docs.md
@@ -7,6 +7,7 @@ It's efforts like yours that help keep our docs useful.
 
 - [Location](#location)
 - [Running the docs locally](#running-the-docs-locally)
+- [Creating new component docs](#creating-new-component-docs)
 - [Code style](#code-style)
 - [Prose style](#prose-style)
 
@@ -14,13 +15,13 @@ It's efforts like yours that help keep our docs useful.
 
 Our docs live mostly in two places.
 
-Basic details (props tables and such) for each component
-live in ReadMe files next to the component
-([example button ReadMe](https://github.com/kiwicom/orbit/blob/master/packages/orbit-components/src/Button/README.md)).
-
-More general guidelines and anything more complex lives in the [docs folder](../../docs),
+General guidelines are in the [docs folder](../../docs),
 mostly in MDX files in the [documentation folder](../../docs/src/documentation).
 The structure of that folder matches the structure on [our built docs site](https://orbit.kiwi).
+
+The basic API (props tables and such) for each component
+is in ReadMe files next to the component
+([example button ReadMe](https://github.com/kiwicom/orbit/blob/master/packages/orbit-components/src/Button/README.md)).
 
 ## Running the docs locally
 
@@ -55,6 +56,15 @@ Your site is now running at `http://localhost:8000`.
 Now you can make a change to a file in `docs/src/` (such as the docs in `docs/src/documentation/`)
 and your site updates automatically.
 
+## Creating new component docs
+
+To create new guidelines for a component,
+follow the [template for components](https://github.com/kiwicom/orbit/blob/master/docs/src/documentation/03-components/component.md.template).
+Place it in the right category for the component.
+
+If the component has a React API already defined,
+put it in a folder with a `meta.yml` file as with most other components.
+
 ## Code style
 
 To keep the files used to build our docs clear, we enforce standard Markdown code styling.
@@ -74,6 +84,7 @@ or run `yarn eslint:docs` from a terminal.
 In addition to the automatic fixes,
 we also prefer it when lines are no longer than 80 characters.
 This helps ensure the code is readable even in narrow spaces.
+It's known as [semantic line breaks](https://sembr.org/)
 
 But we don't enforce a strict limit to line length.
 If we did, automatic tools would rearrange lines at any change.

--- a/.github/styles/Kiwi/Contractions.yml
+++ b/.github/styles/Kiwi/Contractions.yml
@@ -1,29 +1,29 @@
-extends: substitution
-message: "Feel free to use '%s' instead of '%s'."
-link: 'https://orbit.kiwi/content/technical-content/language/#use-contractions'
+extends: existence
+message: "Feel free to use a contraction instead of '%s':
+  https://orbit.kiwi/content/technical-content/language/#use-contractions"
+link: https://orbit.kiwi/content/technical-content/language/#use-contractions
 level: suggestion
 ignorecase: true
-action:
-  name: replace
-swap:
-  are not: aren't
-  cannot: can't
-  could not: couldn't
-  did not: didn't
-  do not: don't
-  does not: doesn't
-  has not: hasn't
-  have not: haven't
-  is not: isn't
-  it is: it's
-  should not: shouldn't
-  that is: that's
-  they are: they're
-  was not: wasn't
-  we are: we're
-  were not: weren't
-  what is: what's
-  when is: when's
-  where is: where's
-  will not: won't
-  you are: you're
+scope: raw
+tokens:
+  - are not
+  - cannot
+  - could not
+  - did not
+  - do not
+  - does not
+  - has not
+  - have not
+  - is not
+  - (?<!(?:where|how|what) )it is
+  - should not
+  - that is
+  - (?<!(?:where|how) )they are
+  - was not
+  - (?<!(?:where|how) [a-z]* )we are
+  - were not
+  - what is
+  - when is
+  - where is
+  - will not
+  - you are

--- a/.github/styles/Vocab/Kiwi/accept.txt
+++ b/.github/styles/Vocab/Kiwi/accept.txt
@@ -1,6 +1,7 @@
 Autoflow
 bitz
 [C|c]allout
+CDN
 Cmd
 composable
 composability
@@ -33,6 +34,7 @@ overcomplicate
 Pantone
 [Pp]escatarian
 Photoshop
+PNG|png
 px
 radiuses
 repos

--- a/docs/plugins/gatsby-remark-figma-images/index.js
+++ b/docs/plugins/gatsby-remark-figma-images/index.js
@@ -74,7 +74,7 @@ module.exports = (props, pluginOptions) => {
     function onError(err) {
       const triesLeft = tries - 1;
       if (!triesLeft) {
-        throw err;
+        return { data: { err } };
       }
       return wait(delay).then(() => fetchRetry(url, delay, triesLeft));
     }
@@ -115,7 +115,10 @@ module.exports = (props, pluginOptions) => {
       fetchNode(fileId, nodeId).then(({ data }) => {
         const { images, err } = data;
         if (err) {
-          reporter.error("An error occurred", err);
+          reporter.error(
+            `The Figma image with a file ID of ${fileId} and a node ID of ${nodeId} was not found.\nThe specific error was: ${err}.`,
+          );
+          return;
         }
         const result = Object.values(images);
         if (result.length !== 1 || err) {

--- a/docs/src/documentation/02-foundation/02-accessibility.mdx
+++ b/docs/src/documentation/02-foundation/02-accessibility.mdx
@@ -206,7 +206,7 @@ are designed to work no matter the direction of the text,
 so the icons default to not reversing based on RTL settings (though you can manually override this).
 
 Focusing on making sure your designs make sense from each direction
-helps ensure they are usable by everyone.
+helps ensure they're usable by everyone.
 
 ## Scale
 

--- a/docs/src/documentation/03-components/01-action/textlink/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/01-action/textlink/01-guidelines.mdx
@@ -13,7 +13,7 @@ check out our [interactive guide on action components](/guides/using-button-type
 
 - To make text inside paragraphs or lists actionable.
 - To offer external navigation that doesn't draw too much attention.
-- To offer action text that is long.
+- To offer action text that's long.
 
 ### When not to use
 

--- a/docs/src/documentation/03-components/03-information/alert/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/03-information/alert/01-guidelines.mdx
@@ -46,7 +46,7 @@ Without icons, people with color blindness might see success and critical alerts
 
 ![Success and critical alerts with icons are clear even without color.](fileId:fannvRpkOJK6uxxT33EKaa;nodeId:364%3A1542)
 
-![Success and critical alerts without icons are not clear without color.](fileId:fannvRpkOJK6uxxT33EKaa;nodeId:364%3A1543)
+![Success and critical alerts without icons aren't clear without color.](fileId:fannvRpkOJK6uxxT33EKaa;nodeId:364%3A1543)
 
 </Guideline>
 

--- a/docs/src/documentation/03-components/03-information/notificationbadge/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/03-information/notificationbadge/01-guidelines.mdx
@@ -23,7 +23,7 @@ redirect_from:
 
 ## Content structure
 
-![Type: visually supports the message with different styles for different types; icon: optionally represent the notification visually and is not an action; content: displays the number of the notification and will not display if an icon is used.](fileId:4QJZqvBvRrLu6t9mwObCkA;nodeId:119%3A1159)
+![Type: visually supports the message with different styles for different types; icon: optionally represent the notification visually and isn't an action; content: displays the number of the notification and doesn't display if an icon is used.](fileId:4QJZqvBvRrLu6t9mwObCkA;nodeId:119%3A1159)
 
 ## Content
 

--- a/docs/src/documentation/03-components/04-overlay/dialog/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/04-overlay/dialog/01-guidelines.mdx
@@ -81,7 +81,7 @@ Warn about destructive actions.
 
 <DontImage>
 
-![A dialog with no description and actions as normal (even though they are destructive – asking to remove a traveler).](fileId:fannvRpkOJK6uxxT33EKaa;nodeId:38%3A666)
+![A dialog with no description and actions as normal (even though they're destructive – asking to remove a traveler).](fileId:fannvRpkOJK6uxxT33EKaa;nodeId:38%3A666)
 
 Don't offer destruction choices with no warning about the consequences.
 

--- a/docs/src/documentation/03-components/05-input/listchoice/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/05-input/listchoice/01-guidelines.mdx
@@ -41,18 +41,6 @@ allows users to quickly scan for what they need to know.
 Don't use list choices when the information for each choice is very different.
 This slows down and confuses users.
 
-### Categorize with icons
-
-When you have a lot of similar structures,
-breaking them into various groups makes it easier for users to choose.
-To show things like stations with different modes of transport,
-use different icons for each mode.
-
-Just remember that [not everyone sees your visual cues](/foundation/accessibility/),
-so include the same information in a non-visual way.
-
-<ReactExample exampleId="ListChoice-icons" minHeight={360} />
-
 ### Use separately
 
 List choices work well when separated from the main flow,
@@ -75,6 +63,18 @@ If it's necessary to present a disabled choice,
 make sure users know why the options aren't available.
 
 ## Content
+
+### Categorize with icons
+
+When you have a lot of similar structures,
+breaking them into various groups makes it easier for users to choose.
+To show things like stations with different modes of transport,
+use different icons for each mode.
+
+Just remember that [not everyone sees your visual cues](/foundation/accessibility/),
+so include the same information in a non-visual way.
+
+<ReactExample exampleId="ListChoice-icons" minHeight={360} />
 
 ### Add context with description
 

--- a/docs/src/documentation/03-components/07-interaction/slider/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/07-interaction/slider/01-guidelines.mdx
@@ -25,7 +25,7 @@ import InputLabelsSnippet from "snippets/input-labels.mdx";
 
 ## Content structure
 
-![Label: optionally provides an overview of what's being selected; value description: optionally clearly describes the range users can select from; histogram description: optionally describes what is contained in the selected range in the histogram; histogram: optionally shows what's included in the selection; min value: sets the lowest possible value; max value: sets the highest possible value; handlers: enable users to select their desired value and to improve accessibility it's best to add a label.](fileId:4QJZqvBvRrLu6t9mwObCkA;nodeId:177%3A0)
+![Label: optionally provides an overview of what's being selected; value description: optionally clearly describes the range users can select from; histogram description: optionally describes what's contained in the selected range in the histogram; histogram: optionally shows what's included in the selection; min value: sets the lowest possible value; max value: sets the highest possible value; handlers: enable users to select their desired value and to improve accessibility it's best to add a label.](fileId:4QJZqvBvRrLu6t9mwObCkA;nodeId:177%3A0)
 
 ## Behavior
 
@@ -35,7 +35,7 @@ Users are used to seeing immediate results from interacting with sliders,
 such as from volume controls on phones and video players.
 Make sure they can see the effect of their choice of range.
 
-Histograms help with this by offering a visualization of what is included within the range.
+Histograms help with this by offering a visualization of what's included within the range.
 Just make sure the information is also included non-visually
 so [everyone can access it](/foundation/accessibility/).
 

--- a/docs/src/documentation/03-components/07-interaction/switch/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/07-interaction/switch/01-guidelines.mdx
@@ -40,7 +40,7 @@ In cases where users are used to certain visuals,
 it can make sense to include them as part of the switch.
 Offer icons that show the currently selected state
 (_not_ showing what happens if users toggle that state).
-This can make it easier to determine what is happening right now.
+This can make it easier to determine what's happening right now.
 
 Just make sure the function of the switch is clear also from just words
 so that [everyone can use it](/foundation/accessibility/).

--- a/docs/src/documentation/03-components/08-visuals/icon/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/08-visuals/icon/01-guidelines.mdx
@@ -33,7 +33,7 @@ import IconColorsSnippet from "snippets/icon-colors.mdx";
 
 ![Icon glyph: works best when accompanied by a clear label to improve usability.](fileId:4QJZqvBvRrLu6t9mwObCkA;nodeId:0%3A259)
 
-## Behavior
+## Content
 
 ### Use interactive icons for interactions
 
@@ -60,7 +60,7 @@ Use non-interactive icons for settings other than interactions.
 
 ![Radio buttons under the heading 'Select an option' with the first icon being X and the second related to baggage.](fileId:fannvRpkOJK6uxxT33EKaa;nodeId:143%3A1473)
 
-Using interactive icons creates the expectation that clicking the icon will do something.
+Using interactive icons creates the expectation that clicking the icon does something.
 
 </DontImage>
 
@@ -92,8 +92,6 @@ Varying the icons creates confusion about the message.
 </DontImage>
 
 </GuidelineImages>
-
-## Content
 
 ### Use labels
 

--- a/docs/src/documentation/03-components/10-progress-indicators/loading/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/10-progress-indicators/loading/01-guidelines.mdx
@@ -25,7 +25,7 @@ Read or listen to [more about progress indicators](https://99percentinvisible.or
 
 ## Content structure
 
-![Animation: varies based on loading type; text: optionally lets users know what is happening.](fileId:4QJZqvBvRrLu6t9mwObCkA;nodeId:89%3A0)
+![Animation: varies based on loading type; text: optionally lets users know what's happening.](fileId:4QJZqvBvRrLu6t9mwObCkA;nodeId:89%3A0)
 
 ## Behavior
 
@@ -33,7 +33,7 @@ Read or listen to [more about progress indicators](https://99percentinvisible.or
 
 Differ loading types take up different spaces
 and create certain expectations in users.
-Choose the loading type to correspond to the content that is being loaded.
+Choose the loading type to correspond to the content that's being loaded.
 
 <ReactExample exampleId="Loading-types" />
 

--- a/docs/src/documentation/03-components/11-navigation/pagination/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/11-navigation/pagination/01-guidelines.mdx
@@ -46,7 +46,7 @@ Ellipses replace some pages so a reasonable number are shown.
 ### Disabled buttons
 
 While we generally [recommend against using disabled buttons](/components/action/button/#avoid-disabled-buttons),
-they are used in pagination on the first and last page.
+they're used in pagination on the first and last page.
 If the buttons were hidden,
 it would cause the other ones to jump around on the page.
 

--- a/docs/src/documentation/03-components/component.md.template
+++ b/docs/src/documentation/03-components/component.md.template
@@ -1,0 +1,75 @@
+---
+title: Guidelines
+---
+
+<ReactExample exampleId="Component-default" />
+
+Start with an example.
+The example should show a basic case where the component would be used.
+It should be simple enough to understand,
+but still show something that might really be used.
+
+Examples can be found within `docs/src/__examples__`.
+
+## When to use
+
+- Put in use cases when this component should be used.
+- Use short fragments ("To achieve X goal").
+
+### When not to use
+
+- Briefly describes cases when this component should **_not_** be used.
+- Link to components to use instead in these cases---use an [other component name](/components/category/othercomponentname/).
+
+## Component status
+
+<ComponentStatus component="Component" />
+
+## Content structure
+
+![Alt text: any words that are in the structure in Figma](fileId:4QJZqvBvRrLu6t9mwObCkA;nodeId:)
+
+Fill in the alt text and node ID for the specific structure in Figma.
+
+## Behavior
+
+Include any guidance about how the component behaves.
+This includes:
+
+- Interactions (like how to show more of the component's content)
+- Next steps
+- Specific use cases (more details on when to use)
+- Responsive behavior (different content on different screen sizes)
+
+### Create guidance in sections
+
+Separate guidance into sections focused on one particular aspect.
+This is true for all major sections.
+
+Label the sections with short imperatives: _Do this_.
+Remember to try to [keep the language positive](/kiwi-use/content/voice-tone/passionate/#use-positive-language)
+(focus on what to do, not what not to do).
+
+<Guideline type="do" title="Use our docs components">
+
+To make the message clear, use any of the components you can see at our [sample page](/mdx-examples/).
+
+</Guideline>
+
+## Content
+
+Include any guidance on what content the component should include.
+This includes:
+
+- Calls to action
+- Labels
+- Help and error messages
+
+## Look & feel
+
+This section should focus on how the component appears
+It can include documentation of design decisions that might not be immediately obvious.
+
+- Types
+- Sizes
+- Differences between apps and web

--- a/docs/src/documentation/04-design-patterns/02-action-components.mdx
+++ b/docs/src/documentation/04-design-patterns/02-action-components.mdx
@@ -68,7 +68,7 @@ They should be used when there are multiple primary actions on one page with the
 ### Secondary buttons
 
 Used for actions that aren't so important.
-They are usually connected to primary buttons.
+They're usually connected to primary buttons.
 
 <ImageContainer size="medium">
 
@@ -134,7 +134,7 @@ There should be no more than _one basic and one subtle button_.
 
 ## ButtonLinks
 
-Choose a button link when it is outside text, the text inside is short,
+Choose a button link when it's outside text, the text inside is short,
 and either of the following is true:
 
 - The action navigates inside the app.
@@ -151,7 +151,7 @@ ButtonLinks come in three sizes (_large_, _normal_, and _small_) and three types
 ### Primary ButtonLinks
 
 Great as complements to **primary buttons**
-or as a primary standalone action that is visually less heavy than **primary subtle buttons**.
+or as a primary standalone action that's visually less heavy than **primary subtle buttons**.
 
 <ImageContainer size="medium">
 
@@ -169,7 +169,7 @@ Often used for filters.
 
 <ImageContainer size="medium">
 
-![A search filter with a list of carriers that is incomplete
+![A search filter with a list of carriers that's incomplete
   and a secondary button link to 'Show all carriers'
   .](fileId:fannvRpkOJK6uxxT33EKaa;nodeId:104%3A36)
 
@@ -178,7 +178,7 @@ Often used for filters.
 ### Critical ButtonLinks
 
 Great as complements to **critical buttons**
-or as a secondary standalone action that is visually less heavy than **critical subtle buttons**.
+or as a secondary standalone action that's visually less heavy than **critical subtle buttons**.
 
 <ImageContainer size="medium">
 

--- a/docs/src/documentation/06-kiwi-use/02-content/01-voice-and-tone/02-empathetic.mdx
+++ b/docs/src/documentation/06-kiwi-use/02-content/01-voice-and-tone/02-empathetic.mdx
@@ -91,7 +91,7 @@ This has the side effect of [making things shorter](/kiwi-use/content/voice-and-
 
 <Compare size="large" />
 
-These guidelines are not absolute and can't cover everything.
+These guidelines aren't absolute and can't cover everything.
 You should use your common sense and **adapt the guidelines** to each situation.
 
 ### Keep tone serious in stressful situations

--- a/docs/src/documentation/06-kiwi-use/02-content/02-grammar-and-mechanics.mdx
+++ b/docs/src/documentation/06-kiwi-use/02-content/02-grammar-and-mechanics.mdx
@@ -9,8 +9,8 @@ redirect_from:
 
 <!-- vale Kiwi.Contractions = NO -->
 
-> If language is not correct, then what is said is not what is meant;
-> if what is said is not what is meant,
+> If language isn't correct, then what's said isn't what's meant;
+> if what's said isn't what's meant,
 > then what must be done remains undone.
 >
 > Confucius

--- a/docs/src/documentation/06-kiwi-use/02-content/04-specific-areas/social-media/02-visual-treatment.mdx
+++ b/docs/src/documentation/06-kiwi-use/02-content/04-specific-areas/social-media/02-visual-treatment.mdx
@@ -28,7 +28,7 @@ showing them the world Kiwi.com can offer.
 
 <!-- eslint-enable -->
 
-**are** real, authentic and full of wanderlust.
+**are** real, authentic, and full of wanderlust.
 Images don't just show the place but the _details_ of the people and the story.
 
 <Grid columns="200px 200px 296px;" rows="minmax(100px, auto) minmax(100px, auto);" gap="10px;">
@@ -59,7 +59,7 @@ Images don't just show the place but the _details_ of the people and the story.
 
 </Grid>
 
-**are not** unrealistic, over edited, broad stock landscapes that lack emotion.
+**aren't** unrealistic, over edited, broad stock landscapes that lack emotion.
 
 <Grid columns="360px 360px;" gap="10px;" rows="minmax(100px, auto) minmax(100px, auto);">
 
@@ -90,7 +90,7 @@ Images don't just show the place but the _details_ of the people and the story.
 <!-- eslint-enable -->
 
 **are** diverse and show real authentic moments.
-They are natural, capturing the emotions and adventurous spirit of our audience.
+They're natural, capturing the emotions and adventurous spirit of our audience.
 
 <Grid columns="360px 360px;" gap="10px;" rows="minmax(100px, auto) minmax(100px, auto);">
 
@@ -114,7 +114,7 @@ They are natural, capturing the emotions and adventurous spirit of our audience.
 
 </Grid>
 
-**are not** posed, facing away from the camera or recreating unrealistic and cliched moments.
+**aren't** posed, facing away from the camera or recreating unrealistic and cliched moments.
 
 <Grid columns="420px 276px;" gap="10px;" rows="minmax(100px, auto) minmax(100px, auto);">
 
@@ -144,9 +144,9 @@ They are natural, capturing the emotions and adventurous spirit of our audience.
 
 <!-- eslint-enable -->
 
-**IS** bright and cheerful.
+**is** bright and cheerful.
 It's packing and getting ready.
-The journey is not a boring transition, it's all part of the adventure.
+The journey isn't a boring transition, it's all part of the adventure.
 
 <Grid columns="260px 300px;" gap="10px;" rows="170px 10px 200px;">
 
@@ -176,7 +176,7 @@ The journey is not a boring transition, it's all part of the adventure.
 
 </Grid>
 
-**IS NOT** dull and boring, it's not posed cliched moments
+**isn't** dull and boring, it's not posed cliched moments
 or suggestive or monotony/complexity/delays.
 
 <Grid columns="430px 290px;" gap="10px;" rows=" minmax(100px, auto);">
@@ -239,7 +239,7 @@ or suggestive or monotony/complexity/delays.
 
 </Grid>
 
-**are not** stylized, tongue-in-cheek or over-produced,
+**aren't** stylized, tongue-in-cheek or over-produced,
 or trying to represent unreal situations.
 
 <Grid columns="202px 202px;" gap="10px;" rows=" minmax(100px, auto);">

--- a/docs/src/documentation/06-kiwi-use/02-content/04-specific-areas/technical-content/01-principles.mdx
+++ b/docs/src/documentation/06-kiwi-use/02-content/04-specific-areas/technical-content/01-principles.mdx
@@ -62,7 +62,7 @@ Before you start writing, you want to ask yourself questions about your readers 
 - **Why** are they reading?
   To accomplish a **task**?
   **To learn** about the project?
-- Will this document come in the middle of something they're in a **hurry** to finish?
+- Does this document come in the middle of something they're in a **hurry** to finish?
   How are they likely to be **feeling** when starting to read?
 
 The answers to these questions give you a better idea of how to present your information.

--- a/docs/src/documentation/06-kiwi-use/02-content/04-specific-areas/technical-content/02-tone.mdx
+++ b/docs/src/documentation/06-kiwi-use/02-content/04-specific-areas/technical-content/02-tone.mdx
@@ -8,7 +8,7 @@ At Kiwi.com, we speak with one voice.
 That voice is a [blend of our core principles](/kiwi-use/content/voice-and-tone/).
 
 When producing technical content,
-usually the most important principle is that we are [straightforward](/kiwi-use/content/voice-and-tone/straightforward/).
+usually the most important principle is that we're [straightforward](/kiwi-use/content/voice-and-tone/straightforward/).
 It's important for our technical writing to be clear and understandable.
 
 At the same time, our other principles are still important.

--- a/docs/src/documentation/06-kiwi-use/02-content/04-specific-areas/technical-content/04-language.mdx
+++ b/docs/src/documentation/06-kiwi-use/02-content/04-specific-areas/technical-content/04-language.mdx
@@ -168,6 +168,8 @@ That structure should be enough, so the headings shouldn't be numbered.
 
 ## Use contractions
 
+<!-- vale Kiwi.Contractions = NO -->
+
 In keeping with our being [empathetic](/kiwi-use/content/voice-and-tone/empathetic/#use-words-and-structures-youd-use-in-speaking),
 feel free to use common contractions.
 This means writing _can't_ and _isn't_ in place of _cannot_ and _are not_.
@@ -175,8 +177,6 @@ This means writing _can't_ and _isn't_ in place of _cannot_ and _are not_.
 It's best to avoid shortening noun and verb combinations where it might be confusing
 (such as making readers think something is a possessive rather than a noun and verb).
 But common contractions such as _it's_ should be clear (just don't confuse _it's_ and _its_).
-
-<!-- vale Kiwi.Contractions = NO -->
 
 <GuidelinesSideBySide>
 

--- a/docs/src/documentation/06-kiwi-use/03-guides/03-working-with-figma/01-basics.mdx
+++ b/docs/src/documentation/06-kiwi-use/03-guides/03-working-with-figma/01-basics.mdx
@@ -15,7 +15,7 @@ For everyone else, we offer an [open-source guide](/getting-started/for-designer
 Instead of different tools in different domains,
 everyone can take advantage of a unified process to focus on creating the best experiences.
 
-All of it is focused on the principle of designing **first for** [**native mobile** implementations](https://www.figma.com/file/PWGp3tANcQDVGI1W12swfn/Mobile-Experience-Guidelines?node-id=0%3A1).
+All of it focuses on the principle of designing **first for** [**native mobile** implementations](https://www.figma.com/file/PWGp3tANcQDVGI1W12swfn/Mobile-Experience-Guidelines?node-id=0%3A1).
 From this seed, all of the other designs grow.
 
 We've broken the process down into various parts so you can focus on what you need to know.

--- a/docs/src/documentation/06-kiwi-use/03-guides/03-working-with-figma/02-structure.mdx
+++ b/docs/src/documentation/06-kiwi-use/03-guides/03-working-with-figma/02-structure.mdx
@@ -117,8 +117,7 @@ Use tags to describe your design files.
 
 <Callout type="warning">
 
-The information below is in the process of review and will be updated.
-Check back soon.
+The information below is in the process of review and may be updated.
 
 </Callout>
 

--- a/docs/src/documentation/06-kiwi-use/03-guides/03-working-with-figma/03-design-flow.mdx
+++ b/docs/src/documentation/06-kiwi-use/03-guides/03-working-with-figma/03-design-flow.mdx
@@ -41,7 +41,7 @@ Generally, buttons are 44 pts high in iOS and 48 pts in Android.
 
 So in Figma, instead of having buttons overly optimized for one platform or the other,
 button components in Figma are 46 pts high.
-This isn't a value that's actually be used,
+This isn't a value that's actually used,
 but it allows designers to make their designs basically fit with each platform.
 
 The recommendation to follow a [4-pixel grid system](/foundation/spacing/) for designs still holds,

--- a/docs/src/documentation/06-kiwi-use/03-guides/03-working-with-figma/03-design-flow.mdx
+++ b/docs/src/documentation/06-kiwi-use/03-guides/03-working-with-figma/03-design-flow.mdx
@@ -41,7 +41,7 @@ Generally, buttons are 44 pts high in iOS and 48 pts in Android.
 
 So in Figma, instead of having buttons overly optimized for one platform or the other,
 button components in Figma are 46 pts high.
-This isn't a value that is actually be used,
+This isn't a value that's actually be used,
 but it allows designers to make their designs basically fit with each platform.
 
 The recommendation to follow a [4-pixel grid system](/foundation/spacing/) for designs still holds,

--- a/docs/src/documentation/06-kiwi-use/03-guides/03-working-with-figma/05-handoff.mdx
+++ b/docs/src/documentation/06-kiwi-use/03-guides/03-working-with-figma/05-handoff.mdx
@@ -48,7 +48,7 @@ which can help you determine which [design tokens](/foundation/design-tokens/) t
 ### Exporting images
 
 If a design has an image in it that you need for development, export it in the format you need.
-You'll find options for size and format on the
+There are options for size and format on the
 Code tab after clicking the **+** next to **Export**.
 
 <ImageContainer size="medium">


### PR DESCRIPTION
And fix a broken build when an improper node ID is supplied for Figma images.
And fix some styling issues.

Storybook: https://orbit-docs-guides.surge.sh