### PR TITLE
fix(Table): responsive shadow was not correct

### DIFF
--- a/packages/orbit-components/src/Table/index.jsx
+++ b/packages/orbit-components/src/Table/index.jsx
@@ -117,9 +117,7 @@ const Table = ({
   const handleScroll = () => {
     if (shadows && inner && table && outer) {
       setLeft(inner.current?.scrollLeft >= 5);
-      setRight(
-        inner.current?.scrollLeft + outer.current?.clientWidth <= table.current?.clientWidth,
-      );
+      setRight(inner.current?.scrollLeft + outer.current?.clientWidth < table.current?.clientWidth);
     }
   };
 


### PR DESCRIPTION
While working on the new Table for Docs, I noticed this small bug on the Table. The shadow on the mobile version was not disappearing even if the user scrolled all the way horizontally.

Before:
![before](https://user-images.githubusercontent.com/6265045/196204525-850e9c79-1e52-4a56-b99c-5075cd4681bf.gif)

Now:
![now](https://user-images.githubusercontent.com/6265045/196204401-750c99fc-1069-410b-8461-29efc121bda6.gif)

 Storybook: https://orbit-mainframev-fix-table-shadow-responsiveness.surge.sh