### PR TITLE
fix(useLockScrolling): fix body positioning on iOS

### DIFF
--- a/packages/orbit-components/src/hooks/useLockScrolling/index.js
+++ b/packages/orbit-components/src/hooks/useLockScrolling/index.js
@@ -4,17 +4,36 @@ import { disableBodyScroll, clearAllBodyScrollLocks } from "body-scroll-lock";
 
 import typeof UseLockScrolling from ".";
 
+function lockScrolling(el: HTMLElement): void {
+  disableBodyScroll(el);
+  // body-scroll-lock sets fixed position on requestAnimationFrame
+  // so we need to use it as well
+  window.requestAnimationFrame(() => {
+    if (document.body && document.body.style.position === "fixed") {
+      // avoid a bug on iOS Safari where body doesn't take up full width
+      document.body.style.right = "0";
+    }
+  });
+}
+
+function unlockScrolling() {
+  if (document.body && document.body.style.position === "fixed") {
+    document.body.style.right = "";
+  }
+  clearAllBodyScrollLocks();
+}
+
 const useLockScrolling: UseLockScrolling = (ref, lock = true) => {
   useLayoutEffect(() => {
     if (ref.current) {
       if (lock) {
-        disableBodyScroll(ref.current);
+        lockScrolling(ref.current);
       } else {
-        clearAllBodyScrollLocks();
+        unlockScrolling();
       }
     }
     return () => {
-      clearAllBodyScrollLocks();
+      unlockScrolling();
     };
   }, [ref, lock]);
 };


### PR DESCRIPTION
This fixes a bug on iOS Safari where locking scroll was causing body not to take up full width of the screen because body-scroll-lock sets only top and left position.

 Storybook: https://orbit-silvenon-fix-scroll-lock-positioning.surge.sh