### PR TITLE
fix/InputField invalid width attribute

### DIFF
--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -60,7 +60,7 @@
   "peerDependencies": {
     "react": ">=16.14.0",
     "react-dom": ">=16.12.0",
-    "styled-components": "^4.4.1"
+    "styled-components": "^4 || ^5"
   },
   "dependencies": {
     "@adeira/js": "^1.3.0",

--- a/packages/orbit-components/src/InputField/index.jsx
+++ b/packages/orbit-components/src/InputField/index.jsx
@@ -58,7 +58,7 @@ const getDOMType = type => {
 
 const Field: any = styled(
   React.forwardRef(
-    ({ component: Component, className, children, spaceAfter, theme, ...props }, ref) => {
+    ({ component: Component, className, children, spaceAfter, theme, $width, ...props }, ref) => {
       return (
         <Component className={className} ref={ref} {...props}>
           {children}


### PR DESCRIPTION
With `styled-components` v4 this was causing a console warning because `$width` was being set as a HTML attribute, as it was forwarded along with other rest `props`.

Also, Orbit supports `styled-components` v5 for a long time now, we're using it ourselves, so I also updated the version in `peerDependencies` to a very loose version range to avoid possibly misleading warnings about unmet peer dependency.

- [Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1638202270179900)

 Storybook: https://orbit-silvenon-fix-InputField-invalid-width-attribute.surge.sh