### PR TITLE
fix(Icon): explicitly set expected `display`

### DIFF
--- a/packages/orbit-components/src/Icon/index.js
+++ b/packages/orbit-components/src/Icon/index.js
@@ -48,6 +48,7 @@ const StyledIcon = styled(({ className, viewBox, dataTest, children, ariaHidden,
     {children}
   </svg>
 ))`
+  display: inline-block;
   width: ${({ size }) => getSize(size)};
   height: ${({ size }) => getSize(size)};
   flex-shrink: 0; // prevent shrinking when used in flex-box

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/__tests__/__snapshots__/index.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Tooltip it should match snapshot 1`] = `
 .c1 {
+  display: inline-block;
   width: 24px;
   height: 24px;
   -webkit-flex-shrink: 0;


### PR DESCRIPTION
On orbit.kiwi the default `display` for `<svg>` elements is `block`, so `vertica-align: middle` didn't work, and icons in Alert components were incorrectly aligned.

 Storybook: https://orbit-silvenon-fix-icon-inline-block.surge.sh