### PR TITLE
fix(useToggle): make typings reflect initial param is optional

### DIFF
--- a/packages/orbit-components/src/hooks/useToggle/index.d.ts
+++ b/packages/orbit-components/src/hooks/useToggle/index.d.ts
@@ -1,2 +1,2 @@
-declare const UseToggle: (initial: boolean) => [boolean, () => void];
+declare const UseToggle: (initial?: boolean) => [boolean, () => void];
 export { UseToggle, UseToggle as default };

--- a/packages/orbit-components/src/hooks/useToggle/index.js.flow
+++ b/packages/orbit-components/src/hooks/useToggle/index.js.flow
@@ -1,4 +1,4 @@
 // @flow strict
-export type UseToggle = (initial: boolean) => [boolean, () => void];
+export type UseToggle = (initial?: boolean) => [boolean, () => void];
 
 declare export default UseToggle;


### PR DESCRIPTION
It defaults to false.
 Storybook: https://orbit-silvenon-rcsl-use-toggle-types.surge.sh