### PR TITLE
fix(getBreakpointWidth): improve typings through overloading

### DIFF
--- a/packages/orbit-components/src/utils/mediaQuery/__typetests__/index.ts
+++ b/packages/orbit-components/src/utils/mediaQuery/__typetests__/index.ts
@@ -1,9 +1,14 @@
 import styled, { css } from "styled-components";
 
-import mediaQuery from "..";
+import Theme from "../../../defaultTheme";
+import mediaQuery, { getBreakpointWidth } from "..";
 
 export const StyledComponent = styled.div`
   ${mediaQuery.desktop(css`
     color: red;
   `)};
 `;
+
+export const shouldBeNumber: number = getBreakpointWidth("desktop", Theme, true);
+export const shouldBeString: string = getBreakpointWidth("desktop", Theme, false);
+export const shouldAlsoBeString: string = getBreakpointWidth("desktop", Theme);

--- a/packages/orbit-components/src/utils/mediaQuery/index.d.ts
+++ b/packages/orbit-components/src/utils/mediaQuery/index.d.ts
@@ -8,10 +8,8 @@ import { Devices } from "./consts";
 type QueryFunction = (style: Interpolation<any>) => Interpolation<any>;
 
 declare const MediaQuery: Record<Devices, QueryFunction>;
-declare function getBreakpointWidth(
-  name: Devices,
-  theme: ThemeShape,
-  pure?: boolean,
-): number | string;
+declare function getBreakpointWidth(name: Devices, theme: ThemeShape): string;
+declare function getBreakpointWidth(name: Devices, theme: ThemeShape, pure: false): string;
+declare function getBreakpointWidth(name: Devices, theme: ThemeShape, pure: true): number;
 
 export { MediaQuery, MediaQuery as default, getBreakpointWidth };


### PR DESCRIPTION
This Pull Request meets the following criteria:

- [ ] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components has both `.flow` and `d.ts` files and are exprorted in `index.js.flow` and `index.d.ts`

 Storybook: https://orbit-silvenon-rcsl-fix-overlord-mediaquery.surge.sh