### PR TITLE
chore: bump monstra to 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "memfs": "^3.2.0",
     "merge-stream": "^2.0.0",
     "mkdirp": "^1.0.4",
-    "monstra": "^0.9.1",
+    "monstra": "^0.9.2",
     "pinst": "^2.1.4",
     "prettier": "^2.1.2",
     "raf": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18108,10 +18108,10 @@ moniker@0.1.2:
   resolved "https://registry.yarnpkg.com/moniker/-/moniker-0.1.2.tgz#872dfba575dcea8fa04a5135b13d5f24beccc97e"
   integrity sha1-hy37pXXc6o+gSlE1sT1fJL7MyX4=
 
-monstra@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/monstra/-/monstra-0.9.1.tgz#0f126e2ce0d19567ecd0ff6c07d4368dc83f2758"
-  integrity sha512-9/zUsHsJBQtOGYt8kEOWEPbXJlv4tv8Kl8N0nmfOwbZNJtWmQAdq41kyUoBuxbYCi09dhZjtJ0UVEau2u9YfMg==
+monstra@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/monstra/-/monstra-0.9.2.tgz#01f75fe23bb9bd948badabdc37882a53d85dcd41"
+  integrity sha512-t5GBi229oVCx6nObjCEUPAPCanGyQNyQ139L0oCKZDbJsfmrVFKZWeSVDMDfBYK85Xnh16HqtebWAd9jB0lnjA==
   dependencies:
     chalk "^4.1.0"
     fast-glob "^3.2.5"


### PR DESCRIPTION
Bumped version with `bin/monstra.js` fix 
 Storybook: https://orbit-silvenon-fix-monstra-bin.surge.sh