### PR TITLE
fix(Heading): fix error when passing unsupported props

### DIFF
--- a/packages/orbit-components/src/Heading/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/Heading/__tests__/index.test.jsx
@@ -25,6 +25,17 @@ describe("Heading", () => {
     expect(heading.tagName.toLowerCase()).toBe("h2");
     expect(heading).toHaveAttribute("id", "id");
   });
+
+  it("should ignore unsupported props", () => {
+    render(
+      // className has to be undefined to reproduce the error
+      // $FlowExpectedError
+      <Heading as="h1" type="display" className={undefined}>
+        My lovely heading
+      </Heading>,
+    );
+    expect(screen.getByRole("heading", { name: "My lovely heading" }));
+  });
 });
 
 describe("Heading with every media query", () => {

--- a/packages/orbit-components/src/Heading/index.jsx
+++ b/packages/orbit-components/src/Heading/index.jsx
@@ -65,18 +65,20 @@ export const StyledHeading: any = styled(
     font-weight: ${getHeadingToken(TOKENS.weightHeading, type)};
     line-height: ${getHeadingToken(TOKENS.lineHeight, type)};
     margin-bottom: ${getSpacingToken};
-    ${Object.keys(viewports).map(viewport => {
-      const { type: value, spaceAfter } = viewports[viewport];
-      return (
-        viewport in mediaQueries &&
-        mediaQueries[viewport](css`
-          font-size: ${getHeadingToken(TOKENS.sizeHeading, value)};
-          font-weight: ${getHeadingToken(TOKENS.weightHeading, value)};
-          line-height: ${getHeadingToken(TOKENS.lineHeight, value)};
-          margin-bottom: ${getSpacingToken({ spaceAfter, theme })};
-        `)
-      );
-    })}
+    ${Object.keys(viewports)
+      .filter(viewport => mediaQueries[viewport])
+      .map(viewport => {
+        const { type: value, spaceAfter } = viewports[viewport];
+        return (
+          viewport in mediaQueries &&
+          mediaQueries[viewport](css`
+            font-size: ${getHeadingToken(TOKENS.sizeHeading, value)};
+            font-weight: ${getHeadingToken(TOKENS.weightHeading, value)};
+            line-height: ${getHeadingToken(TOKENS.lineHeight, value)};
+            margin-bottom: ${getSpacingToken({ spaceAfter, theme })};
+          `)
+        );
+      })}
   `}
 `;
 


### PR DESCRIPTION
In some cases Heading can be used with unsupported props, for example the library `markdown-to-jsx` passes `className` automatically, but Heading mistakenly treats it as a viewport and fails when it tries to access it as an object. Now we're filtering out props which aren't viewports, and simply ignore them.

 Storybook: https://orbit-silvenon-fix-heading-filter-viewports.surge.sh