### PR TITLE
chore: bump Yarn

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -2,4 +2,5 @@
 # yarn lockfile v1
 
 
-yarn-path ".yarn/releases/yarn-1.19.1.js"
+lastUpdateCheck 1638269648692
+yarn-path ".yarn/releases/yarn-1.22.17.js"


### PR DESCRIPTION
Bump Yarn to 1.22.17. We were using a lower version as a workaround for the [missing `sharp` module](https://github.com/yarnpkg/yarn/issues/7807), but that workaround didn't work because I'm often getting that error, so let's bump Yarn considering that it doesn't matter.

Btw, every time I get that error (when I run orbit.kiwi), I run `npm rebuild sharp` and that solves it, so it's not a big problem.


 Storybook: https://orbit-silvenon-chore-bump-yarn.surge.sh