### PR TITLE
docs: flatten and alphabetize list of components in navigation

### DIFF
--- a/docs/src/components/DocNavigation/__tests__/index.test.tsx
+++ b/docs/src/components/DocNavigation/__tests__/index.test.tsx
@@ -17,6 +17,11 @@ describe("DocNavigation", () => {
       ],
       [
         { name: "Components", url: "/components/", hasReactTab: false },
+        { name: "Information", url: "/components/information/", hasReactTab: false },
+        { name: "Toast", url: "/components/information/toast/", hasReactTab: true },
+      ],
+      [
+        { name: "Components", url: "/components/", hasReactTab: false },
         { name: "Action", url: "/components/action/", hasReactTab: false },
         { name: "Button", url: "/components/action/button/", hasReactTab: true },
       ],
@@ -76,17 +81,16 @@ describe("DocNavigation", () => {
           \\"url\\": \\"/components/\\",
           \\"items\\": [
             {
-              \\"type\\": \\"branch\\",
-              \\"name\\": \\"Action\\",
-              \\"url\\": \\"/components/action/\\",
-              \\"items\\": [
-                {
-                  \\"type\\": \\"leaf\\",
-                  \\"name\\": \\"Button\\",
-                  \\"url\\": \\"/components/action/button/\\",
-                  \\"hasReactTab\\": true
-                }
-              ]
+              \\"type\\": \\"leaf\\",
+              \\"name\\": \\"Button\\",
+              \\"url\\": \\"/components/action/button/\\",
+              \\"hasReactTab\\": true
+            },
+            {
+              \\"type\\": \\"leaf\\",
+              \\"name\\": \\"Toast\\",
+              \\"url\\": \\"/components/information/toast/\\",
+              \\"hasReactTab\\": true
             }
           ]
         },

--- a/docs/src/components/DocNavigation/__tests__/index.test.tsx
+++ b/docs/src/components/DocNavigation/__tests__/index.test.tsx
@@ -2,51 +2,53 @@ import { groupTrails } from "..";
 
 describe("DocNavigation", () => {
   it("should group trails into navigation items", () => {
-    const navigation = groupTrails([
-      [
-        { name: "Getting started", url: "/getting-started/", hasReactTab: false },
-        { name: "For designers", url: "/getting-started/for-designers/", hasReactTab: false },
+    const navigation = groupTrails({
+      content: [
+        [
+          { name: "Getting started", url: "/getting-started/", hasReactTab: false },
+          { name: "For designers", url: "/getting-started/for-designers/", hasReactTab: false },
+        ],
+        [
+          { name: "Getting started", url: "/getting-started/", hasReactTab: false },
+          { name: "For developers", url: "/getting-started/for-developers/", hasReactTab: false },
+        ],
+        [
+          { name: "Getting started", url: "/getting-started/", hasReactTab: false },
+          { name: "GitHub repos & resources", url: "/getting-started/github/", hasReactTab: false },
+        ],
+        [
+          { name: "For Kiwi.com use", url: "/kiwi-use/", hasReactTab: false },
+          { name: "Brand", url: "/kiwi-use/brand/", hasReactTab: false },
+          {
+            name: "Brand guidelines",
+            url: "/kiwi-use/brand/brand-guidelines/",
+            hasReactTab: false,
+          },
+        ],
+        [
+          { name: "For Kiwi.com use", url: "/kiwi-use/", hasReactTab: false },
+          { name: "Content", url: "/kiwi-use/content/", hasReactTab: false },
+          { name: "Specific areas", url: "/kiwi-use/content/specific-areas/", hasReactTab: false },
+          { name: "Social media", url: "/kiwi-use/content/social-media/", hasReactTab: false },
+        ],
+        [
+          { name: "For Kiwi.com use", url: "/kiwi-use/", hasReactTab: false },
+          { name: "Content", url: "/kiwi-use/content/", hasReactTab: false },
+          { name: "Specific areas", url: "/kiwi-use/content/specific-areas/", hasReactTab: false },
+          {
+            name: "Technical content",
+            url: "/kiwi-use/content/technical-content/",
+            hasReactTab: false,
+          },
+        ],
       ],
-      [
-        { name: "Getting started", url: "/getting-started/", hasReactTab: false },
-        { name: "For developers", url: "/getting-started/for-developers/", hasReactTab: false },
-      ],
-      [
-        { name: "Getting started", url: "/getting-started/", hasReactTab: false },
-        { name: "GitHub repos & resources", url: "/getting-started/github/", hasReactTab: false },
-      ],
-      [
-        { name: "Components", url: "/components/", hasReactTab: false },
+      components: [
+        { name: "Action", url: "/components/action/", hasReactTab: false },
+        { name: "Button", url: "/components/action/button/", hasReactTab: true },
         { name: "Information", url: "/components/information/", hasReactTab: false },
         { name: "Toast", url: "/components/information/toast/", hasReactTab: true },
       ],
-      [
-        { name: "Components", url: "/components/", hasReactTab: false },
-        { name: "Action", url: "/components/action/", hasReactTab: false },
-        { name: "Button", url: "/components/action/button/", hasReactTab: true },
-      ],
-      [
-        { name: "For Kiwi.com use", url: "/kiwi-use/", hasReactTab: false },
-        { name: "Brand", url: "/kiwi-use/brand/", hasReactTab: false },
-        { name: "Brand guidelines", url: "/kiwi-use/brand/brand-guidelines/", hasReactTab: false },
-      ],
-      [
-        { name: "For Kiwi.com use", url: "/kiwi-use/", hasReactTab: false },
-        { name: "Content", url: "/kiwi-use/content/", hasReactTab: false },
-        { name: "Specific areas", url: "/kiwi-use/content/specific-areas/", hasReactTab: false },
-        { name: "Social media", url: "/kiwi-use/content/social-media/", hasReactTab: false },
-      ],
-      [
-        { name: "For Kiwi.com use", url: "/kiwi-use/", hasReactTab: false },
-        { name: "Content", url: "/kiwi-use/content/", hasReactTab: false },
-        { name: "Specific areas", url: "/kiwi-use/content/specific-areas/", hasReactTab: false },
-        {
-          name: "Technical content",
-          url: "/kiwi-use/content/technical-content/",
-          hasReactTab: false,
-        },
-      ],
-    ]);
+    });
 
     expect(JSON.stringify(navigation, null, 2)).toMatchInlineSnapshot(`
       "[
@@ -72,25 +74,6 @@ describe("DocNavigation", () => {
               \\"name\\": \\"GitHub repos & resources\\",
               \\"url\\": \\"/getting-started/github/\\",
               \\"hasReactTab\\": false
-            }
-          ]
-        },
-        {
-          \\"type\\": \\"branch\\",
-          \\"name\\": \\"Components\\",
-          \\"url\\": \\"/components/\\",
-          \\"items\\": [
-            {
-              \\"type\\": \\"leaf\\",
-              \\"name\\": \\"Button\\",
-              \\"url\\": \\"/components/action/button/\\",
-              \\"hasReactTab\\": true
-            },
-            {
-              \\"type\\": \\"leaf\\",
-              \\"name\\": \\"Toast\\",
-              \\"url\\": \\"/components/information/toast/\\",
-              \\"hasReactTab\\": true
             }
           ]
         },
@@ -137,6 +120,37 @@ describe("DocNavigation", () => {
                   ]
                 }
               ]
+            }
+          ]
+        },
+        {
+          \\"type\\": \\"branch\\",
+          \\"name\\": \\"Components\\",
+          \\"url\\": \\"/components/\\",
+          \\"items\\": [
+            {
+              \\"type\\": \\"leaf\\",
+              \\"name\\": \\"Action\\",
+              \\"url\\": \\"/components/action/\\",
+              \\"hasReactTab\\": false
+            },
+            {
+              \\"type\\": \\"leaf\\",
+              \\"name\\": \\"Button\\",
+              \\"url\\": \\"/components/action/button/\\",
+              \\"hasReactTab\\": true
+            },
+            {
+              \\"type\\": \\"leaf\\",
+              \\"name\\": \\"Information\\",
+              \\"url\\": \\"/components/information/\\",
+              \\"hasReactTab\\": false
+            },
+            {
+              \\"type\\": \\"leaf\\",
+              \\"name\\": \\"Toast\\",
+              \\"url\\": \\"/components/information/toast/\\",
+              \\"hasReactTab\\": true
             }
           ]
         }


### PR DESCRIPTION
Tests are here, but implementation is missing.

 Storybook: https://orbit-silvenon-docs-nav-components-alphabetical.surge.sh