### PR TITLE
fix(docs): fix text and layout redirects

### DIFF
--- a/docs/src/documentation/01-getting-started/02-for-developers.mdx
+++ b/docs/src/documentation/01-getting-started/02-for-developers.mdx
@@ -76,7 +76,7 @@ yarn add @types/styled-components -D
 
 ## Main Sections
 
-- [Components](/components/action/button/)
+- [Components](/components/)
 - [Icons](/foundation/icons/)
 - [Right to left languages](/development/utilities/rtl-languages/)
 - [Theming](https://github.com/kiwicom/orbit/blob/master/.github/theming.md)

--- a/docs/src/documentation/02-foundation/02-accessibility.mdx
+++ b/docs/src/documentation/02-foundation/02-accessibility.mdx
@@ -182,7 +182,7 @@ Lines can be shorter as well, down to 50 (or 25) characters.
 Justifying text to both the right and left can create uneven spacing
 ("[rivers of white](<https://en.wikipedia.org/wiki/River_(typography)>)"),
 which makes it hard to follow the flow of the text.
-That's why Orbit [Text](/components/text/text/) components don't offer this as an alignment option.
+That's why Orbit [Text](/components/text/) components don't offer this as an alignment option.
 Base the text alignment off the directionality of the language.
 
 ## Bi-directionality (RTL)

--- a/docs/src/documentation/03-components/09-text/text/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/09-text/text/01-guidelines.mdx
@@ -1,7 +1,5 @@
 ---
 title: Guidelines
-redirect_from:
-  - /components/text/
 ---
 
 <ReactExample exampleId="Text-default" />

--- a/docs/src/documentation/03-components/09-text/text/02-react.mdx
+++ b/docs/src/documentation/03-components/09-text/text/02-react.mdx
@@ -1,7 +1,5 @@
 ---
 title: React
-redirect_from:
-  - /components/text/react/
 ---
 
 import TextReadMe from "@kiwicom/orbit-components/src/Text/README.md";

--- a/docs/src/documentation/03-components/12-layout/layout/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/12-layout/layout/01-guidelines.mdx
@@ -1,7 +1,5 @@
 ---
 title: Guidelines
-redirect_from:
-  - /components/layout/
 ---
 
 import ResponsiveSimilarContentSnippet from "snippets/responsive-similar-content.mdx";

--- a/docs/src/documentation/03-components/12-layout/layout/02-react.mdx
+++ b/docs/src/documentation/03-components/12-layout/layout/02-react.mdx
@@ -1,7 +1,5 @@
 ---
 title: React
-redirect_from:
-  - /components/layout/react/
 ---
 
 import LayoutReadMe from "@kiwicom/orbit-components/src/Layout/README.md";


### PR DESCRIPTION
Text and Layout were redirecting to the components page. There was also a wrong link to the Button's documentation on the Developers main page.

Routes fixed:
- [Components page](https://orbit.kiwi/components/):
  - Clicking the Layout button now redirects to the page with all layout components.
  - Clicking the Text button now redirects to the page with all text components
- [Developers main page](https://orbit.kiwi/getting-started/for-developers/):
  - Clicking the Components link under **_Main Sections_** now redirects to the components main page.
 Storybook: https://orbit-mainframev-fix-layout-docs-link.surge.sh