### PR TITLE
feat(Layout): accommodate breacrumbs on booking

### DIFF
--- a/packages/orbit-components/src/Layout/Layout.stories.jsx
+++ b/packages/orbit-components/src/Layout/Layout.stories.jsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 import Card, { CardSection } from "../Card";
 import RenderInRtl from "../utils/rtl/RenderInRtl";
+import Wizard, { WizardStep } from "../Wizard";
 
 import Layout, { LayoutColumn } from ".";
 
@@ -45,6 +46,15 @@ export const Search = (): React.Node => (
 export const Booking = (): React.Node => {
   return (
     <Layout type="Booking">
+      <LayoutColumn>
+        <Wizard id="wizard" completedSteps={3} activeStep={3} onChangeStep={() => {}}>
+          <WizardStep title="Search" />
+          <WizardStep title="Passenger details" />
+          <WizardStep title="Ticket fare" />
+          <WizardStep title="Customize your trip" />
+          <WizardStep title="Overview & Payment" />
+        </Wizard>
+      </LayoutColumn>
       <LayoutColumn>
         <Card>
           <CardSection>

--- a/packages/orbit-components/src/Layout/LayoutColumn/index.d.ts
+++ b/packages/orbit-components/src/Layout/LayoutColumn/index.d.ts
@@ -10,6 +10,7 @@ export interface Props extends Common.Global {
   readonly children: React.ReactNode;
   readonly as?: string;
   readonly hideOn?: Devices[];
+  readonly spanEntireRow?: boolean;
 }
 
 declare const LayoutColumn: React.FunctionComponent<Props>;

--- a/packages/orbit-components/src/Layout/LayoutColumn/index.jsx
+++ b/packages/orbit-components/src/Layout/LayoutColumn/index.jsx
@@ -11,21 +11,21 @@ import { QUERIES } from "../../utils/mediaQuery/consts";
 import type { Props } from ".";
 
 const StyledColumn = styled.div`
-  ${({ hideOn }) => !!hideOn && getViewportHideStyles(hideOn)};
-  ${({ spanEntireRow }) =>
-    spanEntireRow &&
+  ${({ theme, spanEntireRow, hideOn }) => css`
+    ${!!hideOn && getViewportHideStyles(hideOn)};
+    ${spanEntireRow &&
     css`
       grid-column: 1 / -1;
     `};
 
-  @media (max-width: ${({ theme }) =>
-      +getBreakpointWidth(QUERIES.LARGEMOBILE, theme, true) - 1}px) {
-    ${StyledCard} {
-      margin-right: -${({ theme }) => theme.orbit.spaceMedium};
-      margin-left: -${({ theme }) => theme.orbit.spaceMedium};
-      width: auto;
+    @media (max-width: ${+getBreakpointWidth(QUERIES.LARGEMOBILE, theme, true) - 1}px) {
+      ${StyledCard} {
+        margin-right: -${theme.orbit.spaceMedium};
+        margin-left: -${theme.orbit.spaceMedium};
+        width: auto;
+      }
     }
-  }
+  `}
 `;
 
 // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198

--- a/packages/orbit-components/src/Layout/LayoutColumn/index.jsx
+++ b/packages/orbit-components/src/Layout/LayoutColumn/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import defaultTheme from "../../defaultTheme";
 import getViewportHideStyles from "../../Hide/helpers/getViewportHideStyles";
@@ -12,6 +12,11 @@ import type { Props } from ".";
 
 const StyledColumn = styled.div`
   ${({ hideOn }) => !!hideOn && getViewportHideStyles(hideOn)};
+  ${({ spanEntireRow }) =>
+    spanEntireRow &&
+    css`
+      grid-column: 1 / -1;
+    `};
 
   @media (max-width: ${({ theme }) =>
       +getBreakpointWidth(QUERIES.LARGEMOBILE, theme, true) - 1}px) {
@@ -28,9 +33,15 @@ StyledColumn.defaultProps = {
   theme: defaultTheme,
 };
 
-const LayoutColumn = ({ children, hideOn, as = "div", dataTest }: Props): React.Node => {
+const LayoutColumn = ({
+  children,
+  hideOn,
+  as = "div",
+  spanEntireRow = false,
+  dataTest,
+}: Props): React.Node => {
   return (
-    <StyledColumn data-test={dataTest} hideOn={hideOn} as={as}>
+    <StyledColumn data-test={dataTest} hideOn={hideOn} as={as} spanEntireRow={spanEntireRow}>
       {children}
     </StyledColumn>
   );

--- a/packages/orbit-components/src/Layout/LayoutColumn/index.jsx
+++ b/packages/orbit-components/src/Layout/LayoutColumn/index.jsx
@@ -37,7 +37,7 @@ const LayoutColumn = ({
   children,
   hideOn,
   as = "div",
-  spanEntireRow = false,
+  spanEntireRow,
   dataTest,
 }: Props): React.Node => {
   return (

--- a/packages/orbit-components/src/Layout/LayoutColumn/index.jsx.flow
+++ b/packages/orbit-components/src/Layout/LayoutColumn/index.jsx.flow
@@ -9,6 +9,7 @@ export type Props = {|
   +children: React.Node,
   +as?: string,
   +hideOn?: Devices[],
+  +spanEntireRow?: boolean,
 |};
 
 declare export default React.ComponentType<Props>;

--- a/packages/orbit-components/src/Layout/consts.js
+++ b/packages/orbit-components/src/Layout/consts.js
@@ -9,6 +9,7 @@ export const LAYOUT_SETTINGS: {|
   Booking: {|
     columnGap: string,
     columns: string,
+    rowGap: string,
     desktop: {| columnGap: string |},
     layoutColumns: { ... },
     maxWidth: string,
@@ -63,6 +64,7 @@ export const LAYOUT_SETTINGS: {|
   [LAYOUT_OPTIONS.BOOKING]: {
     columns: "1fr",
     columnGap: "16px",
+    rowGap: "16px",
     maxWidth: "1200px",
     tablet: {
       columns: "7fr minmax(272px, 3fr)",
@@ -73,10 +75,14 @@ export const LAYOUT_SETTINGS: {|
     layoutColumns: {
       // $FlowIssue
       0: {
-        as: "main",
+        spanEntireRow: true,
       },
       // $FlowIssue
       1: {
+        as: "main",
+      },
+      // $FlowIssue
+      2: {
         as: "aside",
       },
     },


### PR DESCRIPTION
- [Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1641897079019700)

I also extracted the recommended alternative to Layout for booking:

```jsx
import React from "react";
import mq from "@kiwicom/orbit-components/lib/utils/mediaQuery";
import styled, { css } from "styled-components";

const StyledGrid = styled.div`
  ${({ theme }) => css`
    box-sizing: content-box;
    display: grid;
    grid-template-areas:
      "breadcrumbs"
      "main"
      "sidebar";
    max-width: 1140px;
    margin: 0 auto;
    padding: 0 ${theme.orbit.spaceMedium};
    row-gap: ${theme.orbit.spaceMedium};
    ${mq.tablet(css`
      grid-template-areas:
        "breadcrumbs breadcrumbs"
        "main sidebar";
      grid-template-columns: 7fr minmax(272px, 3fr);
      column-gap: ${theme.orbit.spaceMedium};
    `)};
    ${mq.desktop(css`
      padding: 0 ${theme.orbit.spaceLarge};
      column-gap: ${theme.orbit.spaceLarge};
    `)};
    ${mq.largeDesktop(css`
      column-gap: ${theme.orbit.spaceXXLarge};
    `)}:
  `};
`;
const StyledArea = styled.div`
  ${({ name }) => `
    grid-area: ${name};
  `}
`;

function App() {
  return (
    <StyledGrid>
      <StyledArea name="breadcrumbs">
        {/* breadcrumbs */}
      </StyledArea>
      <StyledArea name="main" as="main">
        {/* main */}
      </StyledArea>
      <StyledArea name="sidebar" as="aside">
        {/* sidebar */}
      </StyledArea>
    </StyledGrid>
  );
}
```

 Storybook: https://orbit-silvenon-feat-layout-booking-breacrumbs.surge.sh