### PR TITLE
Document useTransition hook

### DIFF
--- a/docs/src/documentation/05-development/03-hooks/usetransition.mdx
+++ b/docs/src/documentation/05-development/03-hooks/usetransition.mdx
@@ -1,0 +1,8 @@
+---
+title: useTransition
+description: Animate adding and removing elements from the DOM.
+---
+
+import UseTransitionReadMe from "@kiwicom/orbit-components/src/hooks/useTransition/README.md";
+
+<UseTransitionReadMe />

--- a/packages/orbit-components/src/hooks/useTransition/README.md
+++ b/packages/orbit-components/src/hooks/useTransition/README.md
@@ -1,0 +1,59 @@
+# useTransition
+
+Similar to the CSSTransition component in [React Transition Group](https://reactcommunity.org/react-transition-group/), the `useTransition` hook provides a way to animate adding and removing elements from the DOM.
+
+To implement the `useTranstiion` hook in your component, add the import:
+
+```jsx
+import useTransition from "@kiwicom/orbit-components/lib/hooks/useTransition";
+```
+
+Then you can use it like this:
+
+```jsx
+import { useState } from "react";
+import styled, { css } from "styled-components";
+
+const StyledAnimated = styled.div`
+  ${({ $enter }) => css`
+    transition: opacity 0.5s ease-in-out;
+    opacity: ${$state === "enter" ? 1 : 0};
+  `};
+`;
+
+const Component = (props: Props) => {
+  const [show, setShow] = useState(true);
+  const transition = useTransition({ show, appear: true });
+
+  return (
+    <>
+      <button type="button" onClick={() => setShow(prev => !prev)}>
+        Toggle
+      </button>
+      <StyledAnimated ref={transition.ref} $state={transition.state}>
+        Hello world!
+      </StyledAnimated>
+    </>
+  );
+};
+```
+
+## Options
+
+The table below contains all options available to the `useTransition` hook.
+
+| Name   | Type      | Description                                                                                                             |
+| :----- | :-------- | :---------------------------------------------------------------------------------------------------------------------- |
+| show   | `boolean` | Whether to animate the element in or out of the DOM. The duration is defined by the `transition-duration` CSS property. |
+| appear | `boolean` | Whether to show the enter animation right away if `show` is initially set to `true`.                                    |
+
+## Return
+
+The table below contains all properties of the object returned by the `useTransition` hook.
+
+| Name    | Type                                   | Description                                                          |
+| :------ | :------------------------------------- | :------------------------------------------------------------------- |
+| ref     | `{\| current: HTMLElement \| null \|}` | Ref object that should be passed to the HTML element being animated. |
+| mounted | `boolean`                              | Whether the component is mounted.                                    |
+| state   | `"enter" \| "leave"`                   | Whether the element is entering or leaving the DOM.                  |
+| done    | `boolean`                              | Whether the element is done transitioning.                           |

--- a/packages/orbit-components/src/hooks/useTransition/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/hooks/useTransition/__tests__/index.test.jsx
@@ -18,7 +18,7 @@ function App(props: {| show: boolean, appear: boolean |}) {
           ref={transition.ref}
           css={`
             transition: opacity 0.5s ease-in-out;
-            opacity: ${transition.enter ? 1 : 0};
+            opacity: ${transition.state === "enter" ? 1 : 0};
           `}
         >
           Test

--- a/packages/orbit-components/src/hooks/useTransition/index.d.ts
+++ b/packages/orbit-components/src/hooks/useTransition/index.d.ts
@@ -6,6 +6,6 @@ export declare function useTransition(options: {
 }): {
   ref: React.MutableRefObject<HTMLElement | null>;
   mounted: boolean;
-  enter: boolean;
+  state: "enter" | "leave";
   done: boolean;
 };

--- a/packages/orbit-components/src/hooks/useTransition/index.js
+++ b/packages/orbit-components/src/hooks/useTransition/index.js
@@ -6,7 +6,7 @@ import typeof UseTransitionType from ".";
 const useTransition: UseTransitionType = ({ show, appear = false }) => {
   // if appear is true, we want to start from unmounted state, so that we can transition in
   const [mounted, setMounted] = React.useState(!appear && show);
-  const [enter, setEnter] = React.useState(!appear && show);
+  const [state, setState] = React.useState(!appear && show ? "enter" : "leave");
   const [done, setDone] = React.useState(!appear || !show);
   const ref = React.useRef(null);
   const firstRender = React.useRef(true);
@@ -39,7 +39,7 @@ const useTransition: UseTransitionType = ({ show, appear = false }) => {
       if (show) {
         setMounted(true);
       } else {
-        setEnter(false);
+        setState("leave");
         setDone(false);
         listener = () => {
           setMounted(false);
@@ -62,7 +62,7 @@ const useTransition: UseTransitionType = ({ show, appear = false }) => {
         // to make transition work immediately after mount
         // eslint-disable-next-line babel/no-unused-expressions
         ref.current?.scrollTop;
-        setEnter(true);
+        setState("enter");
         setDone(false);
         listener = () => {
           setDone(true);
@@ -79,7 +79,7 @@ const useTransition: UseTransitionType = ({ show, appear = false }) => {
     firstRender.current = false;
   }, []);
 
-  return { ref, mounted, enter, done };
+  return { ref, mounted, state, done };
 };
 
 export default useTransition;

--- a/packages/orbit-components/src/hooks/useTransition/index.js.flow
+++ b/packages/orbit-components/src/hooks/useTransition/index.js.flow
@@ -6,7 +6,7 @@ declare function useTransition(options: {|
 |}): {|
   ref: {| current: HTMLElement | null |},
   mounted: boolean,
-  enter: boolean,
+  state: "enter" | "leave",
   done: boolean,
 |};
 


### PR DESCRIPTION
This also adds a tweak to `useTransition` API. Instead of the `enter` property I decided it would be better to pass the `state` property.

 Storybook: https://orbit-silvenon-docs-use-transition.surge.sh