### PR TITLE
fix(InputField): enable tooltip on hover when disabled

### DIFF
--- a/packages/orbit-components/src/ErrorForms.stories.jsx
+++ b/packages/orbit-components/src/ErrorForms.stories.jsx
@@ -57,6 +57,16 @@ export const Error = (): React.Node => {
       />
       <InputField
         size={size}
+        disabled
+        inlineLabel
+        error={<TextLink tabIndex={0}>{error}</TextLink>}
+        label={label}
+        value={value}
+        placeholder={placeholder}
+        onChange={action("change")}
+      />
+      <InputField
+        size={size}
         error={error}
         label={label}
         value={value}

--- a/packages/orbit-components/src/InputField/index.jsx
+++ b/packages/orbit-components/src/InputField/index.jsx
@@ -410,6 +410,9 @@ const InputField: InputFieldType = React.forwardRef((props, ref) => {
         spaceAfter={spaceAfter}
         ref={fieldRef}
         htmlFor={label ? inputId : undefined}
+        // enable tooltip on hover, if it's disabled
+        onMouseEnter={() => (disabled && inlineLabel ? setTooltipShownHover(true) : undefined)}
+        onMouseLeave={() => (disabled && inlineLabel ? setTooltipShownHover(false) : undefined)}
       >
         {label && !inlineLabel && (
           <FormLabel


### PR DESCRIPTION
[Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1643896085551969)
 Storybook: https://orbit-silvenon-fix-hover-errorforms.surge.sh