### PR TITLE
feat: add tile and tilegroup as prop

### DIFF
--- a/packages/orbit-components/src/Tile/README.md
+++ b/packages/orbit-components/src/Tile/README.md
@@ -19,6 +19,7 @@ Table below contains all types of the props available in Tile component.
 | Name            | Type                       | Default | Description                                                                                                                  |
 | :-------------- | :------------------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------- |
 | children        | `React.Node`               |         | Content of expandable Tile.                                                                                                  |
+| as              | `string`                   | `"div"` | The element used for the root node.                                                                                          |
 | dataTest        | `string`                   |         | Optional prop for testing purposes.                                                                                          |
 | description     | `React.Node`               |         | The description of the Tile.                                                                                                 |
 | expandable      | `boolean`                  | `false` | If `true`, the Tile will be expandable.                                                                                      |

--- a/packages/orbit-components/src/Tile/Tile.stories.jsx
+++ b/packages/orbit-components/src/Tile/Tile.stories.jsx
@@ -23,8 +23,10 @@ export default {
 export const DefaultJustWrapper = (): React.Node => {
   const content = text("content", "Lorem ipsum dolor sit amet");
   const noPadding = boolean("noPadding", false);
+  const as = text("as", "");
+
   return (
-    <Tile onClick={action("clicked")} noPadding={noPadding}>
+    <Tile as={as} onClick={action("clicked")} noPadding={noPadding}>
       {content}
     </Tile>
   );

--- a/packages/orbit-components/src/Tile/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/Tile/__tests__/index.test.jsx
@@ -52,6 +52,11 @@ describe("Tile", () => {
     expect(screen.getByRole("link")).toHaveAttribute("target", "_blank");
   });
 
+  it("should be a list", () => {
+    render(<Tile href="#" external as="li" />);
+    expect(screen.getByRole("listitem")).toBeInTheDocument();
+  });
+
   it("should be expandable", () => {
     render(<Tile expandable initialExpanded />);
     expect(screen.getByRole("button")).toHaveAttribute("aria-expanded");

--- a/packages/orbit-components/src/Tile/index.d.ts
+++ b/packages/orbit-components/src/Tile/index.d.ts
@@ -6,6 +6,7 @@ import * as React from "react";
 import * as Common from "../common/common";
 
 interface Props extends Common.Global {
+  readonly as?: string;
   readonly title?: React.ReactNode;
   readonly description?: React.ReactNode;
   readonly icon?: React.ReactNode;

--- a/packages/orbit-components/src/Tile/index.jsx
+++ b/packages/orbit-components/src/Tile/index.jsx
@@ -24,6 +24,7 @@ const Tile = ({
   noHeaderIcon = false,
   htmlTitle,
   onClick,
+  as,
 }: Props): React.Node => {
   if (expandable) {
     return (
@@ -51,7 +52,7 @@ const Tile = ({
       dataTest={dataTest}
       onClick={onClick}
       onKeyDown={handleKeyDown(onClick)}
-      as={href ? "a" : "div"}
+      as={as || (href ? "a" : "div")}
       tabIndex={!href ? "0" : undefined}
       role={href ? undefined : "button"}
       htmlTitle={htmlTitle}

--- a/packages/orbit-components/src/Tile/index.jsx.flow
+++ b/packages/orbit-components/src/Tile/index.jsx.flow
@@ -11,6 +11,7 @@ export type TileOnClick = (
 ) => void | Promise<any>;
 
 export type Props = {|
+  +as?: string,
   +title?: React.Node,
   +description?: React.Node,
   +icon?: React.Node,

--- a/packages/orbit-components/src/TileGroup/README.md
+++ b/packages/orbit-components/src/TileGroup/README.md
@@ -22,6 +22,7 @@ Table below contains all types of the props available in TileGroup component.
 
 | Name     | Type         | Default | Description                                                                                       |
 | :------- | :----------- | :------ | :------------------------------------------------------------------------------------------------ |
+| as       | `string`     | `"div"` | The element used for the root node.                                                               |
 | dataTest | `string`     |         | Optional prop for testing purposes.                                                               |
 | children | `React.Node` |         | Content of the TileGroup - normally the Tile component. [See functional specs](#functional-specs) |
 

--- a/packages/orbit-components/src/TileGroup/TileGroup.stories.jsx
+++ b/packages/orbit-components/src/TileGroup/TileGroup.stories.jsx
@@ -23,10 +23,11 @@ export default {
 
 export const DefaultJustWrapper = (): React.Node => {
   const dataTest = text("dataTest", "test");
+  const as = text("as", "");
 
   const content = text("content", "Lorem ipsum dolor sit amet");
   return (
-    <TileGroup dataTest={dataTest}>
+    <TileGroup as={as} dataTest={dataTest}>
       <Tile onClick={action("clicked")}>{content}</Tile>
       <Tile onClick={action("clicked")}>{content}</Tile>
       <Tile onClick={action("clicked")}>{content}</Tile>

--- a/packages/orbit-components/src/TileGroup/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/TileGroup/__tests__/index.test.jsx
@@ -9,7 +9,7 @@ describe("Tile clickable", () => {
   it("should have expected DOM output", () => {
     const dataTest = "test";
     render(
-      <TileGroup dataTest={dataTest}>
+      <TileGroup dataTest={dataTest} as="ul">
         <Tile title="title" onClick={() => {}}>
           kek
         </Tile>
@@ -21,5 +21,6 @@ describe("Tile clickable", () => {
 
     expect(screen.getByTestId(dataTest)).toBeInTheDocument();
     expect(screen.getAllByText("kek")).toHaveLength(2);
+    expect(screen.getByRole("list")).toBeInTheDocument();
   });
 });

--- a/packages/orbit-components/src/TileGroup/index.d.ts
+++ b/packages/orbit-components/src/TileGroup/index.d.ts
@@ -6,6 +6,7 @@ import * as React from "react";
 import * as Common from "../common/common";
 
 interface Props extends Common.Global {
+  readonly as?: string;
   readonly children: React.ReactNode;
 }
 

--- a/packages/orbit-components/src/TileGroup/index.jsx
+++ b/packages/orbit-components/src/TileGroup/index.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { StyledTileWrapper } from "../Tile/components/TileWrapper";
 import defaultTheme from "../defaultTheme";
@@ -9,34 +9,38 @@ import { StyledSlide } from "../utils/Slide";
 import type { Props } from ".";
 
 const StyledTileGroup = styled.div`
-  width: 100%;
-  box-shadow: ${({ theme }) => theme.orbit.boxShadowAction};
-  border-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
-  ${StyledSlide} {
-    background: ${({ theme }) => theme.orbit.paletteWhite};
-  }
-  ${StyledTileWrapper} {
-    border-radius: 0;
-    :first-child {
-      border-top-left-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
-      border-top-right-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
+  ${({ theme }) => css`
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    box-shadow: ${theme.orbit.boxShadowAction};
+    border-radius: ${theme.orbit.borderRadiusNormal};
+    ${StyledSlide} {
+      background: ${theme.orbit.paletteWhite};
     }
-    :last-child {
-      border-bottom-left-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
-      border-bottom-right-radius: ${({ theme }) => theme.orbit.borderRadiusNormal};
+    ${StyledTileWrapper} {
+      border-radius: 0;
+      :first-child {
+        border-top-left-radius: ${theme.orbit.borderRadiusNormal};
+        border-top-right-radius: ${theme.orbit.borderRadiusNormal};
+      }
+      :last-child {
+        border-bottom-left-radius: ${theme.orbit.borderRadiusNormal};
+        border-bottom-right-radius: ${theme.orbit.borderRadiusNormal};
+      }
+      :not(:last-child) {
+        border-bottom: 1px solid ${theme.orbit.paletteCloudDark};
+      }
+      box-shadow: none;
+      transition: background ${theme.orbit.durationFast} ease-in-out,
+        box-shadow ${theme.orbit.durationFast} ease-in-out,
+        border-color ${theme.orbit.durationFast} ease-in-out;
+      :hover,
+      :focus {
+        background: ${theme.orbit.paletteCloudNormal};
+      }
     }
-    :not(:last-child) {
-      border-bottom: 1px solid ${({ theme }) => theme.orbit.paletteCloudDark};
-    }
-    box-shadow: none;
-    transition: background ${({ theme }) => theme.orbit.durationFast} ease-in-out,
-      box-shadow ${({ theme }) => theme.orbit.durationFast} ease-in-out,
-      border-color ${({ theme }) => theme.orbit.durationFast} ease-in-out;
-    :hover,
-    :focus {
-      background: ${({ theme }) => theme.orbit.paletteCloudNormal};
-    }
-  }
+  `}
 `;
 
 // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198
@@ -44,8 +48,12 @@ StyledTileGroup.defaultProps = {
   theme: defaultTheme,
 };
 
-const TileGroup = ({ children, dataTest }: Props): React.Node => {
-  return <StyledTileGroup data-test={dataTest}>{children}</StyledTileGroup>;
+const TileGroup = ({ children, dataTest, as }: Props): React.Node => {
+  return (
+    <StyledTileGroup data-test={dataTest} as={as}>
+      {children}
+    </StyledTileGroup>
+  );
 };
 
 export default TileGroup;

--- a/packages/orbit-components/src/TileGroup/index.jsx.flow
+++ b/packages/orbit-components/src/TileGroup/index.jsx.flow
@@ -5,6 +5,7 @@ import type { Globals } from "../common/common.js.flow";
 
 export type Props = {|
   ...Globals,
+  +as?: string,
   +children: React.Node,
 |};
 


### PR DESCRIPTION
[Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1646043279927369)
 Storybook: https://orbit-silvenon-feat-tile-as.surge.sh