### PR TITLE
fix(Card): Adjust icon size on expandable card

### DIFF
--- a/packages/orbit-components/src/Card/components/Header/index.jsx
+++ b/packages/orbit-components/src/Card/components/Header/index.jsx
@@ -18,6 +18,8 @@ import type { Props } from ".";
 const ChevronIcon = styled(ChevronDown)`
   transform: ${({ expanded }) => expanded && "rotate(-180deg)"};
   transition: ${transition(["transform"], "fast", "ease-in-out")};
+  width: 20px;
+  height: 20px;
 `;
 
 // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/3653#issuecomment-568539198


### PR DESCRIPTION
[ORBIT-1977](https://jira.kiwi.com/browse/ORBIT-1977)
Icon size was inconsistent with the design. I has been adjusted.

[Slack thread](https://skypicker.slack.com/archives/GSGN9BN6Q/p1664975130259849)
 Storybook: https://orbit-mainframev-fix-card-icon-size.surge.sh