### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -9,8 +9,16 @@ env: # Set environment variables for every job and step in this workflow
   STREAMLINE_SECRET: ${{ secrets.STREAMLINE_SECRET }}
   STREAMLINE_FAMILIES: ${{ secrets.STREAMLINE_FAMILIES }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      checks: write  # for preactjs/compressed-size-action to create and update the checks
+      contents: read  # for actions/checkout to fetch code
+      issues: write  # for preactjs/compressed-size-action to create comments
+      pull-requests: write  # for preactjs/compressed-size-action to write a PR review
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
