### PR TITLE
fix: prevent tab shadow clipping

### DIFF
--- a/docs/plugins/contributors/fetchedUsers.json
+++ b/docs/plugins/contributors/fetchedUsers.json
@@ -216,7 +216,7 @@
     "error": "",
     "twitter": "silvenon",
     "website": "https://silvenon.com",
-    "info": "Frontend developer, static site enthusiast and blogger.",
+    "info": "Frontend tooling nerd 🤓",
     "active": false,
     "dribble": "",
     "avatar_url": "https://avatars.githubusercontent.com/u/471278?v=4",

--- a/docs/src/components/DocLayout/index.tsx
+++ b/docs/src/components/DocLayout/index.tsx
@@ -64,7 +64,7 @@ const StyledTopWrapper = styled.div<{ $hasTabs: boolean }>`
     ${$hasTabs &&
     // maintain alignment of tabs with the content
     css`
-      padding-left: calc(${theme.orbit.spaceXLarge} - ${getTabShadowReachLeft(theme)});
+      padding-left: calc(${theme.orbit.spaceXLarge} - ${getTabShadowReachLeft});
     `};
   `}
 `;

--- a/docs/src/components/DocLayout/index.tsx
+++ b/docs/src/components/DocLayout/index.tsx
@@ -33,7 +33,7 @@ import { ComponentStatus } from "../ComponentStatus";
 import ComponentStructure from "../ComponentStructure";
 import TableOfContents from "../TableOfContents";
 import { useTableOfContents } from "../../services/table-of-contents";
-import Tabs, { TabObject, SHADOW_LEFT as TAB_SHADOW_LEFT } from "../Tabs";
+import Tabs, { TabObject, getTabShadowReachLeft } from "../Tabs";
 import ReactExample from "../ReactExample";
 import FigmaIframe from "../FigmaIframe";
 import Footer from "../Footer";
@@ -64,7 +64,7 @@ const StyledTopWrapper = styled.div<{ $hasTabs: boolean }>`
     ${$hasTabs &&
     // maintain alignment of tabs with the content
     css`
-      padding-left: calc(${theme.orbit.spaceXLarge} - ${TAB_SHADOW_LEFT});
+      padding-left: calc(${theme.orbit.spaceXLarge} - ${getTabShadowReachLeft(theme)});
     `};
   `}
 `;

--- a/docs/src/components/DocLayout/index.tsx
+++ b/docs/src/components/DocLayout/index.tsx
@@ -33,7 +33,7 @@ import { ComponentStatus } from "../ComponentStatus";
 import ComponentStructure from "../ComponentStructure";
 import TableOfContents from "../TableOfContents";
 import { useTableOfContents } from "../../services/table-of-contents";
-import Tabs, { TabObject } from "../Tabs";
+import Tabs, { TabObject, SHADOW_LEFT as TAB_SHADOW_LEFT } from "../Tabs";
 import ReactExample from "../ReactExample";
 import FigmaIframe from "../FigmaIframe";
 import Footer from "../Footer";
@@ -54,13 +54,18 @@ const StyledDescription = styled.span`
   line-height: 22px;
 `;
 
-const StyledTopWrapper = styled.div`
-  ${({ theme }) => css`
+const StyledTopWrapper = styled.div<{ $hasTabs: boolean }>`
+  ${({ theme, $hasTabs }) => css`
     display: flex;
     width: 100%;
     justify-content: space-between;
     align-items: end;
     padding: 0 ${theme.orbit.spaceXLarge};
+    ${$hasTabs &&
+    // maintain alignment of tabs with the content
+    css`
+      padding-left: calc(${theme.orbit.spaceXLarge} - ${TAB_SHADOW_LEFT});
+    `};
   `}
 `;
 
@@ -176,7 +181,7 @@ export default function DocLayout({
                         justify={tabs && tabs.length > 0 ? "between" : "end"}
                         tablet={{ maxWidth: tocHasItems ? "80%" : "100%" }}
                       >
-                        <StyledTopWrapper>
+                        <StyledTopWrapper $hasTabs={Boolean(tabs)}>
                           {tabs && <Tabs activeTab={location.pathname} tabs={tabs} />}
                           {headerLink && (
                             <Hide on={["smallMobile", "mediumMobile"]}>

--- a/docs/src/components/Tabs/Tab.tsx
+++ b/docs/src/components/Tabs/Tab.tsx
@@ -3,7 +3,8 @@ import { Link } from "gatsby";
 import styled, { css } from "styled-components";
 
 import StackOfTabs, { StyledWrapper as StyledStackWrapper } from "./StackOfTabs";
-import { TAB_HEIGHT, BORDER_RADIUS, SHADOW_TOP } from "./consts";
+import { TAB_HEIGHT, BORDER_RADIUS, TAB_ACTIVE_SHADOW_TOKEN } from "./consts";
+import { getTabShadowReachTop } from "./helpers";
 import { boxShadowDefault } from "../mixins";
 
 export interface TabObject {
@@ -26,7 +27,7 @@ const StyledTabLink = styled(Link)`
   ${({ theme }) => css`
     display: flex;
     align-items: center; /* align text so it matches StyledTab */
-    height: calc(${TAB_HEIGHT} - ${SHADOW_TOP});
+    height: calc(${TAB_HEIGHT} - ${getTabShadowReachTop(theme)});
     color: ${theme.orbit.paletteInkLight};
     transition: color ${theme.orbit.durationFast};
     &:hover {
@@ -37,7 +38,7 @@ const StyledTabLink = styled(Link)`
 
 export const commonTabStyle = css`
   ${({ theme }) => `
-    height: calc(${TAB_HEIGHT} - ${SHADOW_TOP});
+    height: calc(${TAB_HEIGHT} - ${getTabShadowReachTop(theme)});
     border-top-left-radius: ${BORDER_RADIUS};
     border-top-right-radius: ${BORDER_RADIUS};
     ${boxShadowDefault};
@@ -61,7 +62,7 @@ const StyledTab = styled.span<{ fullWidth?: boolean }>`
     transition: box-shadow ${theme.orbit.durationFast};
 
     ${StyledStackWrapper}:hover & {
-      box-shadow: ${theme.orbit.boxShadowRaised};
+      box-shadow: ${theme.orbit[TAB_ACTIVE_SHADOW_TOKEN]};
     }
 
     > * + * {

--- a/docs/src/components/Tabs/Tab.tsx
+++ b/docs/src/components/Tabs/Tab.tsx
@@ -3,7 +3,7 @@ import { Link } from "gatsby";
 import styled, { css } from "styled-components";
 
 import StackOfTabs, { StyledWrapper as StyledStackWrapper } from "./StackOfTabs";
-import { TAB_HEIGHT, BORDER_RADIUS, SHADOW_PADDING_TOP } from "./consts";
+import { TAB_HEIGHT, BORDER_RADIUS, SHADOW_TOP } from "./consts";
 import { boxShadowDefault } from "../mixins";
 
 export interface TabObject {
@@ -26,7 +26,7 @@ const StyledTabLink = styled(Link)`
   ${({ theme }) => css`
     display: flex;
     align-items: center; /* align text so it matches StyledTab */
-    height: calc(${TAB_HEIGHT} - ${SHADOW_PADDING_TOP});
+    height: calc(${TAB_HEIGHT} - ${SHADOW_TOP});
     color: ${theme.orbit.paletteInkLight};
     transition: color ${theme.orbit.durationFast};
     &:hover {
@@ -37,7 +37,7 @@ const StyledTabLink = styled(Link)`
 
 export const commonTabStyle = css`
   ${({ theme }) => `
-    height: calc(${TAB_HEIGHT} - ${SHADOW_PADDING_TOP});
+    height: calc(${TAB_HEIGHT} - ${SHADOW_TOP});
     border-top-left-radius: ${BORDER_RADIUS};
     border-top-right-radius: ${BORDER_RADIUS};
     ${boxShadowDefault};

--- a/docs/src/components/Tabs/Tab.tsx
+++ b/docs/src/components/Tabs/Tab.tsx
@@ -27,7 +27,7 @@ const StyledTabLink = styled(Link)`
   ${({ theme }) => css`
     display: flex;
     align-items: center; /* align text so it matches StyledTab */
-    height: calc(${TAB_HEIGHT} - ${getTabShadowReachTop(theme)});
+    height: calc(${TAB_HEIGHT} - ${getTabShadowReachTop});
     color: ${theme.orbit.paletteInkLight};
     transition: color ${theme.orbit.durationFast};
     &:hover {
@@ -38,7 +38,7 @@ const StyledTabLink = styled(Link)`
 
 export const commonTabStyle = css`
   ${({ theme }) => `
-    height: calc(${TAB_HEIGHT} - ${getTabShadowReachTop(theme)});
+    height: calc(${TAB_HEIGHT} - ${getTabShadowReachTop});
     border-top-left-radius: ${BORDER_RADIUS};
     border-top-right-radius: ${BORDER_RADIUS};
     ${boxShadowDefault};

--- a/docs/src/components/Tabs/consts.ts
+++ b/docs/src/components/Tabs/consts.ts
@@ -2,7 +2,9 @@ import { mediaQueries } from "@kiwicom/orbit-components";
 
 export const TAB_HEIGHT = "64px";
 export const BORDER_RADIUS = "12px";
-// to prevent tab shadow from clipping
-export const SHADOW_PADDING_TOP = "16px";
-export const SHADOW_PADDING_RIGHT = "24px";
+// taken from the stronger shadow that appears when hovering stacked tabs
+// we use these values for padding to prevent that shadow from clipping
+export const SHADOW_TOP = "16px";
+export const SHADOW_LEFT = "24px";
+export const SHADOW_RIGHT = "24px";
 export const FULL_WIDTH_BREAKPOINT: keyof typeof mediaQueries = "largeMobile";

--- a/docs/src/components/Tabs/consts.ts
+++ b/docs/src/components/Tabs/consts.ts
@@ -2,9 +2,5 @@ import { mediaQueries } from "@kiwicom/orbit-components";
 
 export const TAB_HEIGHT = "64px";
 export const BORDER_RADIUS = "12px";
-// taken from the stronger shadow that appears when hovering stacked tabs
-// we use these values for padding to prevent that shadow from clipping
-export const SHADOW_TOP = "16px";
-export const SHADOW_LEFT = "24px";
-export const SHADOW_RIGHT = "24px";
+export const TAB_ACTIVE_SHADOW_TOKEN = "boxShadowRaised";
 export const FULL_WIDTH_BREAKPOINT: keyof typeof mediaQueries = "largeMobile";

--- a/docs/src/components/Tabs/helpers.ts
+++ b/docs/src/components/Tabs/helpers.ts
@@ -10,7 +10,7 @@ function parseBoxShadow(boxShadow: string): number[][] {
     .map(s => s.map(v => parseInt(v, 10)));
 }
 
-export function getTabShadowReachTop(theme: DefaultTheme) {
+export function getTabShadowReachTop({ theme }: { theme: DefaultTheme }) {
   const result = parseBoxShadow(theme.orbit[TAB_ACTIVE_SHADOW_TOKEN])
     .map(s => {
       const [, offsetY = 0, blurRadius = 0, spreadRadius = 0] = s;
@@ -24,7 +24,7 @@ export function getTabShadowReachTop(theme: DefaultTheme) {
   return `${result}px`;
 }
 
-export function getTabShadowReachLeft(theme: DefaultTheme) {
+export function getTabShadowReachLeft({ theme }: { theme: DefaultTheme }) {
   const result = parseBoxShadow(theme.orbit[TAB_ACTIVE_SHADOW_TOKEN])
     .map(s => {
       const [offsetX = 0, , blurRadius = 0, spreadRadius = 0] = s;
@@ -38,7 +38,7 @@ export function getTabShadowReachLeft(theme: DefaultTheme) {
   return `${result}px`;
 }
 
-export function getTabShadowReachRight(theme: DefaultTheme) {
+export function getTabShadowReachRight({ theme }: { theme: DefaultTheme }) {
   const result = parseBoxShadow(theme.orbit[TAB_ACTIVE_SHADOW_TOKEN])
     .map(s => {
       const [offsetX = 0, , blurRadius = 0, spreadRadius = 0] = s;

--- a/docs/src/components/Tabs/helpers.ts
+++ b/docs/src/components/Tabs/helpers.ts
@@ -1,0 +1,53 @@
+import { DefaultTheme } from "styled-components";
+
+import { TAB_ACTIVE_SHADOW_TOKEN } from "./consts";
+
+function parseBoxShadow(boxShadow: string): number[][] {
+  return boxShadow
+    .split(",")
+    .map(s => s.trim())
+    .map(s => s.split(" "))
+    .map(s => s.map(v => parseInt(v, 10)));
+}
+
+export function getTabShadowReachTop(theme: DefaultTheme) {
+  const result = parseBoxShadow(theme.orbit[TAB_ACTIVE_SHADOW_TOKEN])
+    .map(s => {
+      const [, offsetY = 0, blurRadius = 0, spreadRadius = 0] = s;
+      const reachTop = blurRadius + spreadRadius - offsetY;
+      return reachTop;
+    })
+    .reduce((previous, current) => {
+      return Math.max(previous, current);
+    }, 0);
+
+  return `${result}px`;
+}
+
+export function getTabShadowReachLeft(theme: DefaultTheme) {
+  const result = parseBoxShadow(theme.orbit[TAB_ACTIVE_SHADOW_TOKEN])
+    .map(s => {
+      const [offsetX = 0, , blurRadius = 0, spreadRadius = 0] = s;
+      const reachLeft = blurRadius + spreadRadius - offsetX;
+      return reachLeft;
+    })
+    .reduce((previous, current) => {
+      return Math.max(previous, current);
+    }, 0);
+
+  return `${result}px`;
+}
+
+export function getTabShadowReachRight(theme: DefaultTheme) {
+  const result = parseBoxShadow(theme.orbit[TAB_ACTIVE_SHADOW_TOKEN])
+    .map(s => {
+      const [offsetX = 0, , blurRadius = 0, spreadRadius = 0] = s;
+      const reachRight = blurRadius + spreadRadius + offsetX;
+      return reachRight;
+    })
+    .reduce((previous, current) => {
+      return Math.max(previous, current);
+    }, 0);
+
+  return `${result}px`;
+}

--- a/docs/src/components/Tabs/index.tsx
+++ b/docs/src/components/Tabs/index.tsx
@@ -7,12 +7,7 @@ import debounce from "lodash/debounce";
 
 import Tab, { TabObject } from "./Tab";
 import useFontLoaded from "../../hooks/useFontLoaded";
-import {
-  TAB_HEIGHT,
-  SHADOW_PADDING_TOP,
-  SHADOW_PADDING_RIGHT,
-  FULL_WIDTH_BREAKPOINT,
-} from "./consts";
+import { TAB_HEIGHT, SHADOW_TOP, SHADOW_LEFT, SHADOW_RIGHT, FULL_WIDTH_BREAKPOINT } from "./consts";
 
 const StyledContainer = styled.div<{ collapsed: boolean }>`
   ${({ theme, collapsed }) => css`
@@ -27,8 +22,9 @@ const StyledContainer = styled.div<{ collapsed: boolean }>`
     z-index: 1; /* place tabs above the main container */
     display: flex;
     flex-wrap: wrap; /* so that we can detect whether tabs wrap, and in that case collapse them */
-    padding-top: ${SHADOW_PADDING_TOP};
-    padding-right: ${SHADOW_PADDING_RIGHT};
+    padding-top: ${SHADOW_TOP};
+    padding-left: ${SHADOW_LEFT};
+    padding-right: ${SHADOW_RIGHT};
     /* prevents box shadow and tabs stack from overflowing at the bottom in order to */
     /* achieve the effect of attached tabs, also prevents wrapped tabs from showing */
     overflow: hidden;
@@ -189,4 +185,4 @@ export default function Tabs({ activeTab: activeTabSlug, tabs }: Props) {
   );
 }
 
-export { TabObject };
+export { TabObject, SHADOW_LEFT };

--- a/docs/src/components/Tabs/index.tsx
+++ b/docs/src/components/Tabs/index.tsx
@@ -7,7 +7,8 @@ import debounce from "lodash/debounce";
 
 import Tab, { TabObject } from "./Tab";
 import useFontLoaded from "../../hooks/useFontLoaded";
-import { TAB_HEIGHT, SHADOW_TOP, SHADOW_LEFT, SHADOW_RIGHT, FULL_WIDTH_BREAKPOINT } from "./consts";
+import { TAB_HEIGHT, FULL_WIDTH_BREAKPOINT } from "./consts";
+import { getTabShadowReachTop, getTabShadowReachLeft, getTabShadowReachRight } from "./helpers";
 
 const StyledContainer = styled.div<{ collapsed: boolean }>`
   ${({ theme, collapsed }) => css`
@@ -22,9 +23,9 @@ const StyledContainer = styled.div<{ collapsed: boolean }>`
     z-index: 1; /* place tabs above the main container */
     display: flex;
     flex-wrap: wrap; /* so that we can detect whether tabs wrap, and in that case collapse them */
-    padding-top: ${SHADOW_TOP};
-    padding-left: ${SHADOW_LEFT};
-    padding-right: ${SHADOW_RIGHT};
+    padding-top: ${getTabShadowReachTop(theme)};
+    padding-left: ${getTabShadowReachLeft(theme)};
+    padding-right: ${getTabShadowReachRight(theme)};
     /* prevents box shadow and tabs stack from overflowing at the bottom in order to */
     /* achieve the effect of attached tabs, also prevents wrapped tabs from showing */
     overflow: hidden;
@@ -185,4 +186,4 @@ export default function Tabs({ activeTab: activeTabSlug, tabs }: Props) {
   );
 }
 
-export { TabObject, SHADOW_LEFT };
+export { TabObject, getTabShadowReachLeft };

--- a/docs/src/components/Tabs/index.tsx
+++ b/docs/src/components/Tabs/index.tsx
@@ -23,9 +23,9 @@ const StyledContainer = styled.div<{ collapsed: boolean }>`
     z-index: 1; /* place tabs above the main container */
     display: flex;
     flex-wrap: wrap; /* so that we can detect whether tabs wrap, and in that case collapse them */
-    padding-top: ${getTabShadowReachTop(theme)};
-    padding-left: ${getTabShadowReachLeft(theme)};
-    padding-right: ${getTabShadowReachRight(theme)};
+    padding-top: ${getTabShadowReachTop};
+    padding-left: ${getTabShadowReachLeft};
+    padding-right: ${getTabShadowReachRight};
     /* prevents box shadow and tabs stack from overflowing at the bottom in order to */
     /* achieve the effect of attached tabs, also prevents wrapped tabs from showing */
     overflow: hidden;


### PR DESCRIPTION
The tab shadow was very noticeably clipping on the left, especially stacked tabs on hover.

 Storybook: https://orbit-silvenon-docs-tabs-shadow-clip.surge.sh