### PR TITLE
docs: add FigmaIframe component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -235,6 +235,7 @@ module.exports = {
         ImageContainer: false,
         InlineToken: false,
         ReactExample: false,
+        FigmaIframe: false,
       },
     },
     // some ESLint rules fail in certain cases, so we're disabling them

--- a/docs/src/components/DocLayout/index.tsx
+++ b/docs/src/components/DocLayout/index.tsx
@@ -24,6 +24,7 @@ import TableOfContents from "../TableOfContents";
 import { useTableOfContents } from "../../services/table-of-contents";
 import Tabs, { TabObject } from "../Tabs";
 import ReactExample from "../ReactExample";
+import FigmaIframe from "../FigmaIframe";
 import Footer from "../Footer";
 import StyledWrapper from "./primitives/StyledWrapper";
 import StyledMiddle from "./primitives/StyledMiddle";
@@ -209,6 +210,7 @@ export default function DocLayout({
                             ImageContainer,
                             InlineToken,
                             ReactExample,
+                            FigmaIframe,
                           }}
                         >
                           {children}

--- a/docs/src/components/FigmaIframe.tsx
+++ b/docs/src/components/FigmaIframe.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import styled, { css } from "styled-components";
+
+interface Props {
+  border?: string;
+  height?: number;
+  maxWidth: number;
+}
+
+const StyledIframe = styled.iframe<Props>`
+  ${({ border, height, maxWidth }) => css`
+    width: 100%;
+    height: ${height && `${height}px`};
+    max-width: ${maxWidth && `${maxWidth}px`};
+    border: ${border || `1px solid rgba(0, 0, 0, 0.1)`};
+  `}
+`;
+
+const FigmaIframe = ({ maxWidth, height = 400, ...props }: Props) => {
+  return (
+    <StyledIframe allowFullScreen loading="lazy" height={height} maxWidth={maxWidth} {...props} />
+  );
+};
+
+export default FigmaIframe;

--- a/docs/src/documentation/03-components/03-information/badge/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/03-information/badge/01-guidelines.mdx
@@ -23,7 +23,10 @@ redirect_from:
 
 ## Content structure
 
-<iframe title="Button states" style={{ border: "1px solid rgba(0, 0, 0, 0.1)", maxWidth: "700px", height: "350px" }} src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F4QJZqvBvRrLu6t9mwObCkA%2FOrbit-Component-Content-Structure%3Fnode-id%3D286%253A46" allowFullScreen width="100%" height="600px" loading="lazy" />
+<FigmaIframe
+  height={300}
+  src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F4QJZqvBvRrLu6t9mwObCkA%2FOrbit-Component-Content-Structure%3Fnode-id%3D286%253A46"
+/>
 
 ## Behavior
 

--- a/docs/src/documentation/03-components/03-information/badge/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/03-information/badge/01-guidelines.mdx
@@ -28,6 +28,9 @@ redirect_from:
   src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F4QJZqvBvRrLu6t9mwObCkA%2FOrbit-Component-Content-Structure%3Fnode-id%3D286%253A46"
 />
 
+**1. Icon** (Supports the label) <br />
+**2. Label** (Works best when short)
+
 ## Behavior
 
 ### Display static info


### PR DESCRIPTION
Added `FigmaIframe` component. For @williamkolmacka, in order to add examples from Figma. 
 Storybook: https://orbit-silvenon-docs-small-visual-fixes.surge.sh