### PR TITLE
docs: component status is N/A for all Android components

### DIFF
--- a/docs/src/data/component-status.yaml
+++ b/docs/src/data/component-status.yaml
@@ -16,28 +16,28 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Information
 - component: Badge
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Information
 - component: BadgeList
   figma: Released
   react: Released
   ios: Released
-  android: Planned
+  android: N/A
   docs: Released
   group: Information
 - component: BadgePrimitive
   figma: N/A
   react: Released
   ios: N/A
-  android: Planned
+  android: N/A
   docs: Released
   group: Primitives
 - component: Box
@@ -65,7 +65,7 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Action
 - component: ButtonMobileStore
@@ -79,14 +79,14 @@
   figma: N/A
   react: Released
   ios: N/A
-  android: Released
+  android: N/A
   docs: Released
   group: Primitives
 - component: Button
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Action
 - component: CallOutBanner
@@ -100,7 +100,7 @@
   figma: Released
   react: Released
   ios: Released
-  android: Partially
+  android: N/A
   docs: Released
   group: Structure
 - component: CarrierLogo
@@ -114,21 +114,21 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Input
 - component: ChoiceGroup
   figma: Designing
   react: Released
   ios: N/A
-  android: Released
+  android: N/A
   docs: Released
   group: Input
 - component: ChoiceTile
   figma: Designing
   react: Planned
   ios: Released
-  android: Released
+  android: N/A
   docs: Waiting
   group: Structure
 - component: Collapse
@@ -142,7 +142,7 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Visuals
 - component: Coupon
@@ -191,7 +191,7 @@
   figma: Released
   react: Planned
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Progress indicators
 - component: FeatureIcon
@@ -212,7 +212,7 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Text
 - component: Hide
@@ -233,7 +233,7 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Visuals
 - component: IllustrationPrimitive
@@ -247,7 +247,7 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Visuals
 - component: Inline
@@ -261,7 +261,7 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Input
 - component: InputFile
@@ -345,7 +345,7 @@
   figma: Released
   react: Released
   ios: Planned
-  android: Released
+  android: N/A
   docs: Released
   group: Navigation
 - component: NavigationList
@@ -401,7 +401,7 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Input
 - component: RatingStars
@@ -415,14 +415,14 @@
   figma: Designing
   react: Released
   ios: N/A
-  android: Released
+  android: N/A
   docs: Released
   group: Visuals
 - component: Select
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Input
 - component: Skeleton
@@ -436,7 +436,7 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Structure
 - component: ServiceLogo
@@ -485,7 +485,7 @@
   figma: Released
   react: Released
   ios: Planned
-  android: Released
+  android: N/A
   docs: Released
   group: Interaction
 - component: Sticky
@@ -506,14 +506,14 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Writing
   group: Interaction
 - component: TabBar
   figma: Released
   react: N/A
   ios: Waiting
-  android: Waiting
+  android: N/A
   docs: Waiting
   group: Navigation
 - component: Table
@@ -534,7 +534,7 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Interaction
 - component: TextLink
@@ -548,14 +548,14 @@
   figma: Released
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Text
 - component: Textarea
   figma: Planned
   react: Released
   ios: N/A
-  android: Released
+  android: N/A
   docs: Released
   group: Input
 - component: TileGroup
@@ -569,7 +569,7 @@
   figma: Planned
   react: Released
   ios: Released
-  android: Released
+  android: N/A
   docs: Released
   group: Structure
 - component: Timeline


### PR DESCRIPTION
Currently, there is a mistake – component that we do not have and is not defined in our repo is defined here with released state, so rather making everything here a default N/A.
 Storybook: https://orbit-mainframev-hrach-patch-1.surge.sh