### PR TITLE
docs(useLockScrolling): document in orbit.kiwi

### DIFF
--- a/docs/src/documentation/05-development/03-hooks/uselockscrolling.mdx
+++ b/docs/src/documentation/05-development/03-hooks/uselockscrolling.mdx
@@ -1,0 +1,25 @@
+---
+title: useLockScrolling
+description: Prevent scrolling the page and only allow it for the given element, usually an overlay.
+---
+
+import UseLockScrollingReadMe from "@kiwicom/orbit-components/src/hooks/useLockScrolling/README.md";
+import { Alert } from "@kiwicom/orbit-components";
+import { MDXProvider } from "@mdx-js/react";
+
+export default function Layout() {
+  return (
+    <MDXProvider
+      components={{
+        h1: () => null, // we're already have the title
+        Warning: ({ children }) => (
+          <Alert type="warning" icon title="Important!">
+            {children}
+          </Alert>
+        ),
+      }}
+    >
+      <UseLockScrollingReadMe />
+    </MDXProvider>
+  );
+}

--- a/packages/orbit-components/src/hooks/useLockScrolling/README.md
+++ b/packages/orbit-components/src/hooks/useLockScrolling/README.md
@@ -1,6 +1,12 @@
 # useLockScrolling
 
-The `useLockScrolling` hook is useful when you want to lock scrolling to a given element, for example when a modal is open you want only its content to be scrollable, not the entire page.
+The `useLockScrolling` hook is useful when you want to lock scrolling to a given element, for example when a modal is open you want only its content to be scrollable, not the entire page (i.e. the "content in the background").
+
+<Warning>
+
+Locking scrolling is a global functionality – there is only one `<body>` element, so you should use `useLockScrolling` for all your (page) lock scrolling needs. It's keeping track of how many components are using it at the moment to know when to actually unlock scrolling, so if your application is using this hook alongside other implementations of locking scrolling, you might run into bugs where scrolling is not locked when it should be, or much worse, locked when it shouldn't be!
+
+</Warning>
 
 To implement the `useLockScrolling` hook in your component, add the import:
 


### PR DESCRIPTION
I noticed that many of our pages have titles shown twice, which is an unfortunate side-effect of importing readmes, so this page also features one way to avoid that, as well as an awkward trick to sneak in the Alert component into a readme 😄 

 Storybook: https://orbit-silvenon-docs-use-lock-scrolling.surge.sh