### PR TITLE
fix(InputField): label before tags and spacing

### DIFF
--- a/packages/orbit-components/src/InputField/InputTags/index.js
+++ b/packages/orbit-components/src/InputField/InputTags/index.js
@@ -18,7 +18,6 @@ const StyledInputTags = styled.div`
   z-index: 2;
   min-width: 50px;
   overflow: hidden;
-  order: -1;
 `;
 
 // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198

--- a/packages/orbit-components/src/InputField/index.js
+++ b/packages/orbit-components/src/InputField/index.js
@@ -148,7 +148,10 @@ const StyledInlineLabel = styled.div`
   align-items: center;
   pointer-events: none;
   justify-content: center;
-  padding: ${({ theme }) => rtlSpacing(`0 0 0 ${theme.orbit.spaceXXSmall}`)};
+  padding: ${({ theme, hasTags, hasFeedback }) =>
+    rtlSpacing(
+      `0 0 0 ${!hasTags && hasFeedback ? theme.orbit.spaceXXSmall : theme.orbit.spaceSmall}`,
+    )};
 
   ${FormLabel} {
     margin-bottom: 0;
@@ -434,7 +437,12 @@ const InputField: InputFieldType = React.forwardRef((props, ref) => {
             prefix && <Prefix size={size}>{prefix}</Prefix>
           )}
           {label && inlineLabel && (
-            <StyledInlineLabel ref={labelRef} size={size}>
+            <StyledInlineLabel
+              hasTags={!!tags}
+              hasFeedback={!!(error || help)}
+              ref={labelRef}
+              size={size}
+            >
               <FormLabel
                 filled={!!value}
                 required={required}
@@ -446,6 +454,7 @@ const InputField: InputFieldType = React.forwardRef((props, ref) => {
               </FormLabel>
             </StyledInlineLabel>
           )}
+          {tags && <InputTags>{tags}</InputTags>}
           <Input
             data-test={dataTest}
             required={required}
@@ -484,7 +493,6 @@ const InputField: InputFieldType = React.forwardRef((props, ref) => {
             inputMode={inputMode}
             dataAttrs={dataAttrs}
           />
-          {tags && <InputTags>{tags}</InputTags>}
           {suffix && <Suffix size={size}>{suffix}</Suffix>}
           <FakeInput size={size} disabled={disabled} error={error} />
         </InputContainer>

--- a/packages/orbit-components/src/Popover/index.d.ts
+++ b/packages/orbit-components/src/Popover/index.d.ts
@@ -31,5 +31,7 @@ export interface Props extends Common.Global {
   readonly renderInPortal?: boolean;
   readonly onClose?: Common.Callback;
 }
-declare class Popover extends React.Component<Props> {}
+
+declare const Popover: React.FunctionComponent<Props>;
+
 export { Popover, Popover as default };


### PR DESCRIPTION
- [Fixes slack request. ](https://skypicker.slack.com/archives/CAMS40F7B/p1632485533109900). Plus there was a bug with too small spacing in normal inputs (not in error forms). 
- Fixed type definition in the `Popover`
 Storybook: https://orbit-silvenon-fix-small-fixes.surge.sh