### PR TITLE
Remove duplicate ¶ from Toast content

### DIFF
--- a/docs/src/documentation/03-components/03-information/toast/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/03-information/toast/01-guidelines.mdx
@@ -39,5 +39,3 @@ Make the actions available directly on the screen. If there are actions associat
 Toast shows a brief message that’s clear & understandable. It’s shown temporarily, which means that it shouldn’t be used for error messages that block the user in continuing the flow.
 Toast component is used for feedback from the app to the users for informing or warning them about different states.
 Toast should only be used if there are no other ways of providing the feedback.
-
-Toast shows a brief message that’s clear & understandable. It’s shown temporarily, which means that it shouldn’t be used for error messages that block the user in continuing the flow. Toast component is used for feedback from the app to the users for informing or warning them about different states. Toast should only be used if there are no other ways of providing the feedback.


### PR DESCRIPTION
The final paragraph of the Toast component Content description was duplicated.

This removes the extra copy.

This Pull Request meets the following criteria:

- [ ] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components has both `.flow` and `d.ts` files and are exprorted in `index.js.flow` and `index.d.ts`
