### PR TITLE
Better usage of `@testing-library/user-event` and clear up remaining `act` warnings

### DIFF
--- a/packages/orbit-components/src/BaggageStepper/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/BaggageStepper/__tests__/index.test.jsx
@@ -49,10 +49,9 @@ describe("BaggageStepper", () => {
     userEvent.click(screen.getByLabelText(DecrementLabel));
     expect(onDecrement).toHaveBeenCalled();
 
-    // $FlowFixMe
-    userEvent.tab(input);
+    userEvent.tab();
     expect(onFocus).toHaveBeenCalled();
-    fireEvent.blur(input);
+    userEvent.tab();
     expect(onBlur).toHaveBeenCalled();
   });
 

--- a/packages/orbit-components/src/InputField/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/InputField/__tests__/index.test.jsx
@@ -63,7 +63,7 @@ describe("InputField", () => {
     expect(screen.getByTestId("test")).toBeInTheDocument();
     expect(screen.getByTestId("prefix")).toBeInTheDocument();
     expect(screen.getByTestId("suffix")).toBeInTheDocument();
-    fireEvent.focus(input);
+    fireEvent.focus(input); // userEvent.tab() doesn't work because of tabIndex="-1"
     await waitFor(() => expect(screen.getByTestId("help")).toBeInTheDocument());
     expect(container.firstChild).toHaveStyle({ marginBottom: defaultTheme.orbit.spaceSmall });
   });
@@ -98,9 +98,8 @@ describe("InputField", () => {
     expect(onMouseUp).toHaveBeenCalled();
     expect(onKeyDown).toHaveBeenCalled();
     expect(onKeyUp).toHaveBeenCalled();
-    fireEvent.select(input);
     expect(onSelect).toHaveBeenCalled();
-    fireEvent.blur(input);
+    userEvent.tab();
     expect(onBlur).toHaveBeenCalled();
   });
 

--- a/packages/orbit-components/src/InputField/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/InputField/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import InputField from "..";
@@ -64,8 +64,9 @@ describe("InputField", () => {
     expect(screen.getByTestId("prefix")).toBeInTheDocument();
     expect(screen.getByTestId("suffix")).toBeInTheDocument();
     fireEvent.focus(input); // userEvent.tab() doesn't work because of tabIndex="-1"
-    await waitFor(() => expect(screen.getByTestId("help")).toBeInTheDocument());
+    expect(screen.getByTestId("help")).toBeInTheDocument();
     expect(container.firstChild).toHaveStyle({ marginBottom: defaultTheme.orbit.spaceSmall });
+    await act(async () => {});
   });
 
   it("should trigger given event handlers", () => {
@@ -141,8 +142,9 @@ describe("InputField", () => {
       expect(input).toHaveAttribute("data-state", "error");
 
       userEvent.tab();
-      await waitFor(() => expect(screen.queryByTestId("help")).not.toBeInTheDocument());
-      await waitFor(() => expect(screen.getByTestId("error")).toBeInTheDocument());
+      expect(screen.queryByTestId("help")).not.toBeInTheDocument();
+      expect(screen.getByTestId("error")).toBeInTheDocument();
+      await act(async () => {});
     });
   });
 
@@ -158,15 +160,16 @@ describe("InputField", () => {
 
       expect(screen.queryByText("First")).not.toBeInTheDocument();
       userEvent.tab();
-      await waitFor(() => expect(screen.getByText("First")).toBeVisible());
+      expect(screen.getByText("First")).toBeVisible();
       userEvent.tab();
       expect(screen.queryByText("First")).not.toBeInTheDocument();
-      await waitFor(() => expect(screen.getByText("Second")).toBeVisible());
+      expect(screen.getByText("Second")).toBeVisible();
       userEvent.tab();
-      await waitFor(() => expect(screen.getByText("Second")).toHaveFocus());
+      expect(screen.getByText("Second")).toHaveFocus();
       userEvent.tab();
       expect(screen.queryByText("Second")).not.toBeInTheDocument();
-      await waitFor(() => expect(screen.getByText("Third")).toBeVisible());
+      expect(screen.getByText("Third")).toBeVisible();
+      await act(async () => {});
     });
   });
 });

--- a/packages/orbit-components/src/InputFile/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/InputFile/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import InputFile from "..";
@@ -39,7 +39,7 @@ describe("InputFile", () => {
     screen.getByText(placeholder);
     screen.getByText(label);
 
-    const input: any = screen.getByTestId(dataTest);
+    const input = screen.getByTestId(dataTest);
     expect(input).toHaveAttribute("name", name);
     expect(input).toHaveAttribute("tabindex", "-1");
     expect(input).toHaveAttribute("accept", ".png,.jpg,.pdf");
@@ -70,18 +70,18 @@ describe("InputFile", () => {
 
     render(
       <InputFile
-        dataTest="test"
         onFocus={onFocus}
         onBlur={onBlur}
         error="chuck norris counted to infinity twice"
       />,
     );
 
-    userEvent.tab((screen.getByTestId("test"): any));
+    userEvent.tab();
     expect(onFocus).toHaveBeenCalled();
-    fireEvent.blur((screen.getByTestId("test"): any));
-    expect(onBlur).toHaveBeenCalled();
 
     expect(screen.getByText("chuck norris counted to infinity twice")).toBeInTheDocument();
+
+    userEvent.tab();
+    expect(onBlur).toHaveBeenCalled();
   });
 });

--- a/packages/orbit-components/src/InputFile/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/InputFile/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import InputFile from "..";
@@ -83,5 +83,7 @@ describe("InputFile", () => {
 
     userEvent.tab();
     expect(onBlur).toHaveBeenCalled();
+
+    await act(async () => {});
   });
 });

--- a/packages/orbit-components/src/InputGroup/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/InputGroup/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import InputGroup from "..";
@@ -39,9 +39,7 @@ describe("InputGroup", () => {
       </InputGroup>,
     );
 
-    const input = screen.getByRole("textbox");
-    // $FlowFixMe
-    userEvent.tab(input);
+    userEvent.tab();
     expect(screen.getByText("help message")).toBeInTheDocument();
   });
   it("should render error message", async () => {
@@ -51,9 +49,7 @@ describe("InputGroup", () => {
       </InputGroup>,
     );
 
-    const input = screen.getByRole("textbox");
-    // $FlowFixMe
-    userEvent.tab(input);
+    userEvent.tab();
     expect(screen.getByText("error message")).toBeInTheDocument();
   });
 
@@ -70,7 +66,7 @@ describe("InputGroup", () => {
     userEvent.type(input, "text");
     expect(onChange).toHaveBeenCalled();
     expect(onFocus).toHaveBeenCalled();
-    fireEvent.blur(input);
+    userEvent.tab();
     expect(onBlur).toHaveBeenCalled();
   });
   it("should be able to disable children", () => {

--- a/packages/orbit-components/src/InputGroup/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/InputGroup/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import InputGroup from "..";
@@ -41,6 +41,7 @@ describe("InputGroup", () => {
 
     userEvent.tab();
     expect(screen.getByText("help message")).toBeInTheDocument();
+    await act(async () => {});
   });
   it("should render error message", async () => {
     render(
@@ -51,6 +52,7 @@ describe("InputGroup", () => {
 
     userEvent.tab();
     expect(screen.getByText("error message")).toBeInTheDocument();
+    await act(async () => {});
   });
 
   it("should pass event handlers to child inputs", () => {

--- a/packages/orbit-components/src/InputStepper/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/InputStepper/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import InputStepper from "..";
@@ -44,11 +44,13 @@ describe("InputStepper", () => {
     render(<InputStepper label="Label" help="help message" />);
     userEvent.tab();
     expect(screen.getByText("help message")).toBeInTheDocument();
+    await act(async () => {});
   });
   it("should render error message", async () => {
     render(<InputStepper label="Label" error="error message" />);
     userEvent.tab();
     expect(screen.getByText("error message")).toBeInTheDocument();
+    await act(async () => {});
   });
   it("should not be able to change value by typing", () => {
     const onChange = jest.fn();

--- a/packages/orbit-components/src/InputStepper/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/InputStepper/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import InputStepper from "..";
@@ -42,14 +42,12 @@ describe("InputStepper", () => {
   });
   it("should render help message", async () => {
     render(<InputStepper label="Label" help="help message" />);
-    const input = screen.getByRole("spinbutton", { name: /Label/ });
-    fireEvent.focus(input);
+    userEvent.tab();
     expect(screen.getByText("help message")).toBeInTheDocument();
   });
   it("should render error message", async () => {
     render(<InputStepper label="Label" error="error message" />);
-    const input = screen.getByRole("spinbutton", { name: /Label/ });
-    fireEvent.focus(input);
+    userEvent.tab();
     expect(screen.getByText("error message")).toBeInTheDocument();
   });
   it("should not be able to change value by typing", () => {
@@ -76,10 +74,9 @@ describe("InputStepper", () => {
     const onFocus = jest.fn();
     const onBlur = jest.fn();
     render(<InputStepper onFocus={onFocus} onBlur={onBlur} />);
-    const input = screen.getByRole("spinbutton");
-    fireEvent.focus(input);
+    userEvent.tab();
     expect(onFocus).toHaveBeenCalled();
-    fireEvent.blur(input);
+    userEvent.tab();
     expect(onBlur).toHaveBeenCalled();
   });
   it("should not work if disabled", () => {

--- a/packages/orbit-components/src/Modal/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/Modal/__tests__/index.test.jsx
@@ -65,8 +65,7 @@ describe("Modal", () => {
       jest.runOnlyPendingTimers();
     });
     expect(screen.getByRole("dialog")).toHaveFocus();
-    // $FlowFixMe
-    userEvent.tab(screen.getByRole("dialog"));
+    userEvent.tab();
     act(() => {
       jest.runOnlyPendingTimers();
     });

--- a/packages/orbit-components/src/Select/__tests__/Select.test.jsx
+++ b/packages/orbit-components/src/Select/__tests__/Select.test.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Select from "..";
@@ -86,15 +86,15 @@ describe("Select", () => {
   it("should have error message", async () => {
     render(<Select error="error" readOnly options={[{ value: "1", label: "One" }]} />);
     userEvent.tab();
-
     expect(screen.getByText("error")).toBeInTheDocument();
+    await act(async () => {});
   });
 
   it("should have help message", async () => {
     render(<Select help="help" readOnly options={[{ value: "1", label: "One" }]} />);
     userEvent.tab();
-
     expect(screen.getByText("help")).toBeInTheDocument();
+    await act(async () => {});
   });
 
   it("should be disabled", () => {

--- a/packages/orbit-components/src/Select/__tests__/Select.test.jsx
+++ b/packages/orbit-components/src/Select/__tests__/Select.test.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Select from "..";
@@ -50,7 +50,7 @@ describe("Select", () => {
       />,
     );
 
-    const select: any = screen.getByRole("combobox");
+    const select = screen.getByRole("combobox");
 
     expect(screen.getByTestId(dataTest)).toBeInTheDocument();
     expect(select).toHaveAttribute("id", id);
@@ -64,9 +64,9 @@ describe("Select", () => {
 
     userEvent.selectOptions(select, screen.getByText("One"));
     expect(onChange).toHaveBeenCalled();
-    userEvent.tab(select);
+    userEvent.tab();
     expect(onFocus).toHaveBeenCalled();
-    fireEvent.blur(select);
+    userEvent.tab();
     expect(onBlur).toHaveBeenCalled();
   });
 

--- a/packages/orbit-components/src/SkipNavigation/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/SkipNavigation/__tests__/index.test.jsx
@@ -38,8 +38,7 @@ describe("SkipNavigation", () => {
     );
 
     expect(container).toHaveStyle({ clip: "rect(0 0 0 0)" });
-    // $FlowFixMe
-    userEvent.tab(container);
+    userEvent.tab();
     expect(container).toHaveStyle({ clip: "" });
   });
 });

--- a/packages/orbit-components/src/Slider/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/Slider/__tests__/index.test.jsx
@@ -48,10 +48,9 @@ describe("Slider", () => {
     expect(slider).toHaveAttribute("aria-valuenow", defaultValue.toString());
     expect(slider).toHaveAttribute("aria-valuetext", ariaValueText.toString());
 
-    // $FlowFixMe
-    userEvent.tab(slider);
+    userEvent.tab();
     expect(onChangeBefore).toHaveBeenCalled();
-    fireEvent.blur(slider);
+    userEvent.tab();
     expect(onChangeAfter).toHaveBeenCalled();
 
     fireEvent.mouseDown(slider, { button: 0, buttons: 0 });

--- a/packages/orbit-components/src/Stepper/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/Stepper/__tests__/index.test.jsx
@@ -49,10 +49,9 @@ describe("Stepper", () => {
     userEvent.click(screen.getByLabelText(DecrementLabel));
     expect(onDecrement).toHaveBeenCalled();
 
-    // $FlowFixMe
-    userEvent.tab(input);
+    userEvent.tab();
     expect(onFocus).toHaveBeenCalled();
-    fireEvent.blur(input);
+    userEvent.tab();
     expect(onBlur).toHaveBeenCalled();
   });
 

--- a/packages/orbit-components/src/Textarea/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/Textarea/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Textarea from "..";
@@ -68,5 +68,6 @@ describe("Textarea", () => {
     userEvent.tab();
     expect(screen.getByText("error")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toHaveStyle({ padding: "8px 12px" });
+    await act(async () => {});
   });
 });

--- a/packages/orbit-components/src/Textarea/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/Textarea/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Textarea from "..";
@@ -40,8 +40,7 @@ describe("Textarea", () => {
     expect(screen.getByDisplayValue(value)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument();
 
-    const textbox: any = screen.getByRole("textbox");
-    userEvent.tab(textbox);
+    userEvent.tab();
     expect(screen.getByText("Something useful.")).toBeInTheDocument();
     expect(textarea).toHaveAttribute("maxlength", maxLength.toString());
     expect(textarea).toHaveAttribute("rows", "4");
@@ -58,17 +57,15 @@ describe("Textarea", () => {
     const onBlur = jest.fn();
 
     render(<Textarea onFocus={onFocus} onBlur={onBlur} />);
-    // $FlowFixMe
-    userEvent.tab(screen.getByRole("textbox"));
+    userEvent.tab();
     expect(onFocus).toHaveBeenCalled();
-    fireEvent.blur(screen.getByRole("textbox"));
+    userEvent.tab();
     expect(onBlur).toHaveBeenCalled();
   });
 
   it("should have error", async () => {
     render(<Textarea error="error" size="small" />);
-    const textbox: any = screen.getByRole("textbox");
-    userEvent.tab(textbox);
+    userEvent.tab();
     expect(screen.getByText("error")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toHaveStyle({ padding: "8px 12px" });
   });


### PR DESCRIPTION
We still had `act` warnings, so I fixed those and changed the existing fixes with what I think is the most straightforward solution. One way to make it self-documenting is to create a utility that does the empty `act` call named `flushQueue` or something, and add comments to document it, let me know what you think.

This solution should work both for Popper and Floating UI. floating-ui/floating-ui#1521

 Storybook: https://orbit-silvenon-test-popper-act-warnings.surge.sh