### PR TITLE
error forms small changes

### DIFF
--- a/packages/orbit-components/src/ErrorFormTooltip/Tooltip/index.jsx
+++ b/packages/orbit-components/src/ErrorFormTooltip/Tooltip/index.jsx
@@ -158,6 +158,7 @@ StyledCloseButton.defaultProps = {
 const ErrorFormTooltip = ({
   onShown,
   dataTest,
+  helpClosable,
   inputSize,
   children,
   shown,
@@ -210,7 +211,7 @@ const ErrorFormTooltip = ({
   const { popper, arrow } = styles;
 
   useClickOutside(contentRef, () => {
-    if (!isHelp) onShown(false);
+    if (!isHelp || !helpClosable) onShown(false);
   });
 
   React.useEffect(() => {
@@ -234,7 +235,7 @@ const ErrorFormTooltip = ({
     return () => {
       window.removeEventListener("keydown", handleTab);
     };
-  }, [onShown, isHelp]);
+  }, [onShown, isHelp, helpClosable]);
 
   return (
     <StyledFormFeedbackTooltip
@@ -265,7 +266,7 @@ const ErrorFormTooltip = ({
         bottom={arrow.bottom}
       />
       <StyledTooltipContent ref={contentRef}>{children}</StyledTooltipContent>
-      {isHelp && (
+      {isHelp && helpClosable && (
         <StyledCloseButton
           tabIndex={0}
           // $FlowFixMe: TODO

--- a/packages/orbit-components/src/ErrorFormTooltip/Tooltip/index.jsx
+++ b/packages/orbit-components/src/ErrorFormTooltip/Tooltip/index.jsx
@@ -53,7 +53,6 @@ const StyledFormFeedbackTooltip = styled.div`
   }) => css`
     display: flex;
     justify-content: space-between;
-    align-items: center;
     box-sizing: border-box;
     border-radius: ${theme.orbit.borderRadiusNormal};
     box-shadow: ${theme.orbit.boxShadowElevatedLevel1};

--- a/packages/orbit-components/src/ErrorFormTooltip/Tooltip/index.jsx.flow
+++ b/packages/orbit-components/src/ErrorFormTooltip/Tooltip/index.jsx.flow
@@ -7,6 +7,7 @@ export type Props = {|
   +id?: string,
   +children: React.Node,
   +shown?: boolean,
+  +helpClosable: boolean,
   +isHelp?: boolean,
   +referenceElement?: {| current: HTMLElement | null |},
   +inputSize?: "small" | "normal",

--- a/packages/orbit-components/src/ErrorFormTooltip/index.d.ts
+++ b/packages/orbit-components/src/ErrorFormTooltip/index.d.ts
@@ -12,6 +12,7 @@ export interface Props extends Common.Global, Common.SpaceAfter {
   readonly inlineLabel?: boolean;
   readonly referenceElement: HTMLElement | null;
   readonly inputSize?: "small" | "normal";
+  readonly helpClosable?: boolean;
   readonly onShown?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 

--- a/packages/orbit-components/src/ErrorFormTooltip/index.jsx
+++ b/packages/orbit-components/src/ErrorFormTooltip/index.jsx
@@ -5,16 +5,34 @@ import Tooltip from "./Tooltip";
 
 import type { Props } from ".";
 
-const ErrorFormTooltip = ({ shown, onShown, error, help, ...props }: Props): React.Node => {
+const ErrorFormTooltip = ({
+  shown,
+  onShown,
+  error,
+  help,
+  helpClosable = true,
+  ...props
+}: Props): React.Node => {
   return (
     <>
       {shown && help && !error && (
-        <Tooltip isHelp shown={shown} onShown={() => onShown(prev => !prev)} {...props}>
+        <Tooltip
+          isHelp
+          shown={shown}
+          helpClosable={helpClosable}
+          onShown={() => onShown(prev => !prev)}
+          {...props}
+        >
           {help}
         </Tooltip>
       )}
       {shown && error && (
-        <Tooltip shown={shown} onShown={value => onShown(value)} {...props}>
+        <Tooltip
+          shown={shown}
+          helpClosable={helpClosable}
+          onShown={value => onShown(value)}
+          {...props}
+        >
           {error}
         </Tooltip>
       )}

--- a/packages/orbit-components/src/ErrorFormTooltip/index.jsx.flow
+++ b/packages/orbit-components/src/ErrorFormTooltip/index.jsx.flow
@@ -7,6 +7,7 @@ export type Props = {|
   +id?: string,
   +shown: boolean,
   +error?: React.Node,
+  +helpClosable?: boolean,
   +help?: React.Node,
   +referenceElement?: {| current: HTMLElement | null |},
   +inlineLabel?: boolean,

--- a/packages/orbit-components/src/ErrorForms.stories.jsx
+++ b/packages/orbit-components/src/ErrorForms.stories.jsx
@@ -160,6 +160,7 @@ export const Help = (): React.Node => {
   const prefix = text("Prefix", "$");
   const size = select("Size", Object.values(SIZE_OPTIONS), SIZE_OPTIONS.NORMAL);
   const required = boolean("required", true);
+  const helpClosable = boolean("helpClosable", true);
 
   return (
     <Stack>
@@ -167,6 +168,7 @@ export const Help = (): React.Node => {
         size={size}
         help={<TextLink>{help}</TextLink>}
         label={label}
+        helpClosable={helpClosable}
         value={value}
         placeholder={placeholder}
         onChange={action("change")}
@@ -175,6 +177,7 @@ export const Help = (): React.Node => {
         size={size}
         help={help}
         value={value}
+        helpClosable={helpClosable}
         placeholder={placeholder}
         onChange={action("change")}
       />
@@ -183,6 +186,7 @@ export const Help = (): React.Node => {
         help={help}
         inlineLabel
         label={label}
+        helpClosable={helpClosable}
         value={value}
         placeholder={placeholder}
         onChange={action("change")}
@@ -192,6 +196,7 @@ export const Help = (): React.Node => {
         help={help}
         inlineLabel
         prefix={prefix}
+        helpClosable={helpClosable}
         label={label}
         value={value}
         placeholder={placeholder}
@@ -200,6 +205,7 @@ export const Help = (): React.Node => {
       <InputField
         label={label}
         inlineLabel
+        helpClosable={helpClosable}
         readOnly
         tags={
           <div>
@@ -224,28 +230,54 @@ export const Help = (): React.Node => {
         label={label}
         readOnly
         value={value}
+        helpClosable={helpClosable}
         placeholder={placeholder}
         required={required}
         help={help}
       />
-      <Textarea readOnly label={label} placeholder={placeholder} help={help} value={value} />
-      <Textarea placeholder={placeholder} help={help} value={value} readOnly />
+      <Textarea
+        helpClosable={helpClosable}
+        readOnly
+        label={label}
+        placeholder={placeholder}
+        help={help}
+        value={value}
+      />
+      <Textarea
+        helpClosable={helpClosable}
+        placeholder={placeholder}
+        help={help}
+        value={value}
+        readOnly
+      />
       <Select
         label={label}
         options={objectOptions}
         value={1}
+        helpClosable={helpClosable}
         help={help}
         onChange={action("onChange")}
       />
-      <Select options={objectOptions} help={help} value={1} onChange={action("onChange")} />
-      <InputFile label={label} help={help} onRemoveFile={action("removeFile")} />
-      <InputFile help={help} onRemoveFile={action("removeFile")} />
-      <InputGroup label={label}>
+      <Select
+        helpClosable={helpClosable}
+        options={objectOptions}
+        help={help}
+        value={1}
+        onChange={action("onChange")}
+      />
+      <InputFile
+        helpClosable={helpClosable}
+        label={label}
+        help={help}
+        onRemoveFile={action("removeFile")}
+      />
+      <InputFile helpClosable={helpClosable} help={help} onRemoveFile={action("removeFile")} />
+      <InputGroup helpClosable={helpClosable} label={label}>
         <InputField help={help} placeholder="DD" readOnly />
         <Select options={objectOptions} value={1} placeholder="Month" />
         <InputField placeholder="YYYY" readOnly />
       </InputGroup>
-      <InputGroup>
+      <InputGroup helpClosable={helpClosable}>
         <InputField help={help} placeholder="DD" readOnly />
         <Select options={objectOptions} value={1} placeholder="Month" />
         <InputField placeholder="YYYY" readOnly />
@@ -422,7 +454,7 @@ export const withModal = (): React.Node => {
   );
 };
 
-export const AdvancedExample = (): React.Node => {
+export const AdvancedErrorExample = (): React.Node => {
   const defaultValues = {
     name: "",
     surname: "",
@@ -601,6 +633,154 @@ export const AdvancedExample = (): React.Node => {
               placeholder="YYYY"
             />
           </InputGroup>
+        </Stack>
+        <Button type="primary" submit>
+          Continue
+        </Button>
+      </form>
+    </>
+  );
+};
+
+export const AdvancedHelpExample = (): React.Node => {
+  const defaultValues = {
+    name: "",
+    iban: "",
+    swift: "",
+    bank: "",
+  };
+
+  const helpMessages = {
+    name:
+      "Use the full name of the account holder. It’s either you or the person receiving the funds",
+    iban: "Use the international format of your account number, e.g. IBAN if you're from the EU",
+    swift: "This is the code of your bank. You can search for it online or check with your bank",
+    bank:
+      "If your bank doesn’t accept international transfers, we’ll need the code of their correspondent bank. Otherwise, you can leave this blank.",
+  };
+
+  const [values, setValues] = React.useState(defaultValues);
+  const [messages, setMessages] = React.useState(defaultValues);
+  const [errors, setErrors] = React.useState(defaultValues);
+  const [focused, setFocused] = React.useState({});
+
+  const validate = (value: string) => {
+    return !value || value.length <= 2 ? "This field is required" : "";
+  };
+
+  const handleChange = ev => {
+    const { name, value } = ev.target;
+    const error = validate(value);
+
+    setValues(prev => ({
+      ...prev,
+      [name]: value,
+    }));
+
+    setErrors(prev => ({
+      ...prev,
+      [name]: focused[name] && error,
+    }));
+
+    setFocused(prev => ({
+      ...prev,
+      [name]: true,
+    }));
+
+    setMessages(prev => ({
+      ...prev,
+      [name]: helpMessages[name],
+    }));
+  };
+
+  const handleSubmit = ev => {
+    ev.preventDefault();
+
+    const formValidation = Object.entries(values).reduce(
+      (acc, [key, value]) => {
+        // $FlowFixMe: mixed
+        const newError = validate(value);
+        const newFocused = { [key]: true };
+
+        return {
+          errors: {
+            ...acc.errors,
+            [key]: newError,
+          },
+          focused: {
+            ...acc.focused,
+            ...newFocused,
+          },
+        };
+      },
+      {
+        errors: { ...errors },
+        focused: { ...focused },
+      },
+    );
+
+    setErrors(formValidation.errors);
+    setFocused(formValidation.focused);
+  };
+
+  const handleBlur = evt => {
+    const { name, value } = evt.target;
+    const error = validate(value);
+
+    setErrors(prev => ({
+      ...prev,
+      [name]: focused[name] && error,
+    }));
+  };
+
+  return (
+    <>
+      <form
+        onSubmit={handleSubmit}
+        css={css`
+          max-width: 600px;
+          padding: 20px 0;
+        `}
+      >
+        <Stack flex direction="column" spaceAfter="large">
+          <InputField
+            name="name"
+            value={values.name}
+            help={messages.name}
+            error={errors.name}
+            onBlur={handleBlur}
+            onChange={handleChange}
+            label="Account holder name"
+            placeholder="e.g. Harry James"
+          />
+          <InputField
+            name="iban"
+            value={values.iban}
+            error={errors.iban}
+            help={messages.iban}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            label="IBAN/account number"
+          />
+          <InputField
+            name="swift"
+            value={values.swift}
+            error={errors.swift}
+            help={messages.swift}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            label="SWIFT/BIC code"
+          />
+          <InputField
+            name="bank"
+            value={values.bank}
+            error={errors.bank}
+            help={messages.bank}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            label="Correspondent bank SWIFT/BIC code"
+            placeholder="This field is optional"
+          />
         </Stack>
         <Button type="primary" submit>
           Continue

--- a/packages/orbit-components/src/FormLabel/index.jsx
+++ b/packages/orbit-components/src/FormLabel/index.jsx
@@ -58,7 +58,7 @@ const FormLabel: any = styled(
           onMouseLeave={onMouseLeave}
         >
           {error && <AlertCircle ariaLabel="error" color="critical" size="small" />}
-          {!error && help && <InformationCircle ariaLabel="help" color="secondary" size="small" />}
+          {!error && help && <InformationCircle ariaLabel="help" color="info" size="small" />}
         </StyledInputErrorIcWrapper>
       )}
 

--- a/packages/orbit-components/src/InputField/README.md
+++ b/packages/orbit-components/src/InputField/README.md
@@ -55,7 +55,7 @@ Table below contains all types of the props available in InputField component.
 | tabIndex     | `string \| number`          |            | Specifies the tab order of an element                                                                                                                                            |
 | **type**     | [`enum`](#enum)             | `"text"`   | The type of the InputField.                                                                                                                                                      |
 | value        | `string`                    |            | Specifies the value of the InputField.                                                                                                                                           |
-| helpClosable | `boolean`                   | `true`     | Responsible for hiding tooltip with help message by clicking on close button or automatically onBlur                                                                             |
+| helpClosable | `boolean`                   | `true`     | Whether to display help as a closable tooltip, or have it open only while the field is focused, same as error.                                                                   |
 
 ### enum
 

--- a/packages/orbit-components/src/InputField/README.md
+++ b/packages/orbit-components/src/InputField/README.md
@@ -55,6 +55,7 @@ Table below contains all types of the props available in InputField component.
 | tabIndex     | `string \| number`          |            | Specifies the tab order of an element                                                                                                                                            |
 | **type**     | [`enum`](#enum)             | `"text"`   | The type of the InputField.                                                                                                                                                      |
 | value        | `string`                    |            | Specifies the value of the InputField.                                                                                                                                           |
+| helpClosable | `boolean`                   | `true`     | Responsible for hiding tooltip with help message by clicking on close button or automatically onBlur                                                                             |
 
 ### enum
 

--- a/packages/orbit-components/src/InputField/index.d.ts
+++ b/packages/orbit-components/src/InputField/index.d.ts
@@ -38,6 +38,7 @@ export interface Props extends Common.Global, Common.Ref, Common.SpaceAfter, Com
   readonly autoFocus?: boolean;
   readonly id?: string;
   readonly insideInputGroup?: boolean;
+  readonly helpClosable?: boolean;
   readonly onChange?: InputEvent;
   readonly onFocus?: InputEvent;
   readonly onBlur?: InputEvent;

--- a/packages/orbit-components/src/InputField/index.jsx
+++ b/packages/orbit-components/src/InputField/index.jsx
@@ -364,6 +364,7 @@ const InputField: InputFieldType = React.forwardRef((props, ref) => {
     maxLength,
     suffix,
     help,
+    helpClosable = true,
     value,
     tags,
     tabIndex,
@@ -505,6 +506,7 @@ const InputField: InputFieldType = React.forwardRef((props, ref) => {
             help={help}
             id={inputId}
             shown={shown}
+            helpClosable={helpClosable}
             onShown={setTooltipShown}
             error={error}
             inputSize={size}

--- a/packages/orbit-components/src/InputField/index.jsx
+++ b/packages/orbit-components/src/InputField/index.jsx
@@ -429,7 +429,7 @@ const InputField: InputFieldType = React.forwardRef((props, ref) => {
             <Prefix size={size}>
               {help && !error && (
                 <StyledIconWrapper ref={iconRef}>
-                  <InformationCircle color="secondary" size="small" />
+                  <InformationCircle color="info" size="small" />
                 </StyledIconWrapper>
               )}
               {error && (

--- a/packages/orbit-components/src/InputField/index.jsx.flow
+++ b/packages/orbit-components/src/InputField/index.jsx.flow
@@ -40,6 +40,7 @@ export type Props = {|
   +readOnly?: boolean,
   +autoComplete?: string,
   +autoFocus?: boolean,
+  +helpClosable?: boolean,
   +id?: string,
   +insideInputGroup?: boolean,
   +onChange?: (ev: SyntheticInputEvent<HTMLInputElement>) => void | Promise<any>,

--- a/packages/orbit-components/src/InputFile/README.md
+++ b/packages/orbit-components/src/InputFile/README.md
@@ -36,7 +36,7 @@ Table below contains all types of the props available in the InputFile component
 | spaceAfter       | `enum`                     |                      | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
 | tabIndex         | `string \| number`         |                      | Specifies the tab order of an element                                                                                                                          |
 | width            | `string`                   | `100%`               | Specifies width of InputFile                                                                                                                                   |
-| helpClosable     | `boolean`                  | `true`               | Responsible for hiding tooltip with help message by clicking on close button or automatically onBlur                                                           |
+| helpClosable     | `boolean`                  | `true`               | Whether to display help as a closable tooltip, or have it open only while the field is focused, same as error.                                                 |
 
 ## Functional specs
 

--- a/packages/orbit-components/src/InputFile/README.md
+++ b/packages/orbit-components/src/InputFile/README.md
@@ -36,6 +36,7 @@ Table below contains all types of the props available in the InputFile component
 | spaceAfter       | `enum`                     |                      | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
 | tabIndex         | `string \| number`         |                      | Specifies the tab order of an element                                                                                                                          |
 | width            | `string`                   | `100%`               | Specifies width of InputFile                                                                                                                                   |
+| helpClosable     | `boolean`                  | `true`               | Responsible for hiding tooltip with help message by clicking on close button or automatically onBlur                                                           |
 
 ## Functional specs
 

--- a/packages/orbit-components/src/InputFile/index.d.ts
+++ b/packages/orbit-components/src/InputFile/index.d.ts
@@ -19,6 +19,7 @@ export interface Props extends Common.Global, Common.SpaceAfter, Common.Ref {
   readonly error?: React.ReactNode;
   readonly width?: string;
   readonly required?: boolean;
+  readonly helpClosable?: boolean;
   readonly tabIndex?: string | number;
   readonly onChange?: Event;
   readonly onFocus?: Event;

--- a/packages/orbit-components/src/InputFile/index.jsx
+++ b/packages/orbit-components/src/InputFile/index.jsx
@@ -117,6 +117,7 @@ const InputFile: React.AbstractComponent<Props, HTMLDivElement> = React.forwardR
     required,
     onRemoveFile,
     dataTest,
+    helpClosable = true,
     spaceAfter,
     width = "100%",
     help,
@@ -207,6 +208,7 @@ const InputFile: React.AbstractComponent<Props, HTMLDivElement> = React.forwardR
         <ErrorFormTooltip
           help={help}
           error={error}
+          helpClosable={helpClosable}
           inputSize="normal"
           referenceElement={label ? iconRef : labelRef}
           shown={shown}

--- a/packages/orbit-components/src/InputFile/index.jsx.flow
+++ b/packages/orbit-components/src/InputFile/index.jsx.flow
@@ -16,6 +16,7 @@ export type Props = {|
   +placeholder?: TranslationString,
   +fileName?: string,
   +required?: boolean,
+  +helpClosable?: boolean,
   +allowedFileTypes?: string | string[],
   +insideInputGroup?: boolean,
   +help?: React.Node,

--- a/packages/orbit-components/src/InputGroup/README.md
+++ b/packages/orbit-components/src/InputGroup/README.md
@@ -35,6 +35,7 @@ Table below contains all types of the props available in InputGroup component.
 | onBlurGroup  | `event => void \| Promise`  |              | Function for handling onBlur event for the whole InputGroup. [See Functional specs](#functional-specs)                                                         |
 | size         | [`enum`](#enum)             | `"normal"`   | The size of the InputField. [See Functional specs](#functional-specs)                                                                                          |
 | spaceAfter   | `enum`                      |              | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
+| helpClosable | `boolean`                   | `true`       | Responsible for hiding tooltip with help message by clicking on close button or automatically onBlur                                                           |
 
 ### enum
 

--- a/packages/orbit-components/src/InputGroup/README.md
+++ b/packages/orbit-components/src/InputGroup/README.md
@@ -35,7 +35,7 @@ Table below contains all types of the props available in InputGroup component.
 | onBlurGroup  | `event => void \| Promise`  |              | Function for handling onBlur event for the whole InputGroup. [See Functional specs](#functional-specs)                                                         |
 | size         | [`enum`](#enum)             | `"normal"`   | The size of the InputField. [See Functional specs](#functional-specs)                                                                                          |
 | spaceAfter   | `enum`                      |              | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
-| helpClosable | `boolean`                   | `true`       | Responsible for hiding tooltip with help message by clicking on close button or automatically onBlur                                                           |
+| helpClosable | `boolean`                   | `true`       | Whether to display help as a closable tooltip, or have it open only while the field is focused, same as error.                                                 |
 
 ### enum
 

--- a/packages/orbit-components/src/InputGroup/index.d.ts
+++ b/packages/orbit-components/src/InputGroup/index.d.ts
@@ -14,6 +14,7 @@ interface Props extends Common.Global, Common.SpaceAfter {
   readonly size?: Size;
   readonly help?: React.ReactNode;
   readonly children: React.ReactNode;
+  readonly helpClosable?: boolean;
   readonly onBlurGroup?: Event;
   readonly error?: React.ReactNode;
   readonly disabled?: boolean;

--- a/packages/orbit-components/src/InputGroup/index.jsx
+++ b/packages/orbit-components/src/InputGroup/index.jsx
@@ -188,6 +188,7 @@ const InputGroup = ({
   disabled,
   dataTest,
   spaceAfter,
+  helpClosable = true,
   onFocus,
   onBlur,
   onChange,
@@ -302,6 +303,7 @@ const InputGroup = ({
       <ErrorFormTooltip
         help={helpReal}
         error={errorReal}
+        helpClosable={helpClosable}
         inputSize={size}
         onShown={setTooltipShown}
         shown={tooltipShown || tooltipShownHover}

--- a/packages/orbit-components/src/InputGroup/index.jsx.flow
+++ b/packages/orbit-components/src/InputGroup/index.jsx.flow
@@ -15,6 +15,7 @@ export type Props = {|
   +size?: "small" | "normal",
   +help?: React.Node,
   +children: React.Node,
+  +helpClosable?: boolean,
   +error?: React.Node,
   +disabled?: boolean,
   +onBlurGroup?: (

--- a/packages/orbit-components/src/Select/README.md
+++ b/packages/orbit-components/src/Select/README.md
@@ -41,7 +41,7 @@ Table below contains all types of the props available in the Select component.
 | tabIndex        | `string \| number`         |            | Specifies the tab order of an element                                                                                                                          |
 | value           | `string`                   | `""`       | The value of the Select.                                                                                                                                       |
 | width           | `string`                   | `100%`     | Specifies width of the Select                                                                                                                                  |
-| helpClosable    | `boolean`                  | `true`     | Responsible for hiding tooltip with help message by clicking on close button or automatically onBlur                                                           |
+| helpClosable    | `boolean`                  | `true`     | Whether to display help as a closable tooltip, or have it open only while the field is focused, same as error.                                                 |
 
 ## Option
 

--- a/packages/orbit-components/src/Select/README.md
+++ b/packages/orbit-components/src/Select/README.md
@@ -41,6 +41,7 @@ Table below contains all types of the props available in the Select component.
 | tabIndex        | `string \| number`         |            | Specifies the tab order of an element                                                                                                                          |
 | value           | `string`                   | `""`       | The value of the Select.                                                                                                                                       |
 | width           | `string`                   | `100%`     | Specifies width of the Select                                                                                                                                  |
+| helpClosable    | `boolean`                  | `true`     | Responsible for hiding tooltip with help message by clicking on close button or automatically onBlur                                                           |
 
 ## Option
 

--- a/packages/orbit-components/src/Select/index.d.ts
+++ b/packages/orbit-components/src/Select/index.d.ts
@@ -32,6 +32,7 @@ export interface Props extends Common.Global, Common.Ref, Common.SpaceAfter, Com
   readonly onBlur?: Event;
   readonly options: Option[];
   readonly prefix?: React.ReactNode;
+  readonly helpClosable?: boolean;
   readonly readOnly?: boolean;
   readonly insideInputGroup?: boolean;
   readonly customValueText?: Common.Translation;

--- a/packages/orbit-components/src/Select/index.jsx
+++ b/packages/orbit-components/src/Select/index.jsx
@@ -290,6 +290,7 @@ const Select: React.AbstractComponent<
     tabIndex,
     id,
     required,
+    helpClosable = true,
     dataTest,
     prefix,
     spaceAfter,
@@ -386,6 +387,7 @@ const Select: React.AbstractComponent<
           help={help}
           error={error}
           inputSize={size}
+          helpClosable={helpClosable}
           shown={shown}
           onShown={setTooltipShown}
           referenceElement={inputRef}

--- a/packages/orbit-components/src/Select/index.jsx.flow
+++ b/packages/orbit-components/src/Select/index.jsx.flow
@@ -33,6 +33,7 @@ export type Props = {|
   +width?: string,
   +help?: React.Node,
   +insideInputGroup?: boolean,
+  +helpClosable?: boolean,
   +tabIndex?: string | number,
   +onChange?: (ev: SyntheticInputEvent<HTMLSelectElement>) => void | Promise<any>,
   +onFocus?: (ev: SyntheticInputEvent<HTMLSelectElement>) => void | Promise<any>,

--- a/packages/orbit-components/src/Textarea/README.md
+++ b/packages/orbit-components/src/Textarea/README.md
@@ -39,7 +39,7 @@ Table below contains all types of the props available in Textarea component.
 | spaceAfter   | `enum`                     |              | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
 | tabIndex     | `string \| number`         |              | Specifies the tab order of an element                                                                                                                          |
 | value        | `string`                   |              | Specifies the value of the Textarea.                                                                                                                           |
-| helpClosable | `boolean`                  | `true`       | Responsible for hiding tooltip with help message by clicking on close button or automatically onBlur                                                           |
+| helpClosable | `boolean`                  | `true`       | Whether to display help as a closable tooltip, or have it open only while the field is focused, same as error.                                                 |
 
 ### enum
 

--- a/packages/orbit-components/src/Textarea/README.md
+++ b/packages/orbit-components/src/Textarea/README.md
@@ -16,29 +16,30 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in Textarea component.
 
-| Name        | Type                       | Default      | Description                                                                                                                                                    |
-| :---------- | :------------------------- | :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| dataTest    | `string`                   |              | Optional prop for testing purposes.                                                                                                                            |
-| disabled    | `boolean`                  |              | If `true`, the Textarea will be disabled.                                                                                                                      |
-| error       | `React.Node`               |              | The error to display beneath the Textarea. [See Functional specs](#functional-specs)                                                                           |
-| fullHeight  | `boolean`                  | `false`      | If `true`, the Textarea will take 100 % of parent's height.                                                                                                    |
-| help        | `React.Node`               |              | The help to display beneath the Textarea.                                                                                                                      |
-| label       | `Translation`              |              | The label for the Textarea. [See Functional specs](#functional-specs)                                                                                          |
-| maxLength   | `number`                   |              | Specifies the maximum number of characters allowed.                                                                                                            |
-| name        | `string`                   |              | The name for the Textarea.                                                                                                                                     |
-| onChange    | `event => void \| Promise` |              | Function for handling onClick event.                                                                                                                           |
-| onFocus     | `event => void \| Promise` |              | Function for handling onFocus event.                                                                                                                           |
-| onBlur      | `event => void \| Promise` |              | Function for handling onBlur event.                                                                                                                            |
-| placeholder | `TranslationString`        |              | The placeholder of the Textarea.                                                                                                                               |
-| ref         | `func`                     |              | Prop for forwarded ref of the Textarea. [See Functional specs](#functional-specs)                                                                              |
-| resize      | [`enum`](#enum)            | `"vertical"` | The resize option for Textarea.                                                                                                                                |
-| rows        | `number`                   |              | Specifies the height of the text area (in lines).                                                                                                              |
-| readOnly    | `boolean`                  |              | Adds readOnly to html textarea element.                                                                                                                        |
-| required    | `boolean`                  |              | Optional prop, adds `required` to html element.                                                                                                                |
-| size        | [`enum`](#enum)            | `"normal"`   | The size of the Textarea.                                                                                                                                      |
-| spaceAfter  | `enum`                     |              | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
-| tabIndex    | `string \| number`         |              | Specifies the tab order of an element                                                                                                                          |
-| value       | `string`                   |              | Specifies the value of the Textarea.                                                                                                                           |
+| Name         | Type                       | Default      | Description                                                                                                                                                    |
+| :----------- | :------------------------- | :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dataTest     | `string`                   |              | Optional prop for testing purposes.                                                                                                                            |
+| disabled     | `boolean`                  |              | If `true`, the Textarea will be disabled.                                                                                                                      |
+| error        | `React.Node`               |              | The error to display beneath the Textarea. [See Functional specs](#functional-specs)                                                                           |
+| fullHeight   | `boolean`                  | `false`      | If `true`, the Textarea will take 100 % of parent's height.                                                                                                    |
+| help         | `React.Node`               |              | The help to display beneath the Textarea.                                                                                                                      |
+| label        | `Translation`              |              | The label for the Textarea. [See Functional specs](#functional-specs)                                                                                          |
+| maxLength    | `number`                   |              | Specifies the maximum number of characters allowed.                                                                                                            |
+| name         | `string`                   |              | The name for the Textarea.                                                                                                                                     |
+| onChange     | `event => void \| Promise` |              | Function for handling onClick event.                                                                                                                           |
+| onFocus      | `event => void \| Promise` |              | Function for handling onFocus event.                                                                                                                           |
+| onBlur       | `event => void \| Promise` |              | Function for handling onBlur event.                                                                                                                            |
+| placeholder  | `TranslationString`        |              | The placeholder of the Textarea.                                                                                                                               |
+| ref          | `func`                     |              | Prop for forwarded ref of the Textarea. [See Functional specs](#functional-specs)                                                                              |
+| resize       | [`enum`](#enum)            | `"vertical"` | The resize option for Textarea.                                                                                                                                |
+| rows         | `number`                   |              | Specifies the height of the text area (in lines).                                                                                                              |
+| readOnly     | `boolean`                  |              | Adds readOnly to html textarea element.                                                                                                                        |
+| required     | `boolean`                  |              | Optional prop, adds `required` to html element.                                                                                                                |
+| size         | [`enum`](#enum)            | `"normal"`   | The size of the Textarea.                                                                                                                                      |
+| spaceAfter   | `enum`                     |              | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
+| tabIndex     | `string \| number`         |              | Specifies the tab order of an element                                                                                                                          |
+| value        | `string`                   |              | Specifies the value of the Textarea.                                                                                                                           |
+| helpClosable | `boolean`                  | `true`       | Responsible for hiding tooltip with help message by clicking on close button or automatically onBlur                                                           |
 
 ### enum
 

--- a/packages/orbit-components/src/Textarea/index.d.ts
+++ b/packages/orbit-components/src/Textarea/index.d.ts
@@ -23,6 +23,7 @@ interface Props extends Common.Global, Common.Ref, Common.SpaceAfter {
   readonly error?: React.ReactNode;
   readonly resize?: Resize;
   readonly disabled?: boolean;
+  readonly helpClosable?: boolean;
   readonly maxLength?: number;
   readonly tabIndex?: string | number;
   readonly onChange?: Event;

--- a/packages/orbit-components/src/Textarea/index.jsx
+++ b/packages/orbit-components/src/Textarea/index.jsx
@@ -135,6 +135,7 @@ const Textarea: React.AbstractComponent<Props, HTMLElement> = React.forwardRef<
     name,
     error,
     placeholder,
+    helpClosable = true,
     maxLength,
     onChange,
     onFocus,
@@ -196,6 +197,7 @@ const Textarea: React.AbstractComponent<Props, HTMLElement> = React.forwardRef<
       <ErrorFormTooltip
         help={help}
         inputSize={size}
+        helpClosable={helpClosable}
         error={error}
         onShown={setTooltipShown}
         shown={shown}

--- a/packages/orbit-components/src/Textarea/index.jsx.flow
+++ b/packages/orbit-components/src/Textarea/index.jsx.flow
@@ -14,6 +14,7 @@ export type Props = {|
   +name?: string,
   +rows?: number,
   +readOnly?: boolean,
+  +helpClosable?: boolean,
   +required?: boolean,
   +label?: Translation,
   +value?: string,


### PR DESCRIPTION
- added new prop for error forms, if someone would like to disable closable help

small visual changes:
- label icons for help changed colors from secondary to info.
- close icon moved on top
 Storybook: https://orbit-silvenon-fix-error-forms.surge.sh