### PR TITLE
Hide bookmarks UI with missing functionality and list bookmarks vertically

### DIFF
--- a/docs/src/components/Bookmarks/index.tsx
+++ b/docs/src/components/Bookmarks/index.tsx
@@ -29,15 +29,18 @@ const Bookmarks = () => {
   return bookmarks && Object.keys(bookmarks).length > 0 ? (
     <>
       {Object.entries(bookmarks).map(
-        ([key, slug]) =>
+        ([key, slug], index) =>
           slug && (
-            <StyledLink key={key} to={slug}>
-              {String(slug)
-                .split("/")
-                .filter(Boolean)
-                .map(s => s[0].toUpperCase().concat(s.slice(1)))
-                .join(" / ")}
-            </StyledLink>
+            <React.Fragment key={key}>
+              {index !== 0 ? <br /> : null}
+              <StyledLink to={slug}>
+                {String(slug)
+                  .split("/")
+                  .filter(Boolean)
+                  .map(s => s[0].toUpperCase().concat(s.slice(1)))
+                  .join(" / ")}
+              </StyledLink>
+            </React.Fragment>
           ),
       )}
     </>

--- a/docs/src/components/Navbar.tsx
+++ b/docs/src/components/Navbar.tsx
@@ -293,7 +293,8 @@ const Navbar = ({ location, docNavigation }: Props) => {
                       </ModalSection>
                     </>
                   )}
-                  <ModalFooter>
+                  {/* hiding this feature for now, we'll fully implement it later according to the design */}
+                  {/* <ModalFooter>
                     <Hide block on={["largeDesktop"]}>
                       {activeTab === "bookmarks" && editingBookmarks ? (
                         <>
@@ -352,7 +353,7 @@ const Navbar = ({ location, docNavigation }: Props) => {
                         </Stack>
                       )}
                     </Hide>
-                  </ModalFooter>
+                  </ModalFooter> */}
                 </Modal>
               </div>
             </Portal>


### PR DESCRIPTION
List bookmarks vertically and hide UI for managing bookmarks because this functionality doesn't exist yet.

 Storybook: https://orbit-fix-hide-bookmark-editing.surge.sh