### PR TITLE
UI fixes for Collapse, SocialButton, Popover and Separator

### DIFF
--- a/docs/src/__examples__/Separator/DEFAULT.tsx
+++ b/docs/src/__examples__/Separator/DEFAULT.tsx
@@ -40,6 +40,18 @@ export default {
           defaultValue: "none",
           options: ["none", "smallest", "small", "normal", "medium", "large", "largest"],
         },
+        {
+          name: "indent",
+          type: "select",
+          defaultValue: "none",
+          options: ["none", "small", "medium", "large", "XLarge", "XXLarge"],
+        },
+        {
+          name: "align",
+          type: "select",
+          defaultValue: "right",
+          options: ["left", "right", "center"],
+        },
       ],
     },
   ],

--- a/packages/orbit-components/src/Card/components/CardWrapper/index.jsx
+++ b/packages/orbit-components/src/Card/components/CardWrapper/index.jsx
@@ -41,54 +41,67 @@ bottomBorderRadius.defaultProps = {
 };
 
 const StyledCardWrapper = styled.div`
-  padding: ${({ theme, noPadding }) => !noPadding && theme.orbit.spaceMedium};
-  cursor: ${({ onClick }) => onClick && `pointer`};
-  ${CardElement};
-  ${({ bottomBorder }) => bottomBorder && bottomBorderRadius};
-  border-bottom: ${({ roundedBottom, bottomBorder }) =>
-    (roundedBottom || bottomBorder) && getBorder};
-  transition: ${transition(["margin"], "fast", "ease-in-out")};
-  ${({ noBorderTop, expandable }) =>
-    noBorderTop && !expandable && `border-top: 1px solid transparent; padding-top: 0 !important;`};
+  ${({
+    theme,
+    expandable,
+    expanded,
+    noPadding,
+    noBorderTop,
+    bottomBorder,
+    roundedTop,
+    roundedBottom,
+    onClick,
+  }) => css`
+    padding: ${!noPadding && theme.orbit.spaceMedium};
+    cursor: ${onClick && `pointer`};
+    ${CardElement};
+    ${bottomBorder && bottomBorderRadius};
+    border-bottom: ${(roundedBottom || bottomBorder) && getBorder};
+    transition: ${transition(["margin"], "fast", "ease-in-out")};
+    ${noBorderTop &&
+    !expandable &&
+    `
+      border-top: 1px solid transparent;
+      padding-top: 0 !important;
+    `};
 
-  ${({ expanded }) =>
-    expanded &&
-    css`
-      margin: ${({ theme }) => theme.orbit.spaceXSmall} 0;
+    ${expanded &&
+    `
+      margin: ${theme.orbit.spaceXSmall} 0;
       border: 1px solid transparent;
     `};
 
-  ${({ roundedTop }) => roundedTop && topBorderRadius};
-  ${({ roundedBottom }) => roundedBottom && bottomBorderRadius}
+    ${roundedTop && topBorderRadius};
+    ${roundedBottom && bottomBorderRadius}
 
-  &:last-of-type {
-    ${({ expanded }) =>
-      !expanded &&
+    &:last-of-type {
+      ${!expanded &&
       css`
         border-bottom: ${getBorder};
       `}
-  }
-
-  ${mq.largeMobile(css`
-    &:first-of-type {
-      ${topBorderRadius};
     }
 
-    &:last-of-type {
-      ${bottomBorderRadius};
+    ${mq.largeMobile(css`
+      &:first-of-type {
+        ${topBorderRadius};
+      }
+
+      &:last-of-type {
+        ${bottomBorderRadius};
+      }
+
+      padding: ${!noPadding && theme.orbit.spaceLarge};
+    `)}
+
+    &:focus {
+      outline: 0;
+      background: ${theme.orbit.paletteWhiteHover};
     }
 
-    padding: ${({ theme, noPadding }) => !noPadding && theme.orbit.spaceLarge};
-  `)}
-
-  &:focus {
-    outline: 0;
-    background: ${({ theme }) => theme.orbit.paletteWhiteHover};
-  }
-
-  &:hover {
-    background: ${({ theme, onClick }) => onClick && theme.orbit.paletteWhiteHover};
-  }
+    &:hover {
+      background: ${onClick && theme.orbit.paletteWhiteHover};
+    }
+  `};
 `;
 
 // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198

--- a/packages/orbit-components/src/Popover/components/ContentWrapper.jsx
+++ b/packages/orbit-components/src/Popover/components/ContentWrapper.jsx
@@ -35,7 +35,7 @@ const StyledContentWrapper = styled.div`
 
     ${mq.largeMobile(css`
       max-height: 100%;
-      border-radius: 3px;
+      border-radius: ${theme.orbit.borderRadiusNormal};
       bottom: auto;
       left: auto;
       position: relative;
@@ -66,6 +66,8 @@ const StyledActions = styled.div`
       position: relative;
       bottom: auto;
       left: auto;
+      border-bottom-left-radius: ${theme.orbit.borderRadiusNormal};
+      border-bottom-right-radius: 3px;
       ${StyledButtonPrimitive} {
         width: auto;
         flex-grow: 0;

--- a/packages/orbit-components/src/Separator/README.md
+++ b/packages/orbit-components/src/Separator/README.md
@@ -16,6 +16,19 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the Separator component.
 
-| Name       | Type   | Default | Description                                                                                                                                                    |
-| :--------- | :----- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| spaceAfter | `enum` |         | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
+| Name       | Type            | Default  | Description                                                                                                                                                    |
+| :--------- | :-------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| indent     | [`enum`](#enum) | `"none"` | Amount of padding expressed as [spacing tokens](https://orbit.kiwi/foundation/spacing/) in the direction depending on the `align` prop.                        |
+| align      | [`enum`](#enum) | `"left"` | The direction of indentation. If `"center"` then it's indented from both sides.                                                                                |
+| spaceAfter | `enum`          |          | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
+
+### enum
+
+| indent      | align      |
+| :---------- | :--------- |
+| `"none"`    | `"left"`   |
+| `"small"`   | `"right"`  |
+| `"medium"`  | `"center"` |
+| `"large"`   |            |
+| `"XLarge"`  |            |
+| `"XXLarge"` |            |

--- a/packages/orbit-components/src/Separator/Separator.stories.jsx
+++ b/packages/orbit-components/src/Separator/Separator.stories.jsx
@@ -3,8 +3,9 @@ import * as React from "react";
 import { select } from "@storybook/addon-knobs";
 
 import SPACINGS_AFTER from "../common/getSpacingToken/consts";
+import RenderInRtl from "../utils/rtl/RenderInRtl";
 
-import Separator from ".";
+import Separator, { type Indent } from ".";
 
 export default {
   title: "Separator",
@@ -25,12 +26,29 @@ export const Playground = (): React.Node => {
     [null, ...Object.values(SPACINGS_AFTER)],
     SPACINGS_AFTER.LARGEST,
   );
-  return <Separator spaceAfter={spaceAfter} />;
+  const align = select("align", ["left", "right", "center"], "left");
+  const indentOptions: Indent[] = ["none", "small", "medium", "large", "XLarge", "XXLarge"];
+  const indent = select("indent", indentOptions, "none");
+  return <Separator align={align} indent={indent} spaceAfter={spaceAfter} />;
 };
 
 Playground.story = {
   parameters: {
     info:
       "You can try all possible configurations of this component. However, check Orbit.Kiwi for more detailed design guidelines.",
+  },
+};
+
+export const Rtl = (): React.Node => (
+  <RenderInRtl>
+    <Playground />
+  </RenderInRtl>
+);
+
+Rtl.story = {
+  name: "RTL",
+
+  parameters: {
+    info: "This is a preview of this component in RTL setup.",
   },
 };

--- a/packages/orbit-components/src/Separator/index.d.ts
+++ b/packages/orbit-components/src/Separator/index.d.ts
@@ -5,7 +5,10 @@ import * as React from "react";
 
 import * as Common from "../common/common";
 
-type Props = Common.SpaceAfter;
+interface Props extends Common.SpaceAfter {
+  indent?: "none" | "small" | "medium" | "large" | "XLarge" | "XXLarge";
+  align?: "left" | "right" | "center";
+}
 
 declare const Separator: React.FunctionComponent<Props>;
 export { Separator, Separator as default };

--- a/packages/orbit-components/src/Separator/index.jsx
+++ b/packages/orbit-components/src/Separator/index.jsx
@@ -1,20 +1,57 @@
 // @flow
 import * as React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import defaultTheme from "../defaultTheme";
 import getSpacingToken from "../common/getSpacingToken";
+import { left, right } from "../utils/rtl";
 
-import type { Props } from ".";
+import type { Props, Indent } from ".";
+
+function capitalize(string: string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function getIndentAmount({
+  theme,
+  indent,
+}: // StyledContainer takes more props, so this shouldn't be exact
+// eslint-disable-next-line flowtype/require-exact-type
+{
+  theme: typeof defaultTheme,
+  indent: Indent,
+}) {
+  return indent === "none" ? 0 : theme.orbit[`space${capitalize(indent)}`];
+}
+
+const StyledContainer = styled.div`
+  ${({ align }) => css`
+    box-sizing: border-box;
+    width: 100%;
+    ${align === "left" &&
+    css`
+      padding-${right}: ${getIndentAmount};
+    `};
+    ${align === "right" &&
+    css`
+      padding-${left}: ${getIndentAmount};
+    `};
+    ${align === "center" &&
+    css`
+      padding: 0 ${getIndentAmount};
+    `};
+  `};
+`;
 
 const StyledSeparator = styled.hr`
-  width: 100%;
-  height: ${({ theme }) => theme.orbit.heightSeparator};
-  background: ${({ theme }) => theme.orbit.backgroundSeparator};
-  box-sizing: border-box;
-  border-style: none;
-  margin-top: 0;
-  margin-bottom: ${getSpacingToken};
+  ${({ theme }) => css`
+    height: ${theme.orbit.heightSeparator};
+    background: ${theme.orbit.backgroundSeparator};
+    box-sizing: border-box;
+    border-style: none;
+    margin-top: 0;
+    margin-bottom: ${getSpacingToken};
+  `};
 `;
 
 // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198
@@ -22,8 +59,10 @@ StyledSeparator.defaultProps = {
   theme: defaultTheme,
 };
 
-const Separator = ({ spaceAfter }: Props): React.Node => (
-  <StyledSeparator spaceAfter={spaceAfter} />
+const Separator = ({ align = "left", indent = "none", spaceAfter }: Props): React.Node => (
+  <StyledContainer align={align} indent={indent}>
+    <StyledSeparator spaceAfter={spaceAfter} />
+  </StyledContainer>
 );
 
 export default Separator;

--- a/packages/orbit-components/src/Separator/index.jsx.flow
+++ b/packages/orbit-components/src/Separator/index.jsx.flow
@@ -6,8 +6,12 @@ import * as React from "react";
 
 import type { spaceAfter } from "../common/getSpacingToken";
 
+export type Indent = "none" | "small" | "medium" | "large" | "XLarge" | "XXLarge";
+
 export type Props = {|
   ...spaceAfter,
+  indent?: Indent,
+  align?: "left" | "right" | "center",
 |};
 
 declare export default React.ComponentType<Props>;

--- a/packages/orbit-components/src/SocialButton/index.jsx
+++ b/packages/orbit-components/src/SocialButton/index.jsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import ButtonPrimitive from "../primitives/ButtonPrimitive";
 import getIconContainer from "../primitives/ButtonPrimitive/common/getIconContainer";
 import getCommonProps from "../primitives/ButtonPrimitive/common/getCommonProps";
+import ChevronRightIcon from "../icons/ChevronRight";
 import useTheme from "../hooks/useTheme";
 import getSocialButtonStyles from "./helpers/getSocialButtonStyles";
 import getSocialButtonIconForeground from "./helpers/getSocialButtonIconForeground";
@@ -34,7 +35,7 @@ const SocialButton: React.AbstractComponent<Props, HTMLButtonElement> = React.fo
       {...icons}
       disabled={disabled}
       iconLeft={iconLeft}
-      iconRight={null}
+      iconRight={<ChevronRightIcon color="primary" />}
       circled={false}
     />
   );

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.jsx
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.jsx
@@ -157,17 +157,6 @@ export const StyledButtonPrimitive: any = styled(
       `};
     }
 
-    &:active {
-      ${!disabled &&
-      css`
-        background: ${backgroundActive};
-        box-shadow: ${boxShadowActive};
-        color: ${foregroundActive}!important;
-        text-decoration: none;
-        ${iconContainerColor(icons && icons.foregroundActive)};
-      `};
-    }
-
     :focus {
       box-shadow: ${boxShadowFocus};
       background: ${backgroundFocus};
@@ -191,7 +180,24 @@ export const StyledButtonPrimitive: any = styled(
       text-decoration: none;
       ${iconContainerColor(icons && icons.foregroundFocus)};
     }
-  `}};
+
+    // prevent :focus styles from overriding :hover and :active styles
+
+    &:hover:focus {
+      background: ${backgroundHover};
+    }
+    &:active,
+    &:active:focus {
+      ${!disabled &&
+      css`
+        background: ${backgroundActive};
+        box-shadow: ${boxShadowActive};
+        color: ${foregroundActive}!important;
+        text-decoration: none;
+        ${iconContainerColor(icons && icons.foregroundActive)};
+      `};
+    }
+  `};
 `;
 
 // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198


### PR DESCRIPTION
UI fixes for:

- Collapse ([ORBIT-1979](https://jira.kiwi.com/browse/ORBIT-1979))
  - the problem was that `:focus` styles in ButtonPrimitve were overriding `:hover` styles, so I did some editing there, also now `:active` styles should work better
- SocialButton ([ORBIT-1992](https://jira.kiwi.com/browse/ORBIT-1992))
- Popover ([ORBIT-1984](https://jira.kiwi.com/browse/ORBIT-1984))
  - bottom corners weren't rounded when actions were present because of the actions' white background, one solution was to set `overflow: hidden` on the entire Popover, but I didn't want some unintended consequences so I went for the safer option of rounding corners of the actions container
- Separator ([ORBIT-1987](https://jira.kiwi.com/browse/ORBIT-1987))

The two remaining ones are ButtonMobileStore and Card, but those aren't cleared up yet so we'll do them in another PR.

I also refactored CardWrapper as a preparation for UI fixes in Card, so I'm including that in this PR.

 Storybook: https://orbit-silvenon-fix-ui-fixes.surge.sh