### PR TITLE
improve: install dependencies before publishing

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,6 +26,10 @@ function configureGitHubToken(done) {
   }
 }
 
+function installDependencies() {
+  return spawn("yarn", ["install"], { stdio: "inherit" });
+}
+
 async function previewChangelog(done) {
   const packages = await getPackages();
   const streams = packages
@@ -73,5 +77,5 @@ function publishPackages() {
 }
 
 module.exports = {
-  publish: series(configureGitHubToken, previewChangelog, publishPackages),
+  publish: series(configureGitHubToken, installDependencies, previewChangelog, publishPackages),
 };


### PR DESCRIPTION
This ensures that there won't be any problems when switching between branches, because it happened that publish script failed because some dependencies were missing.

 Storybook: https://orbit-silvenon-improve-publish-install.surge.sh