### PR TITLE
fix(Badge): add border to type white

### DIFF
--- a/packages/orbit-components/src/Badge/index.js
+++ b/packages/orbit-components/src/Badge/index.js
@@ -42,7 +42,7 @@ const getTypeToken = ({ name, theme, type }) => {
       [TYPE_OPTIONS.WARNING]: theme.orbit.paletteOrangeLightHover,
       [TYPE_OPTIONS.CRITICAL]: theme.orbit.paletteRedLightHover,
       [TYPE_OPTIONS.DARK]: null,
-      [TYPE_OPTIONS.WHITE]: null,
+      [TYPE_OPTIONS.WHITE]: theme.orbit.paletteCloudDark,
       [TYPE_OPTIONS.INFO_INVERTED]: null,
       [TYPE_OPTIONS.CRITICAL_INVERTED]: null,
       [TYPE_OPTIONS.SUCCESS_INVERTED]: null,


### PR DESCRIPTION
Added border to type `white` as we discussed before. 
 Storybook: https://orbit-silvenon-fix-white-badge-border.surge.sh