### PR TITLE
improve: build tokens on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dev:test": "cross-env NODE_ENV=loki yarn dev",
     "clean:docs": "lerna run --scope @kiwicom/orbit.kiwi clean",
     "publish-packages": "gulp publish",
-    "orbit-kiwi:build": "yarn bootstrap:ci && yarn orbit-design-tokens quickbuild && yarn orbit-components build:lib && yarn orbit-kiwi build",
+    "orbit-kiwi:build": "yarn bootstrap:ci && yarn orbit-design-tokens build:lib && yarn orbit-components build:lib && yarn orbit-kiwi build",
     "prepare": "husky install"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dev:test": "cross-env NODE_ENV=loki yarn dev",
     "clean:docs": "lerna run --scope @kiwicom/orbit.kiwi clean",
     "publish-packages": "gulp publish",
-    "orbit-kiwi:build": "yarn bootstrap:ci && yarn orbit-design-tokens build:lib && yarn orbit-components build:lib && yarn orbit-kiwi build",
+    "orbit-kiwi:build": "yarn bootstrap:ci && yarn orbit-design-tokens quickbuild && yarn orbit-components build:lib && yarn orbit-kiwi build",
     "prepare": "husky install"
   },
   "engines": {

--- a/packages/orbit-design-tokens/package.json
+++ b/packages/orbit-design-tokens/package.json
@@ -26,11 +26,10 @@
     "build:xml": "NODE_RUN=true babel-node ./scripts/generateXMLDesignTokens.js",
     "prebuild": "rimraf lib src/js",
     "build": "yarn clean && yarn run build:lib && yarn run generate-json && yarn run build-html && yarn run build-web && yarn run build-ios && yarn run build-android && yarn build:xml",
-    "quickbuild": "yarn build:lib",
     "copy:lib": "copyfiles -u 1 'src/**/*.js.flow' lib && copyfiles -u 1 'src/**/*.d.ts' lib",
     "copy:es": "copyfiles -u 1 'src/**/*.js.flow' es && copyfiles -u 1 'src/**/*.d.ts' es ",
     "clean": "rimraf lib es pages output",
-    "postinstall": "yarn quickbuild",
+    "postinstall": "yarn build:lib",
     "prepublishOnly": "yarn build && pinst --disable",
     "postpublish": "pinst --enable"
   },

--- a/packages/orbit-design-tokens/package.json
+++ b/packages/orbit-design-tokens/package.json
@@ -26,10 +26,13 @@
     "build:xml": "NODE_RUN=true babel-node ./scripts/generateXMLDesignTokens.js",
     "prebuild": "rimraf lib src/js",
     "build": "yarn clean && yarn run build:lib && yarn run generate-json && yarn run build-html && yarn run build-web && yarn run build-ios && yarn run build-android && yarn build:xml",
+    "quickbuild": "yarn build:lib",
     "copy:lib": "copyfiles -u 1 'src/**/*.js.flow' lib && copyfiles -u 1 'src/**/*.d.ts' lib",
     "copy:es": "copyfiles -u 1 'src/**/*.js.flow' es && copyfiles -u 1 'src/**/*.d.ts' es ",
     "clean": "rimraf lib es pages output",
-    "prepublishOnly": "yarn build"
+    "postinstall": "yarn quickbuild",
+    "prepublishOnly": "yarn build && pinst --disable",
+    "postpublish": "pinst --enable"
   },
   "author": "Kiwi.com",
   "license": "MIT",


### PR DESCRIPTION
This script is important for development, so running it automatically after every install helps when switching between branches where tokens need to be rebuilt.

 Storybook: https://orbit-silvenon-improve-postinstall-build-tokens.surge.sh