### PR TITLE
refactor: rewrite viewport ruler

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@kiwicom/orbit-components": "*",
+    "use-resize-observer": "^8.0.0",
     "@streamlinehq/streamlinehq": "^3.0.3",
     "@types/lodash": "^4.14.170",
     "@types/react-helmet": "^6.1.1",

--- a/docs/src/components/ReactExample/Example.tsx
+++ b/docs/src/components/ReactExample/Example.tsx
@@ -18,13 +18,14 @@ const StyledWrapper = styled.div<{ isFullPage?: boolean }>`
     grid-template-columns: 1fr;
     border-radius: 12px;
     border: 1px solid ${theme.orbit.paletteCloudDark};
+    overflow: hidden;
   `};
 `;
 
-const StyledWrapperFrame = styled.div<{ width: number }>`
+const StyledWrapperFrame = styled.div<{ width: number | string }>`
   ${({ width }) => css`
     margin: 0 auto;
-    max-width: ${width}px;
+    max-width: ${typeof width === "number" ? `${width}px` : width};
     width: 100%;
   `}
 `;
@@ -78,7 +79,7 @@ const Example = ({
     exampleVariants[0]?.name ?? null,
   );
   const [selectedBackground, setSelectedBackground] = React.useState<BgType>("white");
-  const [width, setPreviewWidth] = React.useState(0);
+  const [width, setPreviewWidth] = React.useState<number | string>(0);
   const handleChangeRulerSize = React.useCallback(size => setPreviewWidth(size), []);
 
   React.useEffect(() => {

--- a/docs/src/components/ReactExample/components/ViewportsRuler.tsx
+++ b/docs/src/components/ReactExample/components/ViewportsRuler.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import styled, { css } from "styled-components";
-import useMediaQuery from "@kiwicom/orbit-components/lib/hooks/useMediaQuery";
+import { useMediaQuery, Text } from "@kiwicom/orbit-components";
+import useResizeObserver from "use-resize-observer";
 
 import { QUERIES, CELL_HEIGHT } from "../consts";
 
 interface Props {
-  onChangeSize: (width: number) => void;
+  onChangeSize: (width: number | string) => void;
 }
 
 const StyledViewports = styled.div`
@@ -21,28 +22,26 @@ const StyledViewports = styled.div`
   `}
 `;
 
-const StyledCell = styled(({ className, children, onClick, onMouseEnter }) => (
-  <button type="button" className={className} onClick={onClick} onMouseEnter={onMouseEnter}>
-    {children}
-  </button>
-))`
-  ${({ theme, active, width, index }) => css`
+const StyledCell = styled.button.attrs({ type: "button" })<{
+  $active: boolean;
+  $width: number | string;
+}>`
+  ${({ theme, $active, $width }) => css`
     position: absolute;
     margin-left: auto;
     margin-right: auto;
     left: 0;
     right: 0;
     text-align: center;
-    background: ${active && theme.orbit.paletteCloudLight};
+    background: ${$active && theme.orbit.paletteCloudLight};
     color: ${theme.orbit.paletteInkNormal};
     cursor: pointer;
-    z-index: ${index};
-    width: ${width}px;
+    width: ${typeof $width === "number" ? `${$width}px` : $width};
     height: ${CELL_HEIGHT - 1}px;
     border-right: 1px solid ${theme.orbit.paletteCloudDark};
     border-left: 1px solid ${theme.orbit.paletteCloudDark};
     span {
-      visibility: ${active ? "visible" : "hidden"};
+      visibility: ${$active ? "visible" : "hidden"};
     }
     &:focus {
       outline: none;
@@ -51,62 +50,72 @@ const StyledCell = styled(({ className, children, onClick, onMouseEnter }) => (
   `}
 `;
 
+const StyledLabel = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  display: grid;
+  place-content: center;
+  pointer-events: none;
+`;
+
 const ViewportsRuler = ({ onChangeSize }: Props) => {
-  const [windowWidth, setWindowWidth] = React.useState(QUERIES.smallMobile);
-  const [activeIdx, setActiveIdx] = React.useState<number | null>(null);
-  const [viewports, setViewports] = React.useState<[string, number][]>([]);
-  const [visibleValue, setVisibleValue] = React.useState("smallMobile (320px)");
-  const ref = React.useRef<HTMLDivElement | null>(null);
+  const [activeViewport, setActiveViewport] = React.useState<string>("smallMobile");
+  const [targetViewport, setTargetViewport] = React.useState<string | null>(null);
+  const [viewports, setViewports] = React.useState<string[]>(Object.keys(QUERIES));
+  const { ref: containerRef, width: containerWidth } = useResizeObserver<HTMLDivElement>();
   const { isLargeMobile } = useMediaQuery();
 
-  const setRuler = React.useCallback(() => {
-    const currentViews = Object.entries(QUERIES)
-      .filter(([, value]) => value <= windowWidth)
-      .concat([["fullWidth", windowWidth]])
-      .reverse();
+  React.useEffect(() => {
+    const newViewports = Object.keys(QUERIES).filter(
+      viewport =>
+        typeof containerWidth !== "number" ||
+        typeof QUERIES[viewport] === "string" ||
+        QUERIES[viewport] < containerWidth,
+    );
 
-    setActiveIdx(currentViews.length - 1);
-
-    setViewports(currentViews);
-  }, [windowWidth, setViewports]);
-
-  const handleResize = React.useCallback(() => {
-    onChangeSize(QUERIES.smallMobile);
-    setRuler();
-    setVisibleValue("smallMobile (320px)");
-    if (ref.current) setWindowWidth(ref.current?.clientWidth);
-  }, [onChangeSize, setRuler]);
+    setViewports(prevViewports =>
+      prevViewports.length === newViewports.length ? prevViewports : newViewports,
+    );
+    setActiveViewport(prevActive =>
+      newViewports.includes(prevActive) ? prevActive : newViewports[newViewports.length - 1],
+    );
+  }, [containerWidth]);
 
   React.useEffect(() => {
-    handleResize();
+    onChangeSize(QUERIES[activeViewport]);
+  }, [activeViewport, onChangeSize]);
 
-    window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, [handleResize, windowWidth]);
+  const visibleViewport = targetViewport || activeViewport;
+  const visibleSize = QUERIES[visibleViewport];
 
-  const handleClick = (size: number, idx: number) => {
-    onChangeSize(size);
-    setActiveIdx(idx);
-  };
-
-  return isLargeMobile ? (
-    <StyledViewports ref={ref}>
-      {viewports.map(([name, value], i) => (
-        <StyledCell
-          active={activeIdx === i}
-          key={name}
-          width={value}
-          index={i}
-          onMouseEnter={() => setVisibleValue(`${name} (${value}px)`)}
-          onClick={() => handleClick(value, i)}
-        >
-          <span>{visibleValue}</span>
-        </StyledCell>
-      ))}
-    </StyledViewports>
-  ) : null;
+  return (
+    <div ref={containerRef}>
+      {isLargeMobile && (
+        <StyledViewports>
+          {[...viewports].reverse().map(viewport => (
+            <StyledCell
+              key={viewport}
+              aria-label={`${viewport} (${QUERIES[viewport]})`}
+              $active={targetViewport ? viewport === targetViewport : viewport === activeViewport}
+              $width={QUERIES[viewport]}
+              onMouseEnter={() => setTargetViewport(viewport)}
+              onMouseLeave={() => setTargetViewport(null)}
+              onClick={() => setActiveViewport(viewport)}
+            />
+          ))}
+          <StyledLabel>
+            <Text as="div">
+              {visibleViewport} (
+              {typeof visibleSize === "number" ? `${visibleSize}px` : visibleSize})
+            </Text>
+          </StyledLabel>
+        </StyledViewports>
+      )}
+    </div>
+  );
 };
 
 export default ViewportsRuler;

--- a/docs/src/components/ReactExample/consts.tsx
+++ b/docs/src/components/ReactExample/consts.tsx
@@ -7,6 +7,7 @@ export const QUERIES = {
   tablet: 768,
   desktop: 992,
   largeDesktop: 1200,
+  fullWidth: "100%",
 };
 
 export const PREVIEW_ID = "preview-wrapper";

--- a/docs/src/components/ReactExample/index.tsx
+++ b/docs/src/components/ReactExample/index.tsx
@@ -78,7 +78,7 @@ const ReactExample = ({ exampleId, background = "white", minHeight, maxHeight }:
       background={background}
       origin={origin}
       exampleKnobs={example.exampleKnobs}
-      exampleVariants={example.exampleVariants}
+      exampleVariants={example.exampleVariants || []}
       code={codeWithImports}
       exampleId={example.id}
       fullPageExampleId={exampleId.toLowerCase()}

--- a/docs/src/templates/Sandbox/index.tsx
+++ b/docs/src/templates/Sandbox/index.tsx
@@ -43,7 +43,7 @@ const Sandbox = ({ pathContext }) => {
           example={example}
           origin={origin}
           exampleKnobs={exampleKnobs}
-          exampleVariants={exampleVariants}
+          exampleVariants={exampleVariants || []}
           onChangeCode={c => setCode(c)}
         />
       </LiveProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2489,6 +2489,11 @@
     url-regex "^5.0.0"
     vfile "^4.1.1"
 
+"@juggle/resize-observer@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
+  integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
+
 "@kiwicom/browserslist-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@kiwicom/browserslist-config/-/browserslist-config-1.0.0.tgz#4abe67d42fd037f87e5abc20eb9e392a14639a30"
@@ -26862,6 +26867,13 @@ use-latest@^1.0.0:
   integrity sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
+
+use-resize-observer@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/use-resize-observer/-/use-resize-observer-8.0.0.tgz#69bd80c1ddd94f3758563fe107efb25fed85067a"
+  integrity sha512-n0iKSeiQpJCyaFh5JA0qsVLBIovsF4EIIR1G6XiBwKJN66ZrD4Oj62bjcuTAATPKiSp6an/2UZZxCf/67fk3sQ==
+  dependencies:
+    "@juggle/resize-observer" "^3.3.1"
 
 use-sidecar@^1.0.1:
   version "1.0.5"


### PR DESCRIPTION
There were multiple problems with the viewport ruler, the biggest one being that it was computing container width too soon, so the initial width ended up being 0, making the ruler unusable. This refactor uses ResizeObserver instead of using the `resize` event of the entire window, and fixes some other bugs along the way.

 Storybook: https://orbit-silvenon-fix-sandbox-viewport-ruler.surge.sh