### PR TITLE
fix: don't use Google Analytics in preview

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -14,14 +14,16 @@ module.exports = {
     },
   },
   plugins: [
-    {
-      resolve: `gatsby-plugin-google-gtag`,
-      options: {
-        trackingIds: [
-          "UA-118988244-1", // Google Analytics / GA
-        ],
-      },
-    },
+    ...(process.env.CLOUDFLARE_BUILD_ENV === "preview"
+      ? []
+      : [
+          {
+            resolve: `gatsby-plugin-google-gtag`,
+            options: {
+              trackingIds: ["UA-118988244-1"],
+            },
+          },
+        ]),
     "gatsby-plugin-react-helmet",
     {
       resolve: "gatsby-source-filesystem",


### PR DESCRIPTION
To avoid having to filter by domain.

 Storybook: https://orbit-fix-prod-google-analytics.surge.sh