### PR TITLE
docs: readme for orbit components

### DIFF
--- a/docs/src/documentation/01-getting-started/02-for-developers.mdx
+++ b/docs/src/documentation/01-getting-started/02-for-developers.mdx
@@ -3,7 +3,7 @@ title: For developers
 description: How to use our components from their npm package.
 ---
 
-**`Orbit-components` is a React component library to help developers build Kiwi.com products.**
+**`Orbit-components` is a React component library to help developers build travel products.**
 
 ---
 
@@ -99,8 +99,8 @@ It includes contribution guidelines and information on how to run and develop th
 We want to provide only components of the highest quality.
 We can't do that without your feedback.
 If you have any suggestions about what we can do to improve components,
-please report it directly as an [issue](https://github.com/kiwicom/orbit/issues/new/choose)
-or write to us at **\#plz-orbit** on Slack.
+please report it directly as an [issue](https://github.com/kiwicom/orbit/issues/new/choose).
+Kiwi.com users can also slack us at **\#plz-orbit**.
 
 ## More to explore
 

--- a/packages/orbit-components/README.md
+++ b/packages/orbit-components/README.md
@@ -1,0 +1,70 @@
+# Orbit-components
+
+Orbit-components is a React component library to help developers build travel products.
+Orbit aims to bring order and consistency to all of our products and processes. We elevate the user experience and increase the speed and efficiency of how we design and build products.
+
+## Installation
+
+`orbit-components` is served as an [npm package](https://www.npmjs.com/package/@kiwicom/orbit-components).
+
+Run [npm](https://www.npmjs.com/) to add the package to your project:
+
+`npm install --save @kiwicom/orbit-components`
+
+or do so with [Yarn](https://yarnpkg.com/):
+
+`yarn add @kiwicom/orbit-components`
+
+## Usage
+
+1. Import the fonts that are used in `orbit-components`:
+
+   ```html
+   <link
+     href="https://fonts.googleapis.com/css?family=Roboto:400,400i,500,500i,700"
+     rel="stylesheet"
+   />
+   ```
+
+   Or via CSS:
+
+   ```css
+   @import url("https://fonts.googleapis.com/css?family=Roboto:400,400i,500,500i,700");
+   ```
+
+2. Include any of our components in your project and use it:
+
+   ```jsx
+   import Alert from "@kiwicom/orbit-components/lib/Alert";
+
+   <Alert>Hello World!</Alert>;
+   ```
+
+For a live preview, check out our [Storybook](https://kiwicom.github.io/orbit/) or [orbit.kiwi](https://orbit.kiwi).
+
+You can also try `orbit-components` live on [CodeSandbox](https://codesandbox.io/s/github/designkiwicom/orbit-sandbox).
+
+## Types
+
+Orbit comes with both Flow and Typescript definition files, so you can choose what fits your project.
+If you're working with Typescript, you need to add a type for `styled-components`.
+
+```shell
+// with npm
+npm install @types/styled-components --save-dev
+
+// with yarn
+yarn add @types/styled-components -D
+```
+
+## Contributing
+
+We're working on making this project a fully open source.
+We appreciate any contributions you might make.
+
+[Bug reports](https://github.com/kiwicom/orbit/issues/new?template=bug_report.md)
+and [feature requests](https://github.com/kiwicom/orbit/issues/new?template=feature_request.md) are welcome,
+but please use the correct template.
+
+Please check out our [contribution guide](https://github.com/kiwicom/orbit/tree/master/.github/contribution/README.md).
+It includes contribution guidelines and information on how to run and develop the project.


### PR DESCRIPTION
[ORBIT-1520](https://jira.kiwi.com/browse/ORBIT-1520)

The `orbit-components` package now has a README file, based on other packages' README and also on the public documentation page.
While reading the documentation page I noticed references to kiwi.com devs and internal slack channels and I decided to remove them, since they should not be relevant for people outside kiwi.com. If this change is not desired, the last commit can be removed.
 Storybook: https://orbit-mainframev-chore-create-readme-for-orbit-components.surge.sh