### PR TITLE
fix: remove unnecessary declare module statements

### DIFF
--- a/packages/orbit-components/config/build.js
+++ b/packages/orbit-components/config/build.js
@@ -111,9 +111,7 @@ const flow = `// @flow
 import * as React from "react";\n\n`;
 
 const TSHeader = `// Type definitions for @kiwicom/orbit-components
-// Project: https://github.com/kiwicom/orbit/
-
-declare module "@kiwicom/orbit-components/lib/icons";\n\n`;
+// Project: https://github.com/kiwicom/orbit/\n`;
 
 const iconMapper = interpolation =>
   names.map(({ functionName }) => interpolation(functionName)).join("");

--- a/packages/orbit-components/src/Accordion/AccordionSection/index.d.ts
+++ b/packages/orbit-components/src/Accordion/AccordionSection/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Accordion/AccordionSection";
-
 export interface Props extends Common.Global {
   readonly id?: string | number;
   readonly children?: React.ReactNode;

--- a/packages/orbit-components/src/Accordion/index.d.ts
+++ b/packages/orbit-components/src/Accordion/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import AccordionSection from "./AccordionSection";
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Accordion";
-
 /*
   DOCS:
   To implement Accordion component into your project you'll need to the import the Accordion and the [AccordionSection](#Accordionsection):

--- a/packages/orbit-components/src/Alert/AlertButton/index.d.ts
+++ b/packages/orbit-components/src/Alert/AlertButton/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import { ButtonCommonProps } from "../../primitives/ButtonPrimitive";
 
-declare module "@kiwicom/orbit-components/lib/Alert/AlertButton";
-
 type Type =
   | "info"
   | "success"

--- a/packages/orbit-components/src/Alert/index.d.ts
+++ b/packages/orbit-components/src/Alert/index.d.ts
@@ -8,8 +8,6 @@ import AlertButton from "./AlertButton";
 
 type Type = "info" | "success" | "warning" | "critical";
 
-declare module "@kiwicom/orbit-components/lib/Alert";
-
 export interface Props extends Common.Global, Common.SpaceAfter {
   readonly type?: Type;
   readonly children?: React.ReactNode;

--- a/packages/orbit-components/src/Badge/index.d.ts
+++ b/packages/orbit-components/src/Badge/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Badge";
-
 export type Type =
   | "neutral"
   | "dark"

--- a/packages/orbit-components/src/BadgeList/BadgeListItem/index.d.ts
+++ b/packages/orbit-components/src/BadgeList/BadgeListItem/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/BadgeList/BadgeListItem";
-
 type Type = "neutral" | "info" | "success" | "warning" | "critical";
 
 export interface Props extends Common.Global {

--- a/packages/orbit-components/src/BadgeList/index.d.ts
+++ b/packages/orbit-components/src/BadgeList/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import * as Common from "../common/common";
 import BadgeListItem from "./BadgeListItem";
 
-declare module "@kiwicom/orbit-components/lib/BadgeList";
-
 export interface Props extends Common.Global {
   readonly children: React.ReactNode;
 }

--- a/packages/orbit-components/src/BaggageStepper/Stepper/index.d.ts
+++ b/packages/orbit-components/src/BaggageStepper/Stepper/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import * as Common from "../../common/common";
 import { SharedProps, Event } from "..";
 
-declare module "@kiwicom/orbit-components/lib/StepperStateless";
-
 type InputEvent = Common.Event<React.KeyboardEvent<HTMLInputElement>>;
 export interface Props extends SharedProps {
   readonly value?: number | string | (() => string);

--- a/packages/orbit-components/src/BaggageStepper/index.d.ts
+++ b/packages/orbit-components/src/BaggageStepper/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/BaggageStepper";
-
 type Title = string | ((param?: any) => string);
 // InputEvent
 export type Event = Common.Event<React.SyntheticEvent<HTMLInputElement>>;

--- a/packages/orbit-components/src/Breadcrumbs/BreadcrumbsItem/index.d.ts
+++ b/packages/orbit-components/src/Breadcrumbs/BreadcrumbsItem/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/BreadcrumbsItem";
-
 export interface Props extends Common.Global {
   readonly active?: boolean;
   readonly component?: Common.Component;

--- a/packages/orbit-components/src/Breadcrumbs/index.d.ts
+++ b/packages/orbit-components/src/Breadcrumbs/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import * as Common from "../common/common";
 import { Props as BreadcrumbsItemProps } from "./BreadcrumbsItem";
 
-declare module "@kiwicom/orbit-components/lib/Breadcrumbs";
-
 export interface Props extends Common.Global, Common.SpaceAfter {
   readonly children: React.ReactNode;
   readonly goBackTitle?: Common.Translation;

--- a/packages/orbit-components/src/Button/index.d.ts
+++ b/packages/orbit-components/src/Button/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import { ButtonCommonProps, Size } from "../primitives/ButtonPrimitive";
 
-declare module "@kiwicom/orbit-components/lib/Button";
-
 type Type = "primary" | "secondary" | "critical" | "primarySubtle" | "criticalSubtle" | "white";
 
 export interface Props extends ButtonCommonProps {

--- a/packages/orbit-components/src/ButtonGroup/index.d.ts
+++ b/packages/orbit-components/src/ButtonGroup/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/ButtonGroup";
-
 export interface Props extends Common.Global {
   readonly children: React.ReactNode;
 }

--- a/packages/orbit-components/src/ButtonLink/index.d.ts
+++ b/packages/orbit-components/src/ButtonLink/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import * as Common from "../common/common";
 import { ButtonCommonProps, Size } from "../primitives/ButtonPrimitive";
 
-declare module "@kiwicom/orbit-components/lib/ButtonLink";
-
 type Type = "primary" | "secondary" | "critical";
 
 export interface Props extends Common.Global, Common.Ref, Common.SpaceAfter, ButtonCommonProps {

--- a/packages/orbit-components/src/ButtonMobileStore/index.d.ts
+++ b/packages/orbit-components/src/ButtonMobileStore/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/ButtonMobileStore";
-
 type Type = "appStore" | "googlePlay";
 type Variant = "light" | "dark";
 

--- a/packages/orbit-components/src/CallOutBanner/index.d.ts
+++ b/packages/orbit-components/src/CallOutBanner/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import * as Common from "../common/common";
 import Illustration from "../Illustration";
 
-declare module "@kiwicom/orbit-components/lib/CallOutBanner";
-
 export interface Props {
   readonly tabIndex?: string | number;
   readonly onClick?: Common.Callback;

--- a/packages/orbit-components/src/Card/CardSection/index.d.ts
+++ b/packages/orbit-components/src/Card/CardSection/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Card/CardSection";
-
 export interface Props extends Common.Global {
   readonly title?: React.ReactNode;
   readonly icon?: React.ReactNode;

--- a/packages/orbit-components/src/Card/index.d.ts
+++ b/packages/orbit-components/src/Card/index.d.ts
@@ -7,8 +7,6 @@ import CardSection from "./CardSection";
 import * as Common from "../common/common";
 import { As } from "../Heading";
 
-declare module "@kiwicom/orbit-components/lib/Card";
-
 export interface Props extends Common.Global, Common.SpaceAfter {
   readonly children?: React.ReactNode;
   readonly title?: React.ReactNode;

--- a/packages/orbit-components/src/CarrierLogo/index.d.ts
+++ b/packages/orbit-components/src/CarrierLogo/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/CarrierLogo";
-
 type Size = "small" | "medium" | "large";
 
 export interface Props extends Common.Global {

--- a/packages/orbit-components/src/Checkbox/index.d.ts
+++ b/packages/orbit-components/src/Checkbox/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Checkbox";
-
 export interface Props extends Common.Global, Common.Ref {
   readonly label?: React.ReactNode;
   readonly value?: string;

--- a/packages/orbit-components/src/ChoiceGroup/index.d.ts
+++ b/packages/orbit-components/src/ChoiceGroup/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/ChoiceGroup";
-
 type Size = "normal" | "large";
 type Element = "h2" | "h3" | "h4" | "h5" | "h6";
 

--- a/packages/orbit-components/src/ClickOutside/index.d.ts
+++ b/packages/orbit-components/src/ClickOutside/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/ClickOutside";
-
 export interface Props {
   readonly onClickOutside?: Common.Event<React.MouseEvent>;
   readonly children: React.ReactNode | React.ReactNode[];

--- a/packages/orbit-components/src/Collapse/index.d.ts
+++ b/packages/orbit-components/src/Collapse/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Collapse";
-
 export interface Props extends Common.Global {
   readonly initialExpanded?: boolean;
   readonly expanded?: boolean;

--- a/packages/orbit-components/src/CountryFlag/index.d.ts
+++ b/packages/orbit-components/src/CountryFlag/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/CountryFlag";
-
 export interface Props extends Common.Global {
   readonly code?: string;
   readonly name?: string;

--- a/packages/orbit-components/src/Coupon/index.d.ts
+++ b/packages/orbit-components/src/Coupon/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Coupon";
-
 export interface Props extends Common.Global {
   readonly children: React.ReactNode;
 }

--- a/packages/orbit-components/src/Desktop/index.d.ts
+++ b/packages/orbit-components/src/Desktop/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Desktop";
-
 export interface Props extends Common.Global {
   readonly children: React.ReactNode;
 }

--- a/packages/orbit-components/src/Dialog/index.d.ts
+++ b/packages/orbit-components/src/Dialog/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Dialog";
-
 export interface Props extends Common.Global {
   readonly title: React.ReactNode;
   readonly description?: React.ReactNode;

--- a/packages/orbit-components/src/Dictionary/index.d.ts
+++ b/packages/orbit-components/src/Dictionary/index.d.ts
@@ -3,8 +3,6 @@
 
 import * as React from "react";
 
-declare module "@kiwicom/orbit-components/lib/Dictionary";
-
 export type Translations = {
   [key: string]: string;
 };

--- a/packages/orbit-components/src/Drawer/components/DrawerClose.d.ts
+++ b/packages/orbit-components/src/Drawer/components/DrawerClose.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/DrawerClose";
-
 export interface Props {
   readonly onClick?: Common.Callback;
 }

--- a/packages/orbit-components/src/Drawer/index.d.ts
+++ b/packages/orbit-components/src/Drawer/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Drawer";
-
 type Position = "left" | "right";
 
 export interface Props extends Common.Global {

--- a/packages/orbit-components/src/FormLabel/index.d.ts
+++ b/packages/orbit-components/src/FormLabel/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/FormLabel";
-
 export interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly filled?: boolean;

--- a/packages/orbit-components/src/Heading/index.d.ts
+++ b/packages/orbit-components/src/Heading/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Heading";
-
 export type Type =
   | "display"
   | "displaySubtitle"

--- a/packages/orbit-components/src/Hide/index.d.ts
+++ b/packages/orbit-components/src/Hide/index.d.ts
@@ -3,8 +3,6 @@
 
 import * as React from "react";
 
-declare module "@kiwicom/orbit-components/lib/Hide";
-
 type Device =
   | "largeDesktop"
   | "desktop"

--- a/packages/orbit-components/src/Illustration/TYPESCRIPT_TEMPLATE.template
+++ b/packages/orbit-components/src/Illustration/TYPESCRIPT_TEMPLATE.template
@@ -7,7 +7,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Illustration";
 type Name =%NAMES%
 
 export interface Props extends Common.Global, Common.SpaceAfter {

--- a/packages/orbit-components/src/InputField/index.d.ts
+++ b/packages/orbit-components/src/InputField/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/InputField";
-
 type Type = "text" | "number" | "email" | "password" | "passportid";
 type InputMode = "numeric" | "tel" | "decimal" | "email" | "url" | "search" | "text" | "none";
 // InputEvent

--- a/packages/orbit-components/src/InputFile/index.d.ts
+++ b/packages/orbit-components/src/InputFile/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/InputFile";
-
 // InputEvent
 type Event = Common.Event<React.SyntheticEvent<HTMLInputElement>>;
 

--- a/packages/orbit-components/src/InputGroup/index.d.ts
+++ b/packages/orbit-components/src/InputGroup/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/InputGroup";
-
 type Size = "small" | "normal";
 type Event = Common.Event<React.SyntheticEvent<HTMLInputElement | HTMLSelectElement>>;
 

--- a/packages/orbit-components/src/InputStepper/InputStepperStateless/index.d.ts
+++ b/packages/orbit-components/src/InputStepper/InputStepperStateless/index.d.ts
@@ -6,7 +6,6 @@ import * as React from "react";
 import * as Common from "../../common/common";
 import { SharedProps, Event } from "..";
 
-declare module "@kiwicom/orbit-components/lib/InputStepperStateless";
 export type ButtonEvent = Common.Event<
   React.SyntheticEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>
 >;

--- a/packages/orbit-components/src/InputStepper/index.d.ts
+++ b/packages/orbit-components/src/InputStepper/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/InputStepper";
-
 type Title = string | ((...params: readonly any[]) => string);
 // InputEvent
 export type Event = Common.Event<React.SyntheticEvent<HTMLInputElement>>;

--- a/packages/orbit-components/src/Layout/LayoutColumn/index.d.ts
+++ b/packages/orbit-components/src/Layout/LayoutColumn/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import * as Common from "../../common/common";
 import { Devices } from "../../utils/mediaQuery/consts";
 
-declare module "@kiwicom/orbit-components/lib/LayoutColumn";
-
 export interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly as?: string;

--- a/packages/orbit-components/src/Layout/index.d.ts
+++ b/packages/orbit-components/src/Layout/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Layout";
-
 type Type = "Search" | "Booking" | "MMB";
 
 export interface Props extends Common.Global {

--- a/packages/orbit-components/src/LazyImage/index.d.ts
+++ b/packages/orbit-components/src/LazyImage/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/LazyImage";
-
 interface Image {
   "*"?: string;
   jpg?: string;

--- a/packages/orbit-components/src/LinkList/index.d.ts
+++ b/packages/orbit-components/src/LinkList/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import * as Common from "../common/common";
 import { Spacing } from "../Stack";
 
-declare module "@kiwicom/orbit-components/lib/LinkList";
-
 export interface Props extends Common.Global {
   readonly direction?: "column" | "row";
   readonly indent?: boolean;

--- a/packages/orbit-components/src/List/ListItem/index.d.ts
+++ b/packages/orbit-components/src/List/ListItem/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/ListItem";
-
 interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly label?: Common.Translation;

--- a/packages/orbit-components/src/List/index.d.ts
+++ b/packages/orbit-components/src/List/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import ListItem from "./ListItem";
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/List";
-
 type Type = "primary" | "secondary" | "separated";
 
 interface Props extends Common.Global, Common.SpaceAfter {

--- a/packages/orbit-components/src/ListChoice/index.d.ts
+++ b/packages/orbit-components/src/ListChoice/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/ListChoice";
-
 export interface Props extends Common.Global {
   readonly title: Common.Translation;
   readonly description?: Common.Translation;

--- a/packages/orbit-components/src/Loading/index.d.ts
+++ b/packages/orbit-components/src/Loading/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Loading";
-
 type Type = "buttonLoader" | "boxLoader" | "searchLoader" | "pageLoader" | "inlineLoader";
 
 interface Props extends Common.Global {

--- a/packages/orbit-components/src/Mobile/index.d.ts
+++ b/packages/orbit-components/src/Mobile/index.d.ts
@@ -3,8 +3,6 @@
 
 import * as React from "react";
 
-declare module "@kiwicom/orbit-components/lib/Mobile";
-
 export interface Props {
   readonly children: React.ReactNode;
 }

--- a/packages/orbit-components/src/Modal/ModalCloseButton/index.d.ts
+++ b/packages/orbit-components/src/Modal/ModalCloseButton/index.d.ts
@@ -4,8 +4,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Modal/ModalCloseButton";
-
 export interface Props extends Common.Global {
   readonly onClick?: Common.Event<React.SyntheticEvent<HTMLButtonElement>>;
 }

--- a/packages/orbit-components/src/Modal/ModalContext.d.ts
+++ b/packages/orbit-components/src/Modal/ModalContext.d.ts
@@ -3,8 +3,6 @@
 
 import * as React from "react";
 
-declare module "@kiwicom/orbit-components/lib/Modal";
-
 export interface Props {
   readonly setDimensions?: () => void;
   readonly decideFixedFooter?: () => void;

--- a/packages/orbit-components/src/Modal/ModalFooter/index.d.ts
+++ b/packages/orbit-components/src/Modal/ModalFooter/index.d.ts
@@ -4,8 +4,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Modal/ModalFooter";
-
 export interface Props extends Common.Global {
   readonly flex?: string | Array<string>;
   readonly children: React.ReactNode;

--- a/packages/orbit-components/src/Modal/ModalHeader/index.d.ts
+++ b/packages/orbit-components/src/Modal/ModalHeader/index.d.ts
@@ -4,8 +4,6 @@ import React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Modal/ModalHeader";
-
 export interface Props extends Common.Global {
   readonly children?: React.ReactNode;
   readonly illustration?: React.ReactNode;

--- a/packages/orbit-components/src/Modal/ModalSection/index.d.ts
+++ b/packages/orbit-components/src/Modal/ModalSection/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 import * as Common from "../../common/common";
 import { Props as ModalContextProps } from "../ModalContext";
 
-declare module "@kiwicom/orbit-components/lib/Modal/ModalSection";
-
 export interface Props extends Common.Global, ModalContextProps {
   readonly children: React.ReactNode;
   readonly suppressed?: boolean;

--- a/packages/orbit-components/src/Modal/index.d.ts
+++ b/packages/orbit-components/src/Modal/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Modal";
-
 type Size = "extraSmall" | "small" | "normal" | "large" | "extraLarge";
 
 export interface Props extends Common.Global {

--- a/packages/orbit-components/src/NavigationBar/index.d.ts
+++ b/packages/orbit-components/src/NavigationBar/index.d.ts
@@ -4,8 +4,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/NavigationBar";
-
 export interface Props extends Common.Global {
   readonly onMenuOpen?: Common.Callback;
   readonly onShow?: Common.Callback;

--- a/packages/orbit-components/src/NotificationBadge/index.d.ts
+++ b/packages/orbit-components/src/NotificationBadge/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import * as Common from "../common/common";
 import { Type } from "../Badge";
 
-declare module "@kiwicom/orbit-components/lib/NotificationBadge";
-
 export interface Props extends Common.Global {
   readonly children?: React.ReactNode;
   readonly type?: Type;

--- a/packages/orbit-components/src/Pagination/index.d.ts
+++ b/packages/orbit-components/src/Pagination/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Pagination";
-
 interface Props extends Common.Global {
   readonly onPageChange: (page: number) => void;
   readonly pageCount: number;

--- a/packages/orbit-components/src/PictureCard/index.d.ts
+++ b/packages/orbit-components/src/PictureCard/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/PictureCard";
-
 type Image = {
   readonly original: string;
   readonly placeholder?: string;

--- a/packages/orbit-components/src/Popover/index.d.ts
+++ b/packages/orbit-components/src/Popover/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Popover";
-
 type Offset = {
   top?: number;
   left?: number;

--- a/packages/orbit-components/src/Portal/index.d.ts
+++ b/packages/orbit-components/src/Portal/index.d.ts
@@ -3,8 +3,6 @@
 
 import * as React from "react";
 
-declare module "@kiwicom/orbit-components/lib/Portal";
-
 export interface Props {
   readonly renderInto?: string;
   readonly children: React.ReactNode;

--- a/packages/orbit-components/src/PricingTable/PricingTableItem/index.d.ts
+++ b/packages/orbit-components/src/PricingTable/PricingTableItem/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/PricingTableItem";
-
 export interface Props extends Common.Global {
   readonly name?: Common.Translation;
   readonly price?: Common.Translation;

--- a/packages/orbit-components/src/PricingTable/index.d.ts
+++ b/packages/orbit-components/src/PricingTable/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/PricingTable";
-
 export interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly activeElement?: number | undefined | null;

--- a/packages/orbit-components/src/Radio/index.d.ts
+++ b/packages/orbit-components/src/Radio/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import Tooltip from "../Tooltip";
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Radio";
-
 export interface Props extends Common.Global, Common.Ref {
   readonly label?: React.ReactNode;
   readonly value?: string;

--- a/packages/orbit-components/src/RatingStars/index.d.ts
+++ b/packages/orbit-components/src/RatingStars/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/RatingStars";
-
 type Size = "small" | "medium" | "large";
 type Color = "primary" | "secondary";
 

--- a/packages/orbit-components/src/Seat/index.d.ts
+++ b/packages/orbit-components/src/Seat/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import * as Common from "../common/common";
 import SeatLegend from "./components/SeatLegend";
 
-declare module "@kiwicom/orbit-components/lib/Seat";
-
 type Size = "small" | "medium";
 type Type = "default" | "legroom" | "unavailable";
 

--- a/packages/orbit-components/src/Select/index.d.ts
+++ b/packages/orbit-components/src/Select/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Select";
-
 // InputEvent
 type Event = Common.Event<React.SyntheticEvent<HTMLSelectElement>>;
 

--- a/packages/orbit-components/src/Separator/index.d.ts
+++ b/packages/orbit-components/src/Separator/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Separator";
-
 type Props = Common.SpaceAfter;
 
 declare const Separator: React.FunctionComponent<Props>;

--- a/packages/orbit-components/src/ServiceLogo/TYPESCRIPT_TEMPLATE.template
+++ b/packages/orbit-components/src/ServiceLogo/TYPESCRIPT_TEMPLATE.template
@@ -6,8 +6,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/ServiceLogo";
-
 type Size = "small" | "medium" | "large";
 type Name =%NAMES%
 

--- a/packages/orbit-components/src/Skeleton/index.d.ts
+++ b/packages/orbit-components/src/Skeleton/index.d.ts
@@ -4,8 +4,6 @@ import React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Skeleton";
-
 type Preset = "List" | "Image" | "Card" | "Button" | "Text";
 
 /**  DOCS:

--- a/packages/orbit-components/src/SkipLink/index.d.ts
+++ b/packages/orbit-components/src/SkipLink/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/SkipLink";
-
 interface Action {
   readonly name: string;
   readonly href?: string;

--- a/packages/orbit-components/src/SkipNavigation/index.d.ts
+++ b/packages/orbit-components/src/SkipNavigation/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/SkipNavigation";
-
 interface Action {
   readonly name?: string;
   readonly link?: string;

--- a/packages/orbit-components/src/Slider/index.d.ts
+++ b/packages/orbit-components/src/Slider/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Slider";
-
 export type Label = string | string[];
 export type Value = number | number[];
 export type Data = number[];

--- a/packages/orbit-components/src/SmartPassIllustrations/index.d.ts
+++ b/packages/orbit-components/src/SmartPassIllustrations/index.d.ts
@@ -4,8 +4,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/SmartPassIllustration";
-
 type Sizes = "extraSmall" | "small" | "medium" | "large" | "display";
 
 export interface Props extends Common.Global {

--- a/packages/orbit-components/src/SocialButton/index.d.ts
+++ b/packages/orbit-components/src/SocialButton/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import { ButtonCommonProps, Size } from "../primitives/ButtonPrimitive";
 
-declare module "@kiwicom/orbit-components/lib/Button";
-
 export type Type = "apple" | "facebook" | "google" | "twitter";
 
 type OmittedButtonCommonProps = Omit<ButtonCommonProps, "iconLeft" | "iconRight" | "circled">;

--- a/packages/orbit-components/src/Stack/index.d.ts
+++ b/packages/orbit-components/src/Stack/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Stack";
-
 export type Direction = "row" | "column" | "row-reverse" | "column-reverse";
 export type Align = "start" | "end" | "center" | "stretch" | "baseline";
 export type Justify = "start" | "end" | "center" | "between" | "around";

--- a/packages/orbit-components/src/Stepper/StepperStateless/index.d.ts
+++ b/packages/orbit-components/src/Stepper/StepperStateless/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import * as Common from "../../common/common";
 import { SharedProps, Event } from "..";
 
-declare module "@kiwicom/orbit-components/lib/StepperStateless";
-
 type InputEvent = Common.Event<React.KeyboardEvent<HTMLInputElement>>;
 
 export interface Props extends SharedProps {

--- a/packages/orbit-components/src/Stepper/index.d.ts
+++ b/packages/orbit-components/src/Stepper/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Stepper";
-
 type Title = string | ((param?: any) => string);
 // InputEvent
 export type Event = Common.Event<React.SyntheticEvent<HTMLInputElement>>;

--- a/packages/orbit-components/src/Sticky/index.d.ts
+++ b/packages/orbit-components/src/Sticky/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Sticky";
-
 interface Props extends Common.Global {
   readonly offset?: number;
   readonly children: React.ReactNode;

--- a/packages/orbit-components/src/StopoverArrow/index.d.ts
+++ b/packages/orbit-components/src/StopoverArrow/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/StopoverArrow";
-
 type Stops = "0" | "1" | "2" | "3";
 
 interface Props extends Common.Global {

--- a/packages/orbit-components/src/Switch/index.d.ts
+++ b/packages/orbit-components/src/Switch/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Switch";
-
 export interface Props extends Common.Global, Common.Ref {
   readonly icon?: React.ReactNode;
   readonly checked: boolean;

--- a/packages/orbit-components/src/Table/TableBody/index.d.ts
+++ b/packages/orbit-components/src/Table/TableBody/index.d.ts
@@ -3,7 +3,5 @@
 
 import { SharedProps } from "..";
 
-declare module "@kiwicom/orbit-components/lib/Table/TableBody";
-
 declare const TableBody: React.FunctionComponent<SharedProps>;
 export { TableBody, TableBody as default };

--- a/packages/orbit-components/src/Table/TableCell/index.d.ts
+++ b/packages/orbit-components/src/Table/TableCell/index.d.ts
@@ -3,8 +3,6 @@
 
 import { SharedProps } from "..";
 
-declare module "@kiwicom/orbit-components/lib/Table/TableCell";
-
 type Align = "left" | "center" | "right";
 type As = "th" | "td";
 type Scope = "col" | "row" | "colgroup" | "rowgroup";

--- a/packages/orbit-components/src/Table/TableFooter/index.d.ts
+++ b/packages/orbit-components/src/Table/TableFooter/index.d.ts
@@ -3,7 +3,5 @@
 
 import { SharedProps } from "..";
 
-declare module "@kiwicom/orbit-components/lib/Table/TableFooter";
-
 declare const TableFooter: React.FunctionComponent<SharedProps>;
 export { TableFooter, TableFooter as default };

--- a/packages/orbit-components/src/Table/TableHead/index.d.ts
+++ b/packages/orbit-components/src/Table/TableHead/index.d.ts
@@ -3,7 +3,5 @@
 
 import { SharedProps } from "..";
 
-declare module "@kiwicom/orbit-components/lib/Table/TableHead";
-
 declare const TableHead: React.FunctionComponent<SharedProps>;
 export { TableHead, TableHead as default };

--- a/packages/orbit-components/src/Table/TableRow/index.d.ts
+++ b/packages/orbit-components/src/Table/TableRow/index.d.ts
@@ -3,7 +3,5 @@
 
 import { SharedProps } from "..";
 
-declare module "@kiwicom/orbit-components/lib/Table/TableRow";
-
 declare const TableRow: React.FunctionComponent<SharedProps>;
 export { TableRow, TableRow as default };

--- a/packages/orbit-components/src/Table/index.d.ts
+++ b/packages/orbit-components/src/Table/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Table";
-
 export interface SharedProps extends Common.Global {
   readonly children: React.ReactNode;
 }

--- a/packages/orbit-components/src/Tag/index.d.ts
+++ b/packages/orbit-components/src/Tag/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Tag";
-
 interface Props extends Common.Global, Common.Ref {
   readonly children: React.ReactNode;
   readonly selected?: boolean;

--- a/packages/orbit-components/src/Text/index.d.ts
+++ b/packages/orbit-components/src/Text/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Text";
-
 type Align = "left" | "center" | "right" | "justify";
 type As = "p" | "span" | "div";
 type Type =

--- a/packages/orbit-components/src/TextLink/index.d.ts
+++ b/packages/orbit-components/src/TextLink/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/TextLink";
-
 export type Type = "primary" | "secondary" | "info" | "success" | "warning" | "critical" | "white";
 
 export interface Props extends Common.Global {

--- a/packages/orbit-components/src/Textarea/index.d.ts
+++ b/packages/orbit-components/src/Textarea/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Textarea";
-
 type Resize = "vertical" | "none";
 // InputEvent
 type Event = Common.Event<React.SyntheticEvent<HTMLTextAreaElement>>;

--- a/packages/orbit-components/src/ThemeProvider/QueryContext/index.d.ts
+++ b/packages/orbit-components/src/ThemeProvider/QueryContext/index.d.ts
@@ -3,8 +3,6 @@
 
 import * as React from "react";
 
-declare module "@kiwicom/orbit-components/lib/ThemeProvider/QueryContext";
-
 export interface Props {
   readonly isLargeDesktop: boolean | undefined | null;
   readonly isDesktop: boolean | undefined | null;

--- a/packages/orbit-components/src/ThemeProvider/index.d.ts
+++ b/packages/orbit-components/src/ThemeProvider/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 import { Translations } from "../Dictionary";
 import { ThemeShape } from "../defaultTheme";
 
-declare module "@kiwicom/orbit-components/lib/ThemeProvider";
-
 interface Props {
   readonly theme: ThemeShape;
   readonly dictionary?: Translations;

--- a/packages/orbit-components/src/Tile/index.d.ts
+++ b/packages/orbit-components/src/Tile/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Tile";
-
 interface Props extends Common.Global {
   readonly title?: React.ReactNode;
   readonly description?: React.ReactNode;

--- a/packages/orbit-components/src/TileGroup/index.d.ts
+++ b/packages/orbit-components/src/TileGroup/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/TileGroup";
-
 interface Props extends Common.Global {
   readonly children: React.ReactNode;
 }

--- a/packages/orbit-components/src/Timeline/TimelineStep/index.d.ts
+++ b/packages/orbit-components/src/Timeline/TimelineStep/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Timeline/TimelineStep";
-
 export type Type = "success" | "warning" | "critical";
 export interface Props extends Common.Global, Common.SpaceAfter {
   readonly children: React.ReactNode;

--- a/packages/orbit-components/src/Timeline/index.d.ts
+++ b/packages/orbit-components/src/Timeline/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Timeline";
-
 export interface Props extends Common.Global, Common.SpaceAfter {
   readonly children: React.ReactNode;
 }

--- a/packages/orbit-components/src/Tooltip/index.d.ts
+++ b/packages/orbit-components/src/Tooltip/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Tooltip";
-
 type Size = "small" | "medium";
 type Position = "right" | "left" | "top" | "bottom";
 type Align = "center" | "start" | "end";

--- a/packages/orbit-components/src/Translate/index.d.ts
+++ b/packages/orbit-components/src/Translate/index.d.ts
@@ -3,8 +3,6 @@
 
 import * as React from "react";
 
-declare module "@kiwicom/orbit-components/lib/Translate";
-
 type Values = {
   [key: string]: string | number;
 };

--- a/packages/orbit-components/src/Truncate/index.d.ts
+++ b/packages/orbit-components/src/Truncate/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-declare module "@kiwicom/orbit-components/lib/Truncate";
-
 interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly maxWidth?: string;

--- a/packages/orbit-components/src/defaultTheme.d.ts
+++ b/packages/orbit-components/src/defaultTheme.d.ts
@@ -3,8 +3,6 @@
 
 import { Tokens } from "@kiwicom/orbit-design-tokens";
 
-declare module "@kiwicom/orbit-components/theme";
-
 export interface ThemeShape {
   readonly orbit: Tokens;
   readonly transitions?: boolean;

--- a/packages/orbit-components/src/index.d.ts
+++ b/packages/orbit-components/src/index.d.ts
@@ -1,8 +1,6 @@
 // Type definitions for @kiwicom/orbit-components
 // Project: https://github.com/kiwicom/orbit/
 
-declare module "@kiwicom/orbit-components";
-
 export * as Icons from "./icons";
 
 export { Alert } from "./Alert";

--- a/packages/orbit-components/src/primitives/BadgePrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/BadgePrimitive/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/BadgePrimitive";
-
 export interface Props extends Common.Global {
   readonly children?: React.ReactNode;
   readonly icon?: React.ReactNode;

--- a/packages/orbit-components/src/primitives/IllustrationPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/IllustrationPrimitive/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/BadgePrimitive";
-
 export interface Props extends Common.Global, Common.SpaceAfter {
   readonly size?: "extraSmall" | "small" | "medium" | "large" | "display";
   readonly name: string;

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.d.ts
@@ -6,8 +6,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/primitives/MobileDialogPrimitive";
-
 export interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly enabled?: boolean;

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/primitives/TooltipPrimitive";
-
 type Size = "small" | "medium";
 type Position = "right" | "left" | "top" | "bottom";
 type Align = "center" | "start" | "end";

--- a/packages/orbit-components/src/utils/Grid/index.d.ts
+++ b/packages/orbit-components/src/utils/Grid/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import * as Common from "../../common/common";
 
-declare module "@kiwicom/orbit-components/lib/utils/Grid";
-
 export type BasicProps = {
   readonly inline?: boolean;
   readonly rows?: string;

--- a/packages/orbit-components/src/utils/Slide/index.d.ts
+++ b/packages/orbit-components/src/utils/Slide/index.d.ts
@@ -5,8 +5,6 @@ import * as React from "react";
 
 import type { TransitionDuration } from "../transition";
 
-declare module "@kiwicom/orbit-components/lib/utils/Slide";
-
 interface Props {
   readonly children: React.ReactNode;
   readonly maxHeight: number | undefined | null;

--- a/packages/orbit-components/src/utils/mediaQuery/consts.d.ts
+++ b/packages/orbit-components/src/utils/mediaQuery/consts.d.ts
@@ -1,5 +1,3 @@
-declare module "@kiwicom/orbit-components/lib/utils/mediaQuery/consts";
-
 export type Devices =
   | "largeDesktop"
   | "desktop"

--- a/packages/orbit-components/src/utils/mediaQuery/index.d.ts
+++ b/packages/orbit-components/src/utils/mediaQuery/index.d.ts
@@ -5,8 +5,6 @@ import type { Interpolation } from "styled-components";
 import { ThemeShape } from "../../defaultTheme";
 import { Devices } from "./consts";
 
-declare module "@kiwicom/orbit-components/lib/utils/mediaQuery";
-
 type QueryFunction = (style: Interpolation<any>) => Interpolation<any>;
 
 declare const MediaQuery: { [key in Devices]: QueryFunction };


### PR DESCRIPTION
When type declarations are next to the modules they refer to, they don't need `declare module` statements. I also think that without body they don't do anything anyway.

This is extracted from the TypeScript PR. #3047

 Storybook: https://orbit-silvenon-chore-remove-declare-module.surge.sh