### PR TITLE
feat(ItineraryBadgeListItem): add new ItineraryBadgeListItem

### DIFF
--- a/packages/babel-plugin-orbit-components/index.js
+++ b/packages/babel-plugin-orbit-components/index.js
@@ -37,6 +37,7 @@ const pathOverwrites = {
   ItinerarySeparator: "Itinerary/ItinerarySeparator",
   ItineraryStatus: "Itinerary/ItineraryStatus",
   ItineraryBadgeList: "Itinerary/ItineraryBadgeList",
+  ItineraryBadgeListItem: "Itinerary/ItineraryBadgeList/ItineraryBadgeListItem",
   ItinerarySegmentDetail: "Itinerary/ItinerarySegment/ItinerarySegmentDetail",
   ItinerarySegmentStop: "Itinerary/ItinerarySegment/ItinerarySegmentStop",
   ItinerarySegmentBanner: "Itinerary/ItinerarySegment/ItinerarySegmentBanner",

--- a/packages/orbit-components/src/BadgeList/BadgeListItem/index.d.ts
+++ b/packages/orbit-components/src/BadgeList/BadgeListItem/index.d.ts
@@ -2,10 +2,11 @@
 // Project: http://github.com/kiwicom/orbit
 
 import * as React from "react";
+import { AnyStyledComponent } from "styled-components";
 
 import * as Common from "../../common/common";
 
-type Type = "neutral" | "info" | "success" | "warning" | "critical";
+export type Type = "neutral" | "info" | "success" | "warning" | "critical";
 
 export interface Props extends Common.Global {
   readonly children: React.ReactNode;
@@ -14,6 +15,17 @@ export interface Props extends Common.Global {
   readonly icon: React.ReactNode;
 }
 
+declare const getIconColor: (type: Type) => string;
 declare const BadgeListItem: React.FunctionComponent<Props>;
+declare const StyledBadgeListItem: AnyStyledComponent;
+declare const StyledVerticalBadge: AnyStyledComponent;
+declare const StyledVerticalBadgeContent: AnyStyledComponent;
 
-export { BadgeListItem, BadgeListItem as default };
+export {
+  BadgeListItem,
+  StyledBadgeListItem,
+  StyledVerticalBadge,
+  getIconColor,
+  StyledVerticalBadgeContent,
+  BadgeListItem as default,
+};

--- a/packages/orbit-components/src/BadgeList/BadgeListItem/index.d.ts
+++ b/packages/orbit-components/src/BadgeList/BadgeListItem/index.d.ts
@@ -19,13 +19,13 @@ declare const getIconColor: (type: Type) => string;
 declare const BadgeListItem: React.FunctionComponent<Props>;
 declare const StyledBadgeListItem: AnyStyledComponent;
 declare const StyledVerticalBadge: AnyStyledComponent;
-declare const StyledVerticalBadgeContent: AnyStyledComponent;
+declare const StyledBadgeContent: AnyStyledComponent;
 
 export {
   BadgeListItem,
   StyledBadgeListItem,
   StyledVerticalBadge,
   getIconColor,
-  StyledVerticalBadgeContent,
+  StyledBadgeContent,
   BadgeListItem as default,
 };

--- a/packages/orbit-components/src/BadgeList/BadgeListItem/index.jsx
+++ b/packages/orbit-components/src/BadgeList/BadgeListItem/index.jsx
@@ -9,7 +9,7 @@ import { ICON_COLORS } from "../../Icon/consts";
 import { StyledTooltipChildren } from "../../primitives/TooltipPrimitive";
 import { right } from "../../utils/rtl";
 
-import type { Props } from ".";
+import type { Props, Type } from ".";
 
 const getBackground = ({ theme, $type }) => {
   const tokens = {
@@ -22,12 +22,12 @@ const getBackground = ({ theme, $type }) => {
   return tokens[$type];
 };
 
-const getIconColor = type => {
+export const getIconColor = (type: Type): string => {
   if (type === TYPE_OPTIONS.NEUTRAL) return ICON_COLORS.SECONDARY;
   return type;
 };
 
-const StyledBadgeListItem = styled.li`
+export const StyledBadgeListItem: any = styled.li`
   ${({ theme }) => css`
     display: flex;
     flex-direction: row;
@@ -43,7 +43,7 @@ StyledBadgeListItem.defaultProps = {
   theme: defaultTheme,
 };
 
-const StyledVerticalBadge = styled.div`
+export const StyledVerticalBadge: any = styled.div`
   ${({ theme }) => css`
     background: ${getBackground};
     display: flex;
@@ -66,7 +66,7 @@ StyledVerticalBadge.defaultProps = {
   theme: defaultTheme,
 };
 
-const StyledVerticalBadgeContent = styled.div`
+export const StyledVerticalBadgeContent: any = styled.div`
   ${({ theme }) => css`
     display: inline-flex;
     align-items: center;

--- a/packages/orbit-components/src/BadgeList/BadgeListItem/index.jsx
+++ b/packages/orbit-components/src/BadgeList/BadgeListItem/index.jsx
@@ -66,7 +66,7 @@ StyledVerticalBadge.defaultProps = {
   theme: defaultTheme,
 };
 
-export const StyledVerticalBadgeContent: any = styled.div`
+export const StyledBadgeContent: any = styled.div`
   ${({ theme }) => css`
     display: inline-flex;
     align-items: center;
@@ -83,7 +83,7 @@ export const StyledVerticalBadgeContent: any = styled.div`
 `;
 
 // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198
-StyledVerticalBadgeContent.defaultProps = {
+StyledBadgeContent.defaultProps = {
   theme: defaultTheme,
 };
 
@@ -99,11 +99,11 @@ const BadgeListItem = ({
       <StyledVerticalBadge $type={type} aria-hidden>
         {React.isValidElement(icon) && React.cloneElement(icon, { color: getIconColor(type) })}
       </StyledVerticalBadge>
-      <StyledVerticalBadgeContent>
+      <StyledBadgeContent>
         <Text type="secondary" size="small" as="span" strikeThrough={strikeThrough}>
           {children}
         </Text>
-      </StyledVerticalBadgeContent>
+      </StyledBadgeContent>
     </StyledBadgeListItem>
   );
 };

--- a/packages/orbit-components/src/BadgeList/BadgeListItem/index.jsx.flow
+++ b/packages/orbit-components/src/BadgeList/BadgeListItem/index.jsx.flow
@@ -17,6 +17,6 @@ export type Props = {|
 declare export var getIconColor: (type: Type) => string;
 declare export var StyledBadgeListItem: StyledComponent<any, any, HTMLDivElement>;
 declare export var StyledVerticalBadge: StyledComponent<any, any, HTMLDivElement>;
-declare export var StyledVerticalBadgeContent: StyledComponent<any, any, HTMLDivElement>;
+declare export var StyledBadgeContent: StyledComponent<any, any, HTMLDivElement>;
 
 declare export default React.ComponentType<Props>;

--- a/packages/orbit-components/src/BadgeList/BadgeListItem/index.jsx.flow
+++ b/packages/orbit-components/src/BadgeList/BadgeListItem/index.jsx.flow
@@ -4,7 +4,7 @@ import type { StyledComponent } from "styled-components";
 
 import type { Globals } from "../../common/common.js.flow";
 
-export type Type =  "neutral" | "info" | "success" | "warning" | "critical";
+export type Type = "neutral" | "info" | "success" | "warning" | "critical";
 
 export type Props = {|
   +children: React.Node,

--- a/packages/orbit-components/src/BadgeList/BadgeListItem/index.jsx.flow
+++ b/packages/orbit-components/src/BadgeList/BadgeListItem/index.jsx.flow
@@ -1,14 +1,22 @@
 // @flow
 import * as React from "react";
+import type { StyledComponent } from "styled-components";
 
 import type { Globals } from "../../common/common.js.flow";
+
+export type Type =  "neutral" | "info" | "success" | "warning" | "critical";
 
 export type Props = {|
   +children: React.Node,
   +icon: React.Element<any>,
   +strikeThrough?: boolean,
-  +type?: "neutral" | "info" | "success" | "warning" | "critical",
+  +type?: Type,
   ...Globals,
 |};
+
+declare export var getIconColor: (type: Type) => string;
+declare export var StyledBadgeListItem: StyledComponent<any, any, HTMLDivElement>;
+declare export var StyledVerticalBadge: StyledComponent<any, any, HTMLDivElement>;
+declare export var StyledVerticalBadgeContent: StyledComponent<any, any, HTMLDivElement>;
 
 declare export default React.ComponentType<Props>;

--- a/packages/orbit-components/src/Itinerary/Itinerary.stories.jsx
+++ b/packages/orbit-components/src/Itinerary/Itinerary.stories.jsx
@@ -28,7 +28,6 @@ import Badge from "../Badge";
 import Text from "../Text";
 import CountryFlag from "../CountryFlag";
 import Heading from "../Heading";
-import { BadgeListItem } from "../BadgeList";
 import RenderInRtl from "../utils/rtl/RenderInRtl";
 import defaultTheme from "../defaultTheme";
 import Separator from "../Separator";
@@ -38,6 +37,7 @@ import Itinerary, {
   ItinerarySegmentBanner,
   ItinerarySegment,
   ItineraryBadgeList,
+  ItineraryBadgeListItem,
   ItinerarySegmentDetail,
   ItinerarySegmentStop,
   ItineraryStatus,
@@ -95,24 +95,34 @@ export const BadgeList = (): React.Node => {
   return (
     <Stack flex direction="column">
       <ItineraryBadgeList>
-        <BadgeListItem type="warning" icon={<SelfTransfer />}>
+        <ItineraryBadgeListItem type="warning" icon={<SelfTransfer />}>
           You’re departing from a different place
-        </BadgeListItem>
-        <BadgeListItem type="warning" icon={<SelfTransfer />}>
+        </ItineraryBadgeListItem>
+        <ItineraryBadgeListItem type="warning" icon={<SelfTransfer />}>
           Self transfer at Vienna is your responsibility
-        </BadgeListItem>
-        <BadgeListItem type="warning" icon={<Clock />}>
+        </ItineraryBadgeListItem>
+        <ItineraryBadgeListItem type="warning" icon={<Clock />}>
           1h 20m layover
-        </BadgeListItem>
-        <BadgeListItem icon={<BaggageSet />}>
+        </ItineraryBadgeListItem>
+        <ItineraryBadgeListItem icon={<BaggageSet />}>
           You must collect and recheck your baggage
-        </BadgeListItem>
-        <BadgeListItem icon={<Guarantee />}>
+        </ItineraryBadgeListItem>
+        <ItineraryBadgeListItem icon={<Guarantee />}>
           Connection protected by the Kiwi.com Guarantee
-        </BadgeListItem>
-        <BadgeListItem icon={<Info />} type="info">
+        </ItineraryBadgeListItem>
+        <ItineraryBadgeListItem icon={<Info />} type="info">
           Rooms from 35 € by Booking.com
-        </BadgeListItem>
+        </ItineraryBadgeListItem>
+      </ItineraryBadgeList>
+      <ItineraryBadgeList>
+        <ItineraryBadgeListItem
+          type="info"
+          icon={<Clock />}
+          withBackground
+          cancelledValue="1h 40m layover"
+        >
+          1h 20m layover
+        </ItineraryBadgeListItem>
       </ItineraryBadgeList>
     </Stack>
   );
@@ -261,7 +271,9 @@ export const Status = (): React.Node => {
           </ItinerarySegment>
         </ItineraryStatus>
         <ItineraryBadgeList spaceAfter="medium">
-          <BadgeListItem icon={<AlertCircle />}>The layover in Vienna is too short</BadgeListItem>
+          <ItineraryBadgeListItem icon={<AlertCircle />}>
+            The layover in Vienna is too short
+          </ItineraryBadgeListItem>
         </ItineraryBadgeList>
         <ItineraryStatus type="warning" label="Affected connection">
           <ItinerarySegment noElevation>
@@ -394,20 +406,20 @@ export const Stop = (): React.Node => {
             <Stack inline align="stretch">
               <ItinerarySegmentBanner>
                 <ItineraryBadgeList>
-                  <BadgeListItem type="warning" icon={<StarFull color="warning" />}>
+                  <ItineraryBadgeListItem type="warning" icon={<StarFull color="warning" />}>
                     <StyledText as="span" type="warning">
                       Hidden city hack:{" "}
                     </StyledText>{" "}
                     This itinerary finishes in New York (United States), but you’ll get off during
                     the layover
-                  </BadgeListItem>
-                  <BadgeListItem icon={<Visa />}>
+                  </ItineraryBadgeListItem>
+                  <ItineraryBadgeListItem icon={<Visa />}>
                     Check travel document requirements for all destinations, including passport,
                     visa and COVID-19 documents.
-                  </BadgeListItem>
-                  <BadgeListItem icon={<BaggageCheckedNone />}>
+                  </ItineraryBadgeListItem>
+                  <ItineraryBadgeListItem icon={<BaggageCheckedNone />}>
                     You can’t bring checked or cabin baggage.
-                  </BadgeListItem>
+                  </ItineraryBadgeListItem>
                 </ItineraryBadgeList>
               </ItinerarySegmentBanner>
             </Stack>
@@ -455,12 +467,12 @@ export const Stop = (): React.Node => {
             <Stack inline align="stretch">
               <ItinerarySegmentBanner>
                 <ItineraryBadgeList>
-                  <BadgeListItem type="info" icon={<StarFull color="info" />}>
+                  <ItineraryBadgeListItem type="info" icon={<StarFull color="info" />}>
                     <StyledText as="span" type="info" weight="bold">
                       Throwaway ticketing hack:{" "}
                     </StyledText>{" "}
                     You are saving money with this travel hack.
-                  </BadgeListItem>
+                  </ItineraryBadgeListItem>
                 </ItineraryBadgeList>
               </ItinerarySegmentBanner>
             </Stack>
@@ -528,9 +540,9 @@ export const Default = (): React.Node => {
         />
       </ItinerarySegment>
       <ItineraryBadgeList spaceAfter="medium">
-        <BadgeListItem icon={<Guarantee />}>
+        <ItineraryBadgeListItem icon={<Guarantee />}>
           Connection protected by the Kiwi.com Guarantee
-        </BadgeListItem>
+        </ItineraryBadgeListItem>
       </ItineraryBadgeList>
       <ItinerarySegment spaceAfter="large">
         <ItinerarySegmentStop
@@ -571,26 +583,26 @@ export const InsideModal = (): React.Node => {
                       }}
                     >
                       <ItineraryBadgeList>
-                        <BadgeListItem icon={<StarFull />} type="warning">
+                        <ItineraryBadgeListItem icon={<StarFull />} type="warning">
                           Hidden city hack: This itinerary finishes in New York (United States), but
                           you’ll get off during the layover.
-                        </BadgeListItem>
-                        <BadgeListItem icon={<Visa />}>
+                        </ItineraryBadgeListItem>
+                        <ItineraryBadgeListItem icon={<Visa />}>
                           Check travel document requirements for all destinations, including
                           passport, visa and COVID-19 documents.
-                        </BadgeListItem>
-                        <BadgeListItem icon={<BaggageCheckedNone />}>
+                        </ItineraryBadgeListItem>
+                        <ItineraryBadgeListItem icon={<BaggageCheckedNone />}>
                           You can’t bring checked or cabin baggage.
-                        </BadgeListItem>
+                        </ItineraryBadgeListItem>
                       </ItineraryBadgeList>
                     </ItinerarySegmentBanner>
                     <Separator />
                     <ItinerarySegmentBanner>
                       <ItineraryBadgeList>
-                        <BadgeListItem icon={<Location />} type="warning">
+                        <ItineraryBadgeListItem icon={<Location />} type="warning">
                           You’ll depart from a different place in Prague: Václav Havel Airport
                           Prague
-                        </BadgeListItem>
+                        </ItineraryBadgeListItem>
                       </ItineraryBadgeList>
                     </ItinerarySegmentBanner>
                   </Stack>
@@ -650,31 +662,31 @@ export const MultipleBanners = (): React.Node => {
               <Stack direction="column" align="stretch" spacing="XSmall">
                 <ItinerarySegmentBanner>
                   <ItineraryBadgeList>
-                    <BadgeListItem type="info" icon={<StarFull color="info" />}>
+                    <ItineraryBadgeListItem type="info" icon={<StarFull color="info" />}>
                       <Text as="span" type="info" weight="bold">
                         Throwaway ticketing hack:{" "}
                       </Text>{" "}
                       You are saving money with this travel hack.
-                    </BadgeListItem>
+                    </ItineraryBadgeListItem>
                   </ItineraryBadgeList>
                 </ItinerarySegmentBanner>
                 <Separator />
                 <ItinerarySegmentBanner>
                   <ItineraryBadgeList>
                     <Stack spacing="XSmall">
-                      <BadgeListItem icon={<Location color="secondary" />}>
+                      <ItineraryBadgeListItem icon={<Location color="secondary" />}>
                         You’ll depart from a different place in New York: John F. Kennedy
                         International.
-                      </BadgeListItem>
-                      <BadgeListItem icon={<Location color="secondary" />}>
+                      </ItineraryBadgeListItem>
+                      <ItineraryBadgeListItem icon={<Location color="secondary" />}>
                         You’ll depart from a different place in New York: John F. Kennedy
                         International.
-                      </BadgeListItem>
-                      <BadgeListItem icon={<Accommodation color="secondary" />}>
+                      </ItineraryBadgeListItem>
+                      <ItineraryBadgeListItem icon={<Accommodation color="secondary" />}>
                         We won’t cover your overnight stay. Hotel coverage is only available if the
                         disruption happens during the trip. If you want to avoid extra hotel costs
                         please choose a different alternative or a refund.
-                      </BadgeListItem>
+                      </ItineraryBadgeListItem>
                     </Stack>
                   </ItineraryBadgeList>
                 </ItinerarySegmentBanner>
@@ -705,15 +717,15 @@ export const MultipleBanners = (): React.Node => {
           </ItinerarySegment>
         </ItineraryStatus>
         <ItineraryBadgeList>
-          <BadgeListItem type="warning" icon={<Info color="warning" />}>
+          <ItineraryBadgeListItem type="warning" icon={<Info color="warning" />}>
             Changing stations is your responsibility.
-          </BadgeListItem>
-          <BadgeListItem type="warning" icon={<Clock />}>
+          </ItineraryBadgeListItem>
+          <ItineraryBadgeListItem type="warning" icon={<Clock />}>
             10h 20m layover
-          </BadgeListItem>
-          <BadgeListItem type="warning" icon={<SelfTransfer color="warning" />}>
+          </ItineraryBadgeListItem>
+          <ItineraryBadgeListItem type="warning" icon={<SelfTransfer color="warning" />}>
             You need to do a self-transfer in Prague.
-          </BadgeListItem>
+          </ItineraryBadgeListItem>
         </ItineraryBadgeList>
         <ItineraryStatus type="success" label="This part is new">
           <ItinerarySegment
@@ -721,25 +733,25 @@ export const MultipleBanners = (): React.Node => {
               <Stack>
                 <ItinerarySegmentBanner>
                   <ItineraryBadgeList>
-                    <BadgeListItem icon={<StarFull />} type="warning">
+                    <ItineraryBadgeListItem icon={<StarFull />} type="warning">
                       Hidden city hack: This itinerary finishes in New York (United States), but
                       you’ll get off during the layover.
-                    </BadgeListItem>
-                    <BadgeListItem icon={<Visa />}>
+                    </ItineraryBadgeListItem>
+                    <ItineraryBadgeListItem icon={<Visa />}>
                       Check travel document requirements for all destinations, including passport,
                       visa and COVID-19 documents.
-                    </BadgeListItem>
-                    <BadgeListItem icon={<BaggageCheckedNone />}>
+                    </ItineraryBadgeListItem>
+                    <ItineraryBadgeListItem icon={<BaggageCheckedNone />}>
                       You can’t bring checked or cabin baggage.
-                    </BadgeListItem>
+                    </ItineraryBadgeListItem>
                   </ItineraryBadgeList>
                 </ItinerarySegmentBanner>
                 <Separator />
                 <ItinerarySegmentBanner>
                   <ItineraryBadgeList>
-                    <BadgeListItem icon={<Location />} type="warning">
+                    <ItineraryBadgeListItem icon={<Location />} type="warning">
                       You’ll depart from a different place in Prague: Václav Havel Airport Prague
-                    </BadgeListItem>
+                    </ItineraryBadgeListItem>
                   </ItineraryBadgeList>
                 </ItinerarySegmentBanner>
               </Stack>
@@ -803,9 +815,9 @@ export const RTL = (): React.Node => {
           />
         </ItinerarySegment>
         <ItineraryBadgeList>
-          <BadgeListItem icon={<Guarantee />}>
+          <ItineraryBadgeListItem icon={<Guarantee />}>
             Connection protected by the Kiwi.com Guarantee
-          </BadgeListItem>
+          </ItineraryBadgeListItem>
         </ItineraryBadgeList>
         <ItinerarySegment spaceAfter="large">
           <ItinerarySegmentStop

--- a/packages/orbit-components/src/Itinerary/ItineraryBadgeList/ItineraryBadgeListItem.d.ts
+++ b/packages/orbit-components/src/Itinerary/ItineraryBadgeList/ItineraryBadgeListItem.d.ts
@@ -1,0 +1,13 @@
+import React from "react";
+
+import { Props as BadgeListItemProps } from "../../BadgeList/BadgeListItem";
+import Common from "../../common/common";
+
+export interface Props extends Common.SpaceAfter, BadgeListItemProps {
+  /** Content of the BadgeList (BadgeListItem) */
+  cancelledValue?: React.ReactNode;
+  withBackground?: boolean;
+}
+
+declare const ItineraryBadgeListItem: React.FunctionComponent<Props>;
+export default ItineraryBadgeListItem;

--- a/packages/orbit-components/src/Itinerary/ItineraryBadgeList/ItineraryBadgeListItem.jsx
+++ b/packages/orbit-components/src/Itinerary/ItineraryBadgeList/ItineraryBadgeListItem.jsx
@@ -1,0 +1,56 @@
+// @flow
+import * as React from "react";
+import { css } from "styled-components";
+
+import {
+  StyledBadgeListItem,
+  getIconColor,
+  StyledVerticalBadge,
+  StyledBadgeContent,
+} from "../../BadgeList/BadgeListItem";
+import Text from "../../Text";
+import Stack from "../../Stack";
+import type { Props } from "./ItineraryBadgeListItem";
+
+const ItineraryBadgeListItem = ({
+  children,
+  cancelledValue,
+  withBackground,
+  dataTest,
+  type = "secondary",
+  icon,
+  strikeThrough,
+}: Props): React.Node => {
+  return (
+    <StyledBadgeListItem data-test={dataTest}>
+      <StyledVerticalBadge $type={type} aria-hidden>
+        {React.isValidElement(icon) && React.cloneElement(icon, { color: getIconColor(type) })}
+      </StyledVerticalBadge>
+      <StyledBadgeContent
+        css={css`
+          margin-top: 4px;
+        `}
+      >
+        <Stack direction="column" spacing="XXSmall">
+          <Text
+            withBackground={withBackground}
+            type={withBackground ? type : "secondary"}
+            weight={withBackground ? "medium" : "normal"}
+            size="small"
+            as="span"
+            strikeThrough={strikeThrough}
+          >
+            {children}
+          </Text>
+          {cancelledValue && (
+            <Text type="secondary" size="small" as="span" strikeThrough weight="medium">
+              {cancelledValue}
+            </Text>
+          )}
+        </Stack>
+      </StyledBadgeContent>
+    </StyledBadgeListItem>
+  );
+};
+
+export default ItineraryBadgeListItem;

--- a/packages/orbit-components/src/Itinerary/ItineraryBadgeList/ItineraryBadgeListItem.jsx
+++ b/packages/orbit-components/src/Itinerary/ItineraryBadgeList/ItineraryBadgeListItem.jsx
@@ -34,7 +34,7 @@ const ItineraryBadgeListItem = ({
         <Stack direction="column" spacing="XXSmall">
           <Text
             withBackground={withBackground}
-            type={withBackground ? type : "secondary"}
+            type={withBackground && type !== "neutral" ? type : "secondary"}
             weight={withBackground ? "medium" : "normal"}
             size="small"
             as="span"

--- a/packages/orbit-components/src/Itinerary/ItineraryBadgeList/ItineraryBadgeListItem.jsx.flow
+++ b/packages/orbit-components/src/Itinerary/ItineraryBadgeList/ItineraryBadgeListItem.jsx.flow
@@ -2,7 +2,7 @@
 import * as React from "react";
 
 import type { spaceAfter } from "../../common/getSpacingToken";
-import type { Globals } from "../../common/common";
+import type { Globals } from "../../common/common.js.flow";
 import type { Props as CommonBadgeListItemProps } from "../../BadgeList/BadgeListItem";
 
 export type Props = {|

--- a/packages/orbit-components/src/Itinerary/ItineraryBadgeList/ItineraryBadgeListItem.jsx.flow
+++ b/packages/orbit-components/src/Itinerary/ItineraryBadgeList/ItineraryBadgeListItem.jsx.flow
@@ -1,0 +1,16 @@
+// @flow
+import * as React from "react";
+
+import type { spaceAfter } from "../../common/getSpacingToken";
+import type { Globals } from "../../common/common";
+import type { Props as CommonBadgeListItemProps } from "../../BadgeList/BadgeListItem";
+
+export type Props = {|
+  cancelledValue?: React.Node,
+  withBackground?: boolean,
+  ...CommonBadgeListItemProps,
+  ...Globals,
+  ...spaceAfter,
+|};
+
+declare export default React.ComponentType<Props>;

--- a/packages/orbit-components/src/Itinerary/ItineraryBadgeList/index.d.ts
+++ b/packages/orbit-components/src/Itinerary/ItineraryBadgeList/index.d.ts
@@ -2,6 +2,7 @@ import React from "react";
 
 import Common from "../../common/common";
 import { Props as BadgeListProps } from "../../BadgeList";
+import { Props as ItineraryBadgeListItemProps } from "./ItineraryBadgeListItem";
 
 export interface Props extends BadgeListProps, Common.SpaceAfter {
   /** Content of the BadgeList (BadgeListItem) */
@@ -9,4 +10,6 @@ export interface Props extends BadgeListProps, Common.SpaceAfter {
 }
 
 declare const ItineraryBadgeList: React.FunctionComponent<Props>;
+declare const ItineraryBadgeListItem: React.FunctionComponent<ItineraryBadgeListItemProps>;
 export default ItineraryBadgeList;
+export { ItineraryBadgeListItem };

--- a/packages/orbit-components/src/Itinerary/ItineraryBadgeList/index.jsx
+++ b/packages/orbit-components/src/Itinerary/ItineraryBadgeList/index.jsx
@@ -7,6 +7,7 @@ import themeDefault from "../../defaultTheme";
 import { left } from "../../utils/rtl";
 import BadgeList from "../../BadgeList";
 import { useWidth } from "../context";
+import ItineraryBadgeListItem from "./ItineraryBadgeListItem";
 
 import type { Props } from ".";
 
@@ -33,3 +34,4 @@ const ItineraryBadgeList = ({ children, spaceAfter, ...props }: Props): React.No
 };
 
 export default ItineraryBadgeList;
+export { ItineraryBadgeListItem };

--- a/packages/orbit-components/src/Itinerary/ItineraryBadgeList/index.jsx.flow
+++ b/packages/orbit-components/src/Itinerary/ItineraryBadgeList/index.jsx.flow
@@ -4,6 +4,7 @@ import type { StyledComponent } from "styled-components";
 
 import type { spaceAfter } from "../../common/getSpacingToken";
 import type { Props as BadgeListProps } from "../../BadgeList";
+import type { Props as ItineraryBadgeListItemProps } from "./ItineraryBadgeListItem";
 
 export type Props = {|
   +children: React.Node,
@@ -12,4 +13,5 @@ export type Props = {|
 |};
 
 declare export var StyledWrapper: StyledComponent<any, any, HTMLElement>;
+declare export var ItineraryBadgeListItem: React.ComponentType<ItineraryBadgeListItemProps>;
 declare export default React.ComponentType<Props>;

--- a/packages/orbit-components/src/Itinerary/index.d.ts
+++ b/packages/orbit-components/src/Itinerary/index.d.ts
@@ -4,6 +4,7 @@ import ItinerarySegment from "./ItinerarySegment";
 import ItineraryStatus from "./ItineraryStatus";
 import ItinerarySeparator from "./ItinerarySeparator";
 import ItineraryBadgeList from "./ItineraryBadgeList";
+import ItineraryBadgeListItem from "./ItineraryBadgeList/ItineraryBadgeListItem";
 import ItinerarySegmentStop from "./ItinerarySegment/ItinerarySegmentStop";
 import ItinerarySegmentDetail from "./ItinerarySegment/ItinerarySegmentDetail";
 import ItinerarySegmentBanner from "./ItinerarySegment/ItinerarySegmentBanner";
@@ -57,6 +58,7 @@ export {
   ItinerarySeparator,
   ItinerarySegmentStop,
   ItinerarySegmentBanner,
+  ItineraryBadgeListItem,
   ItinerarySegmentDetail,
   ItineraryStatus,
   ItineraryBadgeList,

--- a/packages/orbit-components/src/Itinerary/index.jsx
+++ b/packages/orbit-components/src/Itinerary/index.jsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import styled from "styled-components";
 
 import ItinerarySegmentBanner from "./ItinerarySegment/ItinerarySegmentBanner";
-import ItineraryBadgeList from "./ItineraryBadgeList";
+import ItineraryBadgeList, { ItineraryBadgeListItem } from "./ItineraryBadgeList";
 import ItinerarySegment from "./ItinerarySegment";
 import ItinerarySeparator from "./ItinerarySeparator";
 import ItineraryStatus from "./ItineraryStatus";
@@ -39,6 +39,7 @@ export {
   ItinerarySegmentStop,
   ItinerarySeparator,
   ItineraryBadgeList,
+  ItineraryBadgeListItem,
   ItineraryStatus,
 };
 export default Itinerary;

--- a/packages/orbit-components/src/Itinerary/index.jsx.flow
+++ b/packages/orbit-components/src/Itinerary/index.jsx.flow
@@ -9,6 +9,7 @@ import * as React from "react";
 import typeof ItinerarySegmentComponent from "./ItinerarySegment";
 import typeof ItinerarySeparatorComponent from "./ItinerarySeparator";
 import typeof ItineraryBadgeListComponent from "./ItineraryBadgeList";
+import typeof ItineraryBadgeListItemComponent from "./ItineraryBadgeList/ItineraryBadgeListItem";
 import typeof ItineraryStatusComponent from "./ItineraryStatus";
 import typeof ItinerarySegmentStopComponent from "./ItinerarySegment/ItinerarySegmentStop";
 import typeof ItinerarySegmentDetailComponent from "./ItinerarySegment/ItinerarySegmentDetail";
@@ -27,6 +28,7 @@ export type Props = {|
 declare export var ItinerarySegment: ItinerarySegmentComponent;
 declare export var ItinerarySeparator: ItinerarySeparatorComponent;
 declare export var ItineraryBadgeList: ItineraryBadgeListComponent;
+declare export var ItineraryBadgeListItem: ItineraryBadgeListItemComponent;
 declare export var ItineraryStatus: ItineraryStatusComponent;
 declare export var ItinerarySegmentStop: ItinerarySegmentStopComponent;
 declare export var ItinerarySegmentDetail: ItinerarySegmentDetailComponent;

--- a/packages/orbit-components/src/index.d.ts
+++ b/packages/orbit-components/src/index.d.ts
@@ -42,6 +42,7 @@ export {
   ItinerarySeparator,
   ItineraryStatus,
   ItineraryBadgeList,
+  ItineraryBadgeListItem,
   ItinerarySegmentDetail,
   ItinerarySegmentStop,
 } from "./Itinerary";

--- a/packages/orbit-components/src/index.js
+++ b/packages/orbit-components/src/index.js
@@ -70,6 +70,7 @@ export {
   default as Itinerary,
   ItinerarySegment,
   ItinerarySegmentBanner,
+  ItineraryBadgeListItem,
   ItinerarySeparator,
   ItineraryStatus,
   ItineraryBadgeList,

--- a/packages/orbit-components/src/index.js.flow
+++ b/packages/orbit-components/src/index.js.flow
@@ -55,6 +55,7 @@ import typeof ItinerarySegmentBannerType from "./Itinerary/ItinerarySegment/Itin
 import typeof ItineraryType from "./Itinerary";
 import typeof ItineraryStatusType from "./Itinerary/ItineraryStatus";
 import typeof ItineraryBadgeListType from "./Itinerary/ItineraryBadgeList";
+import typeof ItineraryBadgeListItemType from "./Itinerary/ItineraryBadgeList/ItineraryBadgeListItem";
 import typeof ItinerarySegmentStopType from "./Itinerary/ItinerarySegment/ItinerarySegmentStop";
 import typeof KeyValueType from "./KeyValue";
 import typeof ItinerarySegmentDetailType from "./Itinerary/ItinerarySegment/ItinerarySegmentDetail";
@@ -225,6 +226,7 @@ declare export var InputStepperStateless: InputStepperStatelessType;
 declare export var Itinerary: ItineraryType;
 declare export var ItineraryStatus: ItineraryStatusType;
 declare export var ItineraryBadgeList: ItineraryBadgeListType;
+declare export var ItineraryBadgeListItem: ItineraryBadgeListItemType;
 declare export var ItinerarySegment: ItinerarySegmentType;
 declare export var ItinerarySegmentBanner: ItinerarySegmentBannerType;
 declare export var ItinerarySegmentStop: ItinerarySegmentStopType;


### PR DESCRIPTION
Add new `ItineraryBadgeListItem`, which is a slightly modified version of the original BadgeListItem for Itinerary. 
[Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1664876251315189?thread_ts=1664875481.009669&cid=CAMS40F7B)
 Storybook: https://orbit-mainframev-feat-itinerary-badge-list-item.surge.sh