### PR TITLE
fix: rtl doc code example goes wrong

### DIFF
--- a/packages/orbit-components/src/utils/rtl/README.md
+++ b/packages/orbit-components/src/utils/rtl/README.md
@@ -8,7 +8,7 @@ If you need to enable `rtl` inside `orbit-components`, set it inside `ThemeProvi
 import { ThemeProvider } from "styled-components";
 import { defaultTheme } from "@kiwicom/orbit-components";
 
-<ThemeProvider theme={{ orbit: defaultTheme, rtl: true }}>
+<ThemeProvider theme={{ ...defaultTheme, rtl: true }}>
   <App />
 </ThemeProvider>;
 ```


### PR DESCRIPTION
This Pull Request meets the following criteria:

- [x] Tests have been added/adjusted for my new feature
- [x] New Components are registered in index.js of my project
- [x] New Components has both `.flow` and `d.ts` files and are exprorted in `index.js.flow` and `index.d.ts`
