### PR TITLE
feat: add new experimental hook `useTransition`

### DIFF
--- a/packages/orbit-components/src/hooks/useTransition/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/hooks/useTransition/__tests__/index.test.jsx
@@ -1,0 +1,53 @@
+// @flow
+import * as React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import useTransition from "..";
+
+function App(props: {| show: boolean, appear: boolean |}) {
+  const [show, setShow] = React.useState(props.show);
+  const transition = useTransition({ show, appear: props.appear });
+  return (
+    <>
+      <button disabled={!transition.done} type="button" onClick={() => setShow(prev => !prev)}>
+        Toggle
+      </button>
+      {transition.mounted && (
+        <div
+          ref={transition.ref}
+          css={`
+            transition: opacity 0.5s ease-in-out;
+            opacity: ${transition.enter ? 1 : 0};
+          `}
+        >
+          Test
+        </div>
+      )}
+    </>
+  );
+}
+
+describe("useTransition", () => {
+  it("should provide correct API for transitioning", async () => {
+    render(<App show={false} appear={false} />);
+    expect(screen.queryByText("Test")).not.toBeInTheDocument();
+    userEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("Test")).toHaveStyle({ opacity: 1 });
+    expect(screen.getByRole("button")).toBeDisabled();
+    fireEvent.transitionEnd(screen.getByText("Test"));
+    expect(screen.getByRole("button")).not.toBeDisabled();
+    userEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("Test")).toHaveStyle({ opacity: 0 });
+    fireEvent.transitionEnd(screen.getByText("Test"));
+    expect(screen.queryByText("Test")).not.toBeInTheDocument();
+  });
+
+  it("should be able to transition in on mount", () => {
+    render(<App show appear />);
+    expect(screen.getByText("Test")).toHaveStyle({ opacity: 1 });
+    expect(screen.getByRole("button")).toBeDisabled();
+    fireEvent.transitionEnd(screen.getByText("Test"));
+    expect(screen.getByRole("button")).not.toBeDisabled();
+  });
+});

--- a/packages/orbit-components/src/hooks/useTransition/index.d.ts
+++ b/packages/orbit-components/src/hooks/useTransition/index.d.ts
@@ -1,0 +1,11 @@
+import React from "react";
+
+export declare function useTransition(options: {
+  readonly show: boolean;
+  readonly appear?: boolean;
+}): {
+  ref: React.MutableRefObject<HTMLElement | null>;
+  mounted: boolean;
+  enter: boolean;
+  done: boolean;
+};

--- a/packages/orbit-components/src/hooks/useTransition/index.js
+++ b/packages/orbit-components/src/hooks/useTransition/index.js
@@ -26,7 +26,7 @@ const useTransition: UseTransitionType = ({ show, appear = false }) => {
 
   React.useEffect(() => {
     if (firstRender.current) {
-      if (appear && show && firstRender.current) {
+      if (appear && show) {
         setMounted(true);
       }
     }
@@ -56,17 +56,19 @@ const useTransition: UseTransitionType = ({ show, appear = false }) => {
   React.useEffect(() => {
     let listener;
     const el = ref.current;
-    if (!firstRender.current && mounted) {
-      // reading from properties like scrollTop forces a repaint, which we need
-      // to make transition work immediately after mount
-      // eslint-disable-next-line babel/no-unused-expressions
-      ref.current?.scrollTop;
-      setEnter(true);
-      setDone(false);
-      listener = () => {
-        setDone(true);
-      };
-      el?.addEventListener("transitionend", listener);
+    if (!firstRender.current) {
+      if (mounted) {
+        // reading from properties like scrollTop forces a repaint, which we need
+        // to make transition work immediately after mount
+        // eslint-disable-next-line babel/no-unused-expressions
+        ref.current?.scrollTop;
+        setEnter(true);
+        setDone(false);
+        listener = () => {
+          setDone(true);
+        };
+        el?.addEventListener("transitionend", listener);
+      }
     }
     return () => {
       el?.removeEventListener("transitionend", listener);

--- a/packages/orbit-components/src/hooks/useTransition/index.js
+++ b/packages/orbit-components/src/hooks/useTransition/index.js
@@ -1,0 +1,83 @@
+// @flow
+import * as React from "react";
+
+import typeof UseTransitionType from ".";
+
+const useTransition: UseTransitionType = ({ show, appear = false }) => {
+  // if appear is true, we want to start from unmounted state, so that we can transition in
+  const [mounted, setMounted] = React.useState(!appear && show);
+  const [enter, setEnter] = React.useState(!appear && show);
+  const [done, setDone] = React.useState(!appear || !show);
+  const ref = React.useRef(null);
+  const firstRender = React.useRef(true);
+
+  // const [, updateState] = React.useState()
+  // const forceUpdate = React.useCallback(() => updateState({}), [])
+
+  // if (module.hot) {
+  //   module.hot.dispose(() => {
+  //     firstRender.current = true
+  //     setMounted(!appear && show)
+  //     setEnter(!appear && show)
+  //     setDone(!appear || !show)
+  //     forceUpdate()
+  //   })
+  // }
+
+  React.useEffect(() => {
+    if (firstRender.current) {
+      if (appear && show && firstRender.current) {
+        setMounted(true);
+      }
+    }
+  }, [appear, show]);
+
+  React.useEffect(() => {
+    let listener;
+    const el = ref.current;
+    if (!firstRender.current) {
+      if (show) {
+        setMounted(true);
+      } else {
+        setEnter(false);
+        setDone(false);
+        listener = () => {
+          setMounted(false);
+          setDone(true);
+        };
+        el?.addEventListener("transitionend", listener);
+      }
+    }
+    return () => {
+      el?.removeEventListener("transitionend", listener);
+    };
+  }, [show]);
+
+  React.useEffect(() => {
+    let listener;
+    const el = ref.current;
+    if (!firstRender.current && mounted) {
+      // reading from properties like scrollTop forces a repaint, which we need
+      // to make transition work immediately after mount
+      // eslint-disable-next-line babel/no-unused-expressions
+      ref.current?.scrollTop;
+      setEnter(true);
+      setDone(false);
+      listener = () => {
+        setDone(true);
+      };
+      el?.addEventListener("transitionend", listener);
+    }
+    return () => {
+      el?.removeEventListener("transitionend", listener);
+    };
+  }, [mounted]);
+
+  React.useEffect(() => {
+    firstRender.current = false;
+  }, []);
+
+  return { ref, mounted, enter, done };
+};
+
+export default useTransition;

--- a/packages/orbit-components/src/hooks/useTransition/index.js.flow
+++ b/packages/orbit-components/src/hooks/useTransition/index.js.flow
@@ -1,0 +1,13 @@
+// @flow
+
+declare function useTransition(options: {|
+  +show: boolean,
+  +appear?: boolean,
+|}): {|
+  ref: {| current: HTMLElement | null |},
+  mounted: boolean,
+  enter: boolean,
+  done: boolean,
+|};
+
+export default useTransition;


### PR DESCRIPTION
The Toast implementation in #3187 uses CSS Animations, but I think this is unnecessary, you can get by with just CSS Transitions. The problem with the current Toast implementation is that it stays in the DOM after fading out, so you won't be able to click on something below it if you need to, which will be very confusing because Toast is invisible, so I recommend unmounting Toast after fading out.

The problem with animating the presence of an element in the DOM is a well-known one, and has already been solved by libraries like react-transition-group (more specifically, its CSSTransition component), which I used as an inspiration for this hook. Currently it's undocumented because it's intended primarily for internal use, but people are welcome to try it.

I considered using [Headless UI's Transition component](https://headlessui.dev/react/transition), but it seems significantly bigger, so by having our own minimal hook we're saving about 3 kB.

 Storybook: https://orbit-silvenon-feat-use-transition.surge.sh