### PR TITLE
improve: be more exact in icons' gitignore

### DIFF
--- a/packages/orbit-components/src/icons/.gitignore
+++ b/packages/orbit-components/src/icons/.gitignore
@@ -1,7 +1,6 @@
-/*
-/*/
-!/svg/
-!readme.md
-!.gitignore
-!.eslintrc
-!.npmignore
+/*.js
+/*.jsx
+/*.ts
+/*.tsx
+/*.flow
+/*.d.ts


### PR DESCRIPTION
Previous patterns were very forgiving, so for me there were some stray directories that ended up in the build! These new patterns will ignore only what we want, nothing more.

 Storybook: https://orbit-silvenon-improve-icons-gitignore.surge.sh