### PR TITLE
fix(storybook): logo url

### DIFF
--- a/packages/orbit-components/.storybook/orbitTheme.js
+++ b/packages/orbit-components/.storybook/orbitTheme.js
@@ -5,5 +5,5 @@ export default create({
   base: "light",
   brandTitle: "Orbit",
   brandUrl: "https://orbit.kiwi",
-  brandImage: "https://orbit.kiwi/files/2019/08/cropped-OrbitLogo-1.png",
+  brandImage: "https://images.kiwi.com/common/orbit-logo-full.png",
 });


### PR DESCRIPTION
the old logo is not accessible, because the web is down. 
 Storybook: https://orbit-silvenon-fix-storybook-logo.surge.sh