### PR TITLE
chore: fix TypeScript errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,7 +96,11 @@ module.exports = {
         "prettier/@typescript-eslint",
       ],
       parserOptions: {
-        project: ["./tsconfig.json", "./packages/orbit-components/cypress/tsconfig.json"],
+        project: [
+          "./tsconfig.json",
+          "./docs/tsconfig.json",
+          "./packages/orbit-components/cypress/tsconfig.json",
+        ],
         ecmaVersion: 2018,
         sourceType: "module",
       },

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,8 +15,8 @@
     "@csstools/convert-colors": "^2.0.0",
     "@icons-pack/react-simple-icons": "^4.0.0",
     "@jsdevtools/rehype-url-inspector": "^2.0.2",
-    "@kiwicom/babel-plugin-orbit-components": "^2.5.0",
-    "@kiwicom/orbit-design-tokens": "^0.14.0",
+    "@kiwicom/babel-plugin-orbit-components": "*",
+    "@kiwicom/orbit-design-tokens": "*",
     "@loadable/component": "^5.15.0",
     "@mapbox/rehype-prism": "^0.6.0",
     "@mdx-js/mdx": "^1.6.22",
@@ -67,7 +67,7 @@
     "vfile-reporter": "^6.0.2"
   },
   "dependencies": {
-    "@kiwicom/orbit-components": "^0.122.0",
+    "@kiwicom/orbit-components": "*",
     "@streamlinehq/streamlinehq": "^3.0.3",
     "@types/lodash": "^4.14.170",
     "@types/react-helmet": "^6.1.1",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*"],
+  "exclude": []
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prettier:test": "prettier --check '**/*.md'",
     "eslint:ci": "eslint-config-prettier index.js index.ts && eslint . --report-unused-disable-directives",
     "eslint:docs": "eslint --fix docs/src/documentation --report-unused-disable-directives",
-    "check-types": "yarn tsc && yarn tsc --project packages/orbit-components/cypress",
+    "check-types": "tsc && tsc --project docs && tsc --project packages/orbit-components/cypress",
     "check-links": "yarn check-links:src && yarn check-links:dist",
     "check-links:src": "remark -e '.mdx' -fq -u validate-links docs/src/documentation --no-config",
     "check-links:dist": "node docs/services/check-links.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
   "include": [
     "packages/orbit-components/**/*",
     "packages/orbit-design-tokens/**/*",
-    "packages/eslint-plugin-orbit-components/**/*",
-    "docs/**/*"
+    "packages/eslint-plugin-orbit-components/**/*"
   ],
   "exclude": ["packages/orbit-components/cypress/**/*.test.*"]
 }


### PR DESCRIPTION
If we check docs separately `docs/styled.d.ts` won't cause problems when changing the global type for default theme.

 Storybook: https://orbit-silvenon-chore-fix-typescript-errors.surge.sh