### PR TITLE
fix(useLockScrolling): ensure that scroll is locked by default

### DIFF
--- a/packages/orbit-components/cypress/integration/index.tsx
+++ b/packages/orbit-components/cypress/integration/index.tsx
@@ -35,7 +35,7 @@ function App() {
           theme={{
             ...defaultTheme,
             // eslint-disable-next-line no-restricted-globals
-            lockScrolling: location.search !== "?disabled",
+            lockScrolling: location.search === "?disabled" ? false : undefined,
           }}
         >
           <LockScrolling />

--- a/packages/orbit-components/src/hooks/useLockScrolling/index.js
+++ b/packages/orbit-components/src/hooks/useLockScrolling/index.js
@@ -26,10 +26,10 @@ function unlockScrolling() {
 }
 
 const useLockScrolling: UseLockScrolling = (ref, lock = true, dependencies = []) => {
-  const theme = useTheme();
+  const { lockScrolling: themeLockScrolling = true } = useTheme();
 
   useLayoutEffect(() => {
-    if (ref.current && lock && theme.lockScrolling) {
+    if (ref.current && lock && themeLockScrolling) {
       lockScrolling(ref.current);
     }
     return () => {
@@ -37,7 +37,7 @@ const useLockScrolling: UseLockScrolling = (ref, lock = true, dependencies = [])
     };
     // the rule doesn't know that "ref" is a ref object
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lock, theme.lockScrolling, ...dependencies]);
+  }, [lock, themeLockScrolling, ...dependencies]);
 };
 
 export default useLockScrolling;


### PR DESCRIPTION
Currently we don't merge theme given to `ThemeProvider` with default theme, so unless people merge it themselves, `lockScrolling` will be falsy and `useLockScrolling` will not lock scrolling. Instead of merging the given with the default theme, which might cause unexpected changes, we'll simply treat `lockScrolling` as `true` if it's not being set.

 Storybook: https://orbit-silvenon-fix-theme-lock-scrolling-default.surge.sh