### PR TITLE
fix(Popover): useClickOutside after isLargeMobile

### DIFF
--- a/packages/orbit-components/src/Popover/components/ContentWrapper.jsx
+++ b/packages/orbit-components/src/Popover/components/ContentWrapper.jsx
@@ -200,7 +200,7 @@ const PopoverContentWrapper = ({
 }: Props): React.Node => {
   const [actionsDimensions, setActionsDimensions] = React.useState(0);
   const { isInsideModal } = React.useContext(ModalContext);
-  const { isLargeMobile, isTablet } = useMediaQuery();
+  const { isLargeMobile } = useMediaQuery();
 
   const content = React.useRef<?HTMLElement | null>(null);
   const scrollingElementRef = React.useRef<HTMLElement | null>(null);
@@ -263,7 +263,7 @@ const PopoverContentWrapper = ({
   );
 
   useClickOutside(content, ev => {
-    if (isTablet) onClose(ev);
+    if (isLargeMobile) onClose(ev);
   });
 
   const handleKeyDown = (ev: SyntheticKeyboardEvent<HTMLDivElement>) => {


### PR DESCRIPTION
[Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1636718118131300). We used the wrong media query because mobile styles stop applying from `isLargeMobile`. 
 Storybook: https://orbit-silvenon-fix-popover-onclose.surge.sh