### PR TITLE
feat: add onShow properties for Tooltip and TooltipPrimitive 

### DIFF
--- a/packages/orbit-components/src/Tooltip/README.md
+++ b/packages/orbit-components/src/Tooltip/README.md
@@ -36,6 +36,7 @@ Table below contains all types of the props available in the Tooltip component.
 | offset               | `[number, number]`        | `[0, 5]` | Set offset `[vertical, horizontal]` for Tooltip                                                                                                  |
 
 | tabIndex | `string \| number` | `"0"` | Specifies the tab order of an element |
+| onShow | `() => void \| () => Promise<void>` | | Callback when Tooltip is shown |
 
 ## enum
 

--- a/packages/orbit-components/src/Tooltip/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/Tooltip/__tests__/index.test.jsx
@@ -1,6 +1,7 @@
 // @flow
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import Tooltip from "..";
 
@@ -15,9 +16,16 @@ jest.mock("../../hooks/useMediaQuery", () => {
 describe("Tooltip", () => {
   it("it should render Tooltip", () => {
     const content = "Write some message to the user";
+    const onShow = jest.fn();
 
-    render(<Tooltip content={content}>kek</Tooltip>);
+    render(
+      <Tooltip content={content} onShow={onShow}>
+        kek
+      </Tooltip>,
+    );
 
     expect(screen.getByText("kek")).toBeInTheDocument();
+    userEvent.hover(screen.getByText("kek"));
+    expect(onShow).toHaveBeenCalled();
   });
 });

--- a/packages/orbit-components/src/Tooltip/index.d.ts
+++ b/packages/orbit-components/src/Tooltip/index.d.ts
@@ -14,6 +14,7 @@ export interface Props extends Common.Global, Popper {
   readonly renderInPortal?: boolean;
   readonly stopPropagation?: boolean;
   readonly enabled?: boolean;
+  readonly onShow?: Common.Callback;
   readonly tabIndex?: string | number;
   readonly removeUnderlinedText?: boolean;
   readonly block?: boolean;

--- a/packages/orbit-components/src/Tooltip/index.jsx
+++ b/packages/orbit-components/src/Tooltip/index.jsx
@@ -11,6 +11,7 @@ import type { Props } from ".";
 const Tooltip = ({
   children,
   enabled = true,
+  onShow,
   tabIndex = "0",
   dataTest,
   size = SIZE_OPTIONS.SMALL,
@@ -29,6 +30,7 @@ const Tooltip = ({
       dataTest={dataTest}
       id={id}
       tabIndex={tabIndex}
+      onShow={onShow}
       enabled={enabled}
       content={content}
       size={size}

--- a/packages/orbit-components/src/Tooltip/index.jsx.flow
+++ b/packages/orbit-components/src/Tooltip/index.jsx.flow
@@ -18,6 +18,7 @@ export type Props = {|
   +children?: React.Node,
   +content: React.Node,
   +size?: Sizes,
+  +onShow?: () => void | Promise<void>,
   +enabled?: boolean,
   +renderInPortal?: boolean,
   +stopPropagation?: boolean,

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/README.md
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/README.md
@@ -34,7 +34,7 @@ Table below contains all types of the props available in the TooltipPrimitive co
 | noFlip               | `boolean`                     | `false`  | Turns off automatic flipping of the Tooltip when there is not enough space                                                 |
 | offset               | `[number, number]`            | `[0, 5]` | Set offset `[vertical, horizontal]` for Tooltip                                                                            |
 | tabIndex             | `string \| number`            | `"0"`    | Specifies the tab order of an element                                                                                      |
-| onShown              | `() => void \| Promise<void>` |          | Callback for Tooltip, which will be fired when it will be shown                                                            |
+| onShow               | `() => void \| Promise<void>` |          | Callback for Tooltip, which will be fired when it is shown                                                                 |
 
 ## size
 

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/README.md
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/README.md
@@ -18,22 +18,23 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the TooltipPrimitive component.
 
-| Name                 | Type                      | Default  | Description                                                                                                                |
-| :------------------- | :------------------------ | :------- | :------------------------------------------------------------------------------------------------------------------------- |
-| **children**         | `React.Node`              |          | The reference element where the TooltipPrimitive will appear.                                                              |
-| **content**          | `React.Node`              |          | The content to display in the TooltipPrimitive.                                                                            |
-| dataTest             | `string`                  |          | Optional prop for testing purposes.                                                                                        |
-| id                   | `string`                  |          | Set id for `TooltipPrimitive`                                                                                              |
-| enabled              | `boolean`                 | `true`   | Enable render of tooltipPrimitive                                                                                          |
-| renderInPortal       | `boolean`                 | `true`   | Optional prop, set it to `false` if you're rendering TooltipPrimitive inside a custom portal, defaults to `true`           |
-| block                | `boolean`                 | `false`  | Whether the children wrapper is inline or block. Useful when children need to take up the entire container width.          |
-| removeUnderlinedText | `boolean`                 |          | Removes underline on child component, when underline is not desired.                                                       |
-| size                 | [`size`](#size)           |          | The maximum possible size of the TooltipPrimitive.                                                                         |
-| stopPropagation      | `boolean`                 |          | If `true` the click event on children won't bubble. Useful when you use TooltipPrimitive inside another clickable element. |
-| placement            | [`placement`](#placement) | `auto`   | 12 different placements to choose from                                                                                     |
-| noFlip               | `boolean`                 | `false`  | Turns off automatic flipping of the Tooltip when there is not enough space                                                 |
-| offset               | `[number, number]`        | `[0, 5]` | Set offset `[vertical, horizontal]` for Tooltip                                                                            |
-| tabIndex             | `string \| number`        | `"0"`    | Specifies the tab order of an element                                                                                      |
+| Name                 | Type                          | Default  | Description                                                                                                                |
+| :------------------- | :---------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------- |
+| **children**         | `React.Node`                  |          | The reference element where the TooltipPrimitive will appear.                                                              |
+| **content**          | `React.Node`                  |          | The content to display in the TooltipPrimitive.                                                                            |
+| dataTest             | `string`                      |          | Optional prop for testing purposes.                                                                                        |
+| id                   | `string`                      |          | Set id for `TooltipPrimitive`                                                                                              |
+| enabled              | `boolean`                     | `true`   | Enable render of tooltipPrimitive                                                                                          |
+| renderInPortal       | `boolean`                     | `true`   | Optional prop, set it to `false` if you're rendering TooltipPrimitive inside a custom portal, defaults to `true`           |
+| block                | `boolean`                     | `false`  | Whether the children wrapper is inline or block. Useful when children need to take up the entire container width.          |
+| removeUnderlinedText | `boolean`                     |          | Removes underline on child component, when underline is not desired.                                                       |
+| size                 | [`size`](#size)               |          | The maximum possible size of the TooltipPrimitive.                                                                         |
+| stopPropagation      | `boolean`                     |          | If `true` the click event on children won't bubble. Useful when you use TooltipPrimitive inside another clickable element. |
+| placement            | [`placement`](#placement)     | `auto`   | 12 different placements to choose from                                                                                     |
+| noFlip               | `boolean`                     | `false`  | Turns off automatic flipping of the Tooltip when there is not enough space                                                 |
+| offset               | `[number, number]`            | `[0, 5]` | Set offset `[vertical, horizontal]` for Tooltip                                                                            |
+| tabIndex             | `string \| number`            | `"0"`    | Specifies the tab order of an element                                                                                      |
+| onShown              | `() => void \| Promise<void>` |          | Callback for Tooltip, which will be fired when it will be shown                                                            |
 
 ## size
 

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
@@ -17,6 +17,7 @@ interface Props extends Common.Global, Popper {
   readonly children?: React.ReactNode;
   readonly content: React.ReactNode;
   readonly size?: Size;
+  readonly onShown?: Common.Callback;
   readonly error?: boolean;
   readonly help?: boolean;
   readonly stopPropagation?: boolean;

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.d.ts
@@ -17,7 +17,7 @@ interface Props extends Common.Global, Popper {
   readonly children?: React.ReactNode;
   readonly content: React.ReactNode;
   readonly size?: Size;
-  readonly onShown?: Common.Callback;
+  readonly onShow?: Common.Callback;
   readonly error?: boolean;
   readonly help?: boolean;
   readonly stopPropagation?: boolean;

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.jsx
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.jsx
@@ -41,6 +41,7 @@ const TooltipPrimitive = ({
   enabled = true,
   tooltipShown,
   tabIndex = "0",
+  onShown,
   dataTest,
   id,
   renderInPortal = true,
@@ -64,11 +65,13 @@ const TooltipPrimitive = ({
   ] = useStateWithTimeout<boolean>(false, 200);
 
   const tooltipId = useRandomId();
+
   const handleIn = React.useCallback(() => {
     setRender(true);
     setShown(true);
+    if (onShown) onShown();
     clearRenderTimeout();
-  }, [clearRenderTimeout, setRender]);
+  }, [clearRenderTimeout, setRender, onShown]);
 
   const handleOut = React.useCallback(() => {
     setShown(false);
@@ -85,8 +88,9 @@ const TooltipPrimitive = ({
   );
 
   React.useEffect(() => {
-    if (tooltipShown) handleIn();
-    else {
+    if (tooltipShown) {
+      handleIn();
+    } else {
       handleOut();
     }
   }, [tooltipShown, handleIn, handleOut]);

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.jsx
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.jsx
@@ -41,7 +41,7 @@ const TooltipPrimitive = ({
   enabled = true,
   tooltipShown,
   tabIndex = "0",
-  onShown,
+  onShow,
   dataTest,
   id,
   renderInPortal = true,
@@ -69,9 +69,9 @@ const TooltipPrimitive = ({
   const handleIn = React.useCallback(() => {
     setRender(true);
     setShown(true);
-    if (onShown) onShown();
+    if (onShow) onShow();
     clearRenderTimeout();
-  }, [clearRenderTimeout, setRender, onShown]);
+  }, [clearRenderTimeout, setRender, onShow]);
 
   const handleOut = React.useCallback(() => {
     setShown(false);

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.jsx.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.jsx.flow
@@ -25,7 +25,7 @@ export type Props = {|
   +children?: React.Node,
   +content: React.Node,
   +size?: Sizes,
-  +onShown?: () => void | Promise<any>,
+  +onShow?: () => void | Promise<any>,
   +error?: boolean,
   +help?: boolean,
   +stopPropagation?: boolean,

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.jsx.flow
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.jsx.flow
@@ -25,6 +25,7 @@ export type Props = {|
   +children?: React.Node,
   +content: React.Node,
   +size?: Sizes,
+  +onShown?: () => void | Promise<any>,
   +error?: boolean,
   +help?: boolean,
   +stopPropagation?: boolean,


### PR DESCRIPTION
[Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1664966991843809)
 Storybook: https://orbit-mainframev-feat-add-onshow-callback.surge.sh