### PR TITLE
fix(InputField): value color on iOS Safari when disabled

### DIFF
--- a/packages/orbit-components/src/InputField/index.js
+++ b/packages/orbit-components/src/InputField/index.js
@@ -221,7 +221,8 @@ export const Input: any = styled(
   ),
 )`
   appearance: none;
-  -webkit-text-fill-color: ${({ disabled }) => disabled && "inherit"};
+  -webkit-text-fill-color: ${({ disabled, theme }) =>
+    disabled && theme.orbit.colorTextInputDisabled};
   font-family: ${({ theme }) => theme.orbit.fontFamily};
   border: none;
   padding: ${getPadding()};


### PR DESCRIPTION
Related to [Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1628069883005000).
 Storybook: https://orbit-silvenon-fix-input-ios.surge.sh