### PR TITLE
docs: tweak and wrap design tokens docs

### DIFF
--- a/.github/foundation.md
+++ b/.github/foundation.md
@@ -1,6 +1,6 @@
 # Foundation
 
-Foundation object offers us very easy and quick way how to define design tokens and also how to simply create needed themes.
+Foundation object offers us very easy and quick way to define design tokens and also how to simply create needed themes.
 
 > You can overwrite some or all properties in this object with `getTokens` function.
 

--- a/docs/src/documentation/03-design-tokens/01-general.mdx
+++ b/docs/src/documentation/03-design-tokens/01-general.mdx
@@ -5,18 +5,27 @@ description: Design tokens store visual design attributes. They help us make our
 
 ## What are design tokens?
 
-Orbit design tokens could be considered as a simple way how to describe, document and use the visual language of Orbit design system. They represent our design decisions like the value of color, typography attributes, breakpoints, spacings, etc.
+Orbit design tokens could be considered as a simple way to describe, document
+and use the visual language of Orbit design system.
+They represent our design decisions
+like the value of color, typography attributes, breakpoints, spacings, etc.
 
 ## Organization
 
-We organize design tokens based on their planned and possible usage variety. Therefore we have two main levels of design tokens: **global design tokens** and **component specific design tokens**.
+We organize design tokens based on their planned and possible usage variety.
+Therefore we have two main levels of design tokens:
+**global design tokens** and **component specific design tokens**.
 
 ### Global design tokens
 
-Global level of our design tokens represents the core and main level of properties that can be used globally, in most use cases and describes the majority of the [foundation](/foundation).
+Global level of our design tokens represents the core
+and main level of properties that can be used globally,
+in most use cases and describes the majority of the [foundation](/foundation).
 
 ### Component specific design tokens
 
-On the other hand, component specific design tokens represents properties associated with a component or component group.
+On the other hand,
+component specific design tokens represents properties
+associated with a component or component group.
 
 They should be used only for their intended components and variants.

--- a/docs/src/documentation/03-design-tokens/02-installation.mdx
+++ b/docs/src/documentation/03-design-tokens/02-installation.mdx
@@ -3,7 +3,9 @@ title: Installation
 ---
 
 If you're already using `@kiwicom/orbit-components`,
-you don't need to install the tokens because they're included as a dependency to ensure compatibility, see []()
+you don't need to install the tokens
+because they're included as a dependency to ensure compatibility,
+see [usage with `@kiwicom/orbit-components`](#usage-with-kiwicomorbit-components).
 
 If not, you can install the package on its own.
 
@@ -17,13 +19,16 @@ yarn add @kiwicom/orbit-design-tokens
 
 ## Usage without @kiwicom/orbit-components
 
-Once installed in your codebase, you can use our design tokens in JavaScript environment with simply importing them.
+Once installed in your codebase,
+you can use our design tokens in JavaScript environment
+by simply importing them.
 
 ```js
 import { defaultTheme } from "@kiwicom/orbit-design-tokens";
 ```
 
-The `defaultTheme` object contains all design tokens that are available for every usage.
+The `defaultTheme` object contains all design tokens
+that are available for every usage.
 
 ```js
 /*
@@ -39,17 +44,21 @@ The `defaultTheme` object contains all design tokens that are available for ever
 }
 ```
 
-We recommend this specified usage only for cases when you don't need to work also with `@kiwicom/orbit-components`.
+Use this only in cases when you don't need to also work with `@kiwicom/orbit-components`.
 
 ## Usage with @kiwicom/orbit-components
 
-To be able to use our design tokens together with Orbit React components, we highly recommend using import from them, instead of from design tokens.
+To be able to use our design tokens together with Orbit React components,
+we highly recommend using import from the components package,
+instead of from design tokens.
 
 ```js
 import { defaultTheme } from "@kiwicom/orbit-components";
 ```
 
-There is only small minor change. The `defaultTheme` contains more various data that we use for creating more advanced and scale-able user interfaces.
+There is one minor difference:
+`defaultTheme` contains a few more things
+that we use for creating more advanced and scalable user interfaces.
 
 ```js
 /*
@@ -68,11 +77,14 @@ There is only small minor change. The `defaultTheme` contains more various data 
 }
 ```
 
-> You can read more the support of right-to-left languages [here](/development/utilities/rtl-languages).
+> You can read more about the [support of right-to-left languages](/development/utilities/rtl-languages).
 
-Since `@kiwicom/orbit-components` is build upon `styled-components` CSS-in-JS library, it's necessary to work with a theming (styling) context across the whole application.
+Since `@kiwicom/orbit-components` is build upon the `styled-components` CSS-in-JS library,
+it's necessary to work with a theming (styling) context across the whole application.
 
-To be able to use the same `theme` context object with same value across the whole application we encourage users to wrap the whole application into Orbits' `ThemeProvider`.
+To be able to use the same `theme` context object with same value
+across the whole application
+we encourage users to wrap the whole application into Orbit's `ThemeProvider`.
 
 ```js
 import * as React from "react";
@@ -83,7 +95,9 @@ const App = ({ children }) => {
 };
 ```
 
-And, most importantly consuming the `theme` by accessing the context object directly inside `styled-components`.
+And, most importantly consuming the `theme`
+by accessing the context object
+directly inside `styled-components`.
 
 ```jsx
 import * as React from "react";
@@ -94,6 +108,10 @@ export const CustomStyled = styled.div`
 `;
 ```
 
-This approach enables easier consistency how to work and consume the Orbit's foundation, tokenized by `@kiwicom/orbit-design-tokens`.
-Lastly, it also provides a better and easier way how to enable custom theming for your application. To read more about theming possibilities and implementation,
+This approach enables easier consistency
+when working and consuming Orbit's foundation,
+tokenized by `@kiwicom/orbit-design-tokens`.
+Lastly, it also provides a better and easier way
+of adding a custom theme to your application.
+To read more about theming possibilities and implementation,
 please check the [theming](/design-tokens/theming) page.

--- a/packages/orbit-design-tokens/docs/SCHEMA.md
+++ b/packages/orbit-design-tokens/docs/SCHEMA.md
@@ -1,8 +1,8 @@
 # Schema of @kiwicom/orbit-design-tokens
 
-Orbit design tokens could be considered as a simple way how to describe, document and use the visual language of Orbit design system, but there are multiple requirements that it needs to meet and support.
+Orbit design tokens could be considered as a simple way to describe, document and use the visual language of Orbit design system, but there are multiple requirements that it needs to meet and support.
 
-Therefore, we use structured and standardized way how Orbit design tokens are being created, stored and how we work with them.
+Therefore, we use structured and standardized way Orbit design tokens are being created, stored and how we work with them.
 
 ## Namespace / Object / Variant / Property
 
@@ -179,14 +179,14 @@ Status types:
 – success
 
 - warning
-– critical
+  – critical
 - neutral
 
 Ordered importance types:
 
 - primary
-– secondary
-– tertiary
+  – secondary
+  – tertiary
 
 We also use additional types connected to some specific behaviour, such as:
 
@@ -206,6 +206,7 @@ For transitioning, we use simple scale of three values that represents relative 
 
 – slow
 – normal
+
 - fast
 
 ### Typography scale


### PR DESCRIPTION
Added some tweaks and wrapped the docs seemingly according to how the rest of our docs is wrapped. Not sure what are the rules, though, I forgot where are the docs for that.
