### PR TITLE
fix: restore examples for error forms

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -21,5 +21,3 @@ runs:
     - name: Install dependencies
       run: yarn install --frozen-lockfile
       shell: bash
-      env:
-        STREAMLINE_FAMILIES: ${{ secrets.STREAMLINE_FAMILIES }}

--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -21,3 +21,5 @@ runs:
     - name: Install dependencies
       run: yarn install --frozen-lockfile
       shell: bash
+      env:
+        STREAMLINE_FAMILIES: ${{ secrets.STREAMLINE_FAMILIES }}

--- a/docs/src/__examples__/InputField/ERROR.tsx
+++ b/docs/src/__examples__/InputField/ERROR.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import InputField from "@kiwicom/orbit-components/lib/InputField";
+
+export default {
+  Example: () => {
+    const [value, setValue] = React.useState("");
+    return (
+      <InputField
+        error={!value && "Please enter your email"}
+        help="Enter your email in the format name@example.com"
+        placeholder="your@email.com"
+        label="Email"
+        type="email"
+        inputMode="email"
+        value={value}
+        onChange={event => setValue(event.currentTarget.value)}
+      />
+    );
+  },
+};

--- a/docs/src/__examples__/InputField/HELP.tsx
+++ b/docs/src/__examples__/InputField/HELP.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import InputField from "@kiwicom/orbit-components/lib/InputField";
+
+export default {
+  Example: () => {
+    return (
+      <InputField
+        help="Enter your email in the format name@example.com"
+        placeholder="your@email.com"
+        label="Email"
+        type="email"
+        inputMode="email"
+      />
+    );
+  },
+};

--- a/docs/src/__examples__/InputField/REQUIRED.tsx
+++ b/docs/src/__examples__/InputField/REQUIRED.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import InputField from "@kiwicom/orbit-components/lib/InputField";
+
+export default {
+  Example: () => {
+    return (
+      <InputField
+        required
+        placeholder="your@email.com"
+        label="Email"
+        type="email"
+        inputMode="email"
+      />
+    );
+  },
+};


### PR DESCRIPTION
#3122 by @mainframev removed examples for InputField, which made sense for the InputField component page. But it left the [Forms and errors page](https://orbit.kiwi/design-patterns/form-errors/) with 3 instances of `Could not find example with the id:`. This PR restores those examples.