### PR TITLE
fix(Tooltip): add max-width and render as flex instead of block

### DIFF
--- a/packages/orbit-components/src/primitives/TooltipPrimitive/__tests__/__snapshots__/index.test.jsx.snap
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/__tests__/__snapshots__/index.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`Tooltip it should match snapshot 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  max-width: 100%;
 }
 
 .c0:focus:active {

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/index.jsx
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/index.jsx
@@ -12,16 +12,13 @@ import useStateWithTimeout from "../../hooks/useStateWithTimeout";
 import type { Props } from ".";
 
 export const StyledTooltipChildren: any = styled.span`
-  ${({ block }) =>
-    !block &&
-    css`
-      display: inline-flex;
-    `};
-  &:focus:active {
-    outline: none;
-  }
-  ${({ enabled, removeUnderlinedText }) =>
-    enabled &&
+  ${({ block, enabled, removeUnderlinedText }) => css`
+    display: ${block ? "flex" : "inline-flex"};
+    max-width: 100%;
+    &:focus:active {
+      outline: none;
+    }
+    ${enabled &&
     !removeUnderlinedText &&
     css`
       ${StyledText} {
@@ -30,10 +27,11 @@ export const StyledTooltipChildren: any = styled.span`
         text-decoration: underline currentColor dotted;
       }
     `};
-  /* enable event bubbling for disabled children, e.g. buttons */
-  [disabled] {
-    pointer-events: none;
-  }
+    /* enable event bubbling for disabled children, e.g. buttons */
+    [disabled] {
+      pointer-events: none;
+    }
+  `}
 `;
 
 const TooltipPrimitive = ({


### PR DESCRIPTION
[Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1665477949634829)
 Storybook: https://orbit-mainframev-fix-tooltip-req.surge.sh