### PR TITLE
feat(Modal): add mobileHeader prop

### DIFF
--- a/packages/orbit-components/src/Modal/Modal.stories.js
+++ b/packages/orbit-components/src/Modal/Modal.stories.js
@@ -436,6 +436,7 @@ export const FullPreview = (): React.Node => {
   const flex = array("Flex", ["0 0 auto", "1 1 100%"]);
   const dataTest = text("dataTest", "test");
   const isMobileFullPage = boolean("isMobileFullPage", false);
+  const mobileHeader = boolean("mobileHeader", true);
   const showBack = boolean("showBackButton", true);
   const preventOverlayClose = boolean("preventOverlayClose", false);
 
@@ -450,6 +451,7 @@ export const FullPreview = (): React.Node => {
     >
       <ModalHeader
         title={title}
+        mobileHeader={mobileHeader}
         illustration={illustration && <Illustration name={illustration} size="small" />}
         description={description}
         suppressed={suppressed}

--- a/packages/orbit-components/src/Modal/ModalHeader/index.d.ts
+++ b/packages/orbit-components/src/Modal/ModalHeader/index.d.ts
@@ -2,7 +2,6 @@
 // Project: http://github.com/kiwicom/orbit
 import * as React from "react";
 
-import { Props as IllustrationProps } from "../../Illustration";
 import * as Common from "../../common/common";
 
 declare module "@kiwicom/orbit-components/lib/Modal/ModalHeader";
@@ -10,6 +9,7 @@ declare module "@kiwicom/orbit-components/lib/Modal/ModalHeader";
 export interface Props extends Common.Global {
   readonly children?: React.ReactNode;
   readonly illustration?: React.ReactNode;
+  readonly mobileHeader?: boolean;
   readonly title?: React.ReactNode;
   readonly description?: React.ReactNode;
   readonly suppressed?: boolean;

--- a/packages/orbit-components/src/Modal/ModalHeader/index.js
+++ b/packages/orbit-components/src/Modal/ModalHeader/index.js
@@ -153,6 +153,7 @@ const StyledModalHeaderContent = styled.div`
 
 const ModalHeader = ({
   illustration,
+  mobileHeader = true,
   suppressed,
   children,
   description,
@@ -195,7 +196,9 @@ const ModalHeader = ({
       {children && (
         <StyledModalHeaderContent description={!!description}>{children}</StyledModalHeaderContent>
       )}
-      {title && <MobileHeader isMobileFullPage={isMobileFullPage}>{title}</MobileHeader>}
+      {title && mobileHeader && (
+        <MobileHeader isMobileFullPage={isMobileFullPage}>{title}</MobileHeader>
+      )}
     </StyledModalHeader>
   );
 };

--- a/packages/orbit-components/src/Modal/ModalHeader/index.js.flow
+++ b/packages/orbit-components/src/Modal/ModalHeader/index.js.flow
@@ -7,6 +7,7 @@ import type { Globals } from "../../common/common.js.flow";
 export type Props = {|
   ...Globals,
   +children?: React.Node,
+  +mobileHeader?: boolean,
   +illustration?: React.Node,
   +title?: React.Node,
   +description?: React.Node,

--- a/packages/orbit-components/src/Modal/README.md
+++ b/packages/orbit-components/src/Modal/README.md
@@ -151,14 +151,15 @@ import Modal, { ModalHeader } from "@kiwicom/orbit-components/lib/Modal";
 
 Table below contains all types of the props in the ModalHeader component.
 
-| Name         | Type                                 | Default | Description                                            |
-| :----------- | :----------------------------------- | :------ | :----------------------------------------------------- |
-| children     | `React.Node`                         |         | The content of the ModalHeader.                        |
-| dataTest     | `string`                             |         | Optional prop for testing purposes.                    |
-| description  | `React.Node`                         |         | The displayed description of the ModalHeader.          |
-| illustration | `React.Element<typeof Illustration>` |         | The displayed Illustration of the ModalHeader.         |
-| suppressed   | `boolean`                            | `false` | If `true` the ModalHeader will have cloudy background. |
-| title        | `React.Node`                         |         | The displayed title of the ModalHeader.                |
+| Name         | Type                                 | Default | Description                                                                    |
+| :----------- | :----------------------------------- | :------ | :----------------------------------------------------------------------------- |
+| children     | `React.Node`                         |         | The content of the ModalHeader.                                                |
+| dataTest     | `string`                             |         | Optional prop for testing purposes.                                            |
+| description  | `React.Node`                         |         | The displayed description of the ModalHeader.                                  |
+| illustration | `React.Element<typeof Illustration>` |         | The displayed Illustration of the ModalHeader.                                 |
+| suppressed   | `boolean`                            | `false` | If `true` the ModalHeader will have cloudy background.                         |
+| mobileHeader | `boolean`                            | `true`  | If `false` the ModalHeader will not have MobileHeader which appears on scroll. |
+| title        | `React.Node`                         |         | The displayed title of the ModalHeader.                                        |
 
 ### ModalFooter
 


### PR DESCRIPTION
[Slack request. ](https://skypicker.slack.com/archives/CAMS40F7B/p1628082105007800). 

It should be possible to turn off `MobileHeader`, added the prop, which is default set to `true`. 
 Storybook: https://orbit-silvenon-feat-no-mobile-header.surge.sh