### PR TITLE
fix(Modal): hide closeContainer with mobileHeader set to false

### DIFF
--- a/packages/orbit-components/src/Modal/Modal.stories.js
+++ b/packages/orbit-components/src/Modal/Modal.stories.js
@@ -37,6 +37,7 @@ export const Sizes = (): React.Node => {
   const size = select("Size", Object.values(SIZES), SIZES.NORMAL);
   const title = text("Title", "Orbit design system");
   const description = text("Title", "I'm lovely description");
+  const mobileHeader = boolean("mobileHeader", true);
 
   const onClose = action("onClose");
   const content = text(
@@ -44,7 +45,7 @@ export const Sizes = (): React.Node => {
     "You can try all possible configurations of this component. However, check Orbit.Kiwi for more detailed design guidelines.",
   );
   return (
-    <Modal size={size} onClose={onClose}>
+    <Modal size={size} onClose={onClose} mobileHeader={mobileHeader}>
       <ModalHeader title={title}>{description}</ModalHeader>
       <ModalSection>
         <Text>{content}</Text>
@@ -443,6 +444,7 @@ export const FullPreview = (): React.Node => {
   return (
     <Modal
       onClose={onClose}
+      mobileHeader={mobileHeader}
       size={size}
       fixedFooter={fixed}
       dataTest={dataTest}
@@ -451,7 +453,6 @@ export const FullPreview = (): React.Node => {
     >
       <ModalHeader
         title={title}
-        mobileHeader={mobileHeader}
         illustration={illustration && <Illustration name={illustration} size="small" />}
         description={description}
         suppressed={suppressed}

--- a/packages/orbit-components/src/Modal/ModalContext.d.ts
+++ b/packages/orbit-components/src/Modal/ModalContext.d.ts
@@ -13,6 +13,7 @@ export interface Props {
   readonly removeHasModalSection?: () => void;
   readonly manageFocus?: () => void;
   readonly hasModalSection?: boolean;
+  readonly hasMobileHeader?: boolean;
   readonly isMobileFullPage?: boolean;
   readonly isInsideModal?: boolean;
   readonly closable?: boolean;

--- a/packages/orbit-components/src/Modal/ModalContext.js
+++ b/packages/orbit-components/src/Modal/ModalContext.js
@@ -9,6 +9,7 @@ export const ModalContext: ModalContextType = React.createContext({
   removeHasModalSection: () => {},
   callContextFunctions: () => {},
   hasModalSection: false,
+  hasMobileHeader: true,
   isMobileFullPage: false,
   isInsideModal: false,
   closable: false,

--- a/packages/orbit-components/src/Modal/ModalContext.js.flow
+++ b/packages/orbit-components/src/Modal/ModalContext.js.flow
@@ -7,6 +7,7 @@ export type ModalContextProps = {|
   +removeHasModalSection?: () => void,
   +callContextFunctions?: () => void,
   +hasModalSection?: boolean,
+  +hasMobileHeader?: boolean,
   +isMobileFullPage?: boolean,
   +isInsideModal?: boolean,
   +closable?: boolean,

--- a/packages/orbit-components/src/Modal/ModalHeader/index.d.ts
+++ b/packages/orbit-components/src/Modal/ModalHeader/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
-import * as React from "react";
+import React from "react";
 
 import * as Common from "../../common/common";
 
@@ -9,7 +9,6 @@ declare module "@kiwicom/orbit-components/lib/Modal/ModalHeader";
 export interface Props extends Common.Global {
   readonly children?: React.ReactNode;
   readonly illustration?: React.ReactNode;
-  readonly mobileHeader?: boolean;
   readonly title?: React.ReactNode;
   readonly description?: React.ReactNode;
   readonly suppressed?: boolean;

--- a/packages/orbit-components/src/Modal/ModalHeader/index.js
+++ b/packages/orbit-components/src/Modal/ModalHeader/index.js
@@ -153,14 +153,13 @@ const StyledModalHeaderContent = styled.div`
 
 const ModalHeader = ({
   illustration,
-  mobileHeader = true,
   suppressed,
   children,
   description,
   title,
   dataTest,
 }: Props): React.Node => {
-  const { setHasModalTitle, isMobileFullPage } = React.useContext(ModalContext);
+  const { setHasModalTitle, hasMobileHeader, isMobileFullPage } = React.useContext(ModalContext);
 
   useModalContextFunctions();
 
@@ -196,7 +195,7 @@ const ModalHeader = ({
       {children && (
         <StyledModalHeaderContent description={!!description}>{children}</StyledModalHeaderContent>
       )}
-      {title && mobileHeader && (
+      {title && hasMobileHeader && (
         <MobileHeader isMobileFullPage={isMobileFullPage}>{title}</MobileHeader>
       )}
     </StyledModalHeader>

--- a/packages/orbit-components/src/Modal/README.md
+++ b/packages/orbit-components/src/Modal/README.md
@@ -36,6 +36,7 @@ Table below contains all types of the props available in the Modal component.
 | hasCloseButton      | `boolean`                  | `true`     | Defines whether the Modal displays a close button. If you disable this, we recommend adding some kind of an alternative.                                                                             |
 | autoFocus           | `boolean`                  | `true`     | The autofocus attribute of the Modal, see [this docs](https://www.w3schools.com/tags/att_autofocus.asp).                                                                                             |
 | disableAnimation    | `boolean`                  | `false`    | Defines whether the Modal performs the slide in animation on mobile. If you want to improve your [CLS](https://web.dev/cls/) score, you might want to set this to `true`.                            |
+| mobileHeader        | `boolean`                  | `true`     | If `false` the ModalHeader will not have MobileHeader and CloseContainer                                                                                                                             |
 
 ### Modal enum
 
@@ -151,15 +152,14 @@ import Modal, { ModalHeader } from "@kiwicom/orbit-components/lib/Modal";
 
 Table below contains all types of the props in the ModalHeader component.
 
-| Name         | Type                                 | Default | Description                                                                    |
-| :----------- | :----------------------------------- | :------ | :----------------------------------------------------------------------------- |
-| children     | `React.Node`                         |         | The content of the ModalHeader.                                                |
-| dataTest     | `string`                             |         | Optional prop for testing purposes.                                            |
-| description  | `React.Node`                         |         | The displayed description of the ModalHeader.                                  |
-| illustration | `React.Element<typeof Illustration>` |         | The displayed Illustration of the ModalHeader.                                 |
-| suppressed   | `boolean`                            | `false` | If `true` the ModalHeader will have cloudy background.                         |
-| mobileHeader | `boolean`                            | `true`  | If `false` the ModalHeader will not have MobileHeader which appears on scroll. |
-| title        | `React.Node`                         |         | The displayed title of the ModalHeader.                                        |
+| Name         | Type                                 | Default | Description                                            |
+| :----------- | :----------------------------------- | :------ | :----------------------------------------------------- |
+| children     | `React.Node`                         |         | The content of the ModalHeader.                        |
+| dataTest     | `string`                             |         | Optional prop for testing purposes.                    |
+| description  | `React.Node`                         |         | The displayed description of the ModalHeader.          |
+| illustration | `React.Element<typeof Illustration>` |         | The displayed Illustration of the ModalHeader.         |
+| suppressed   | `boolean`                            | `false` | If `true` the ModalHeader will have cloudy background. |
+| title        | `React.Node`                         |         | The displayed title of the ModalHeader.                |
 
 ### ModalFooter
 

--- a/packages/orbit-components/src/Modal/index.d.ts
+++ b/packages/orbit-components/src/Modal/index.d.ts
@@ -19,6 +19,7 @@ export interface Props extends Common.Global {
     React.KeyboardEvent<HTMLDivElement> | React.SyntheticEvent<HTMLButtonElement> | React.MouseEvent
   >;
   readonly fixedFooter?: boolean;
+  readonly mobileHeader?: boolean;
   readonly isMobileFullPage?: boolean;
   readonly preventOverlayClose?: boolean;
   readonly hasCloseButton?: boolean;

--- a/packages/orbit-components/src/Modal/index.js
+++ b/packages/orbit-components/src/Modal/index.js
@@ -347,6 +347,7 @@ const Modal: React.AbstractComponent<Props, Instance> = React.forwardRef<Props, 
       isMobileFullPage = false,
       preventOverlayClose = false,
       hasCloseButton = true,
+      mobileHeader = true,
       disableAnimation = false,
       dataTest,
       lockScrolling = true,
@@ -638,7 +639,7 @@ const Modal: React.AbstractComponent<Props, Instance> = React.forwardRef<Props, 
       }
     }, [children, prevChildren]);
 
-    const hasCloseContainer = hasModalTitle || (onClose && hasCloseButton);
+    const hasCloseContainer = mobileHeader && (hasModalTitle || (onClose && hasCloseButton));
 
     return (
       <ModalBody
@@ -696,6 +697,7 @@ const Modal: React.AbstractComponent<Props, Instance> = React.forwardRef<Props, 
                 removeHasModalSection: () => setHasModalSection(false),
                 callContextFunctions,
                 hasModalSection,
+                hasMobileHeader: mobileHeader,
                 isMobileFullPage,
                 closable: Boolean(onClose),
                 isInsideModal: true,

--- a/packages/orbit-components/src/Modal/index.js.flow
+++ b/packages/orbit-components/src/Modal/index.js.flow
@@ -38,6 +38,7 @@ export type Props = {|
   +isMobileFullPage?: boolean,
   +preventOverlayClose?: boolean,
   +hasCloseButton?: boolean,
+  +mobileHeader?: boolean,
   +disableAnimation?: boolean,
   ...Globals,
 |};


### PR DESCRIPTION
[Slack request. ](https://skypicker.slack.com/archives/CAMS40F7B/p1628082105007800)

Related to: #2634, #3063 

Not sure about condition, which sets `CloseContainer`, did not want to leave there only `onClose and hasCloseButton`. In my opinion, it should appear only if `onClose` passed. 

 Storybook: https://orbit-silvenon-fix-close-container.surge.sh