### PR TITLE
fix: export ThemeShape for backwards compatibility

### DIFF
--- a/packages/orbit-components/src/defaultTheme.d.ts
+++ b/packages/orbit-components/src/defaultTheme.d.ts
@@ -10,6 +10,9 @@ export interface Theme {
   readonly rtl?: boolean;
 }
 
+// backwards compatibility
+export { Theme as ThemeShape };
+
 export interface ThemeProps {
   theme: Theme;
 }

--- a/packages/orbit-components/src/defaultTheme.js.flow
+++ b/packages/orbit-components/src/defaultTheme.js.flow
@@ -8,6 +8,9 @@ export type Theme = {|
   +rtl?: boolean,
 |};
 
+// backwards compatibility
+export type { Theme as ThemeShape };
+
 export type ThemeProps = {|
   theme: Theme,
 |};


### PR DESCRIPTION
People were using the old `ThemeShape`, so when we renamed it in #3125 we broke their code. For backwards compatibility we're re-exporting `Theme` as `ThemeShape` so that people can go on with their lives, but that we can continue pushing for a better type name.
