### PR TITLE
revert(Stack): remove gap change

### DIFF
--- a/packages/orbit-components/src/LinkList/README.md
+++ b/packages/orbit-components/src/LinkList/README.md
@@ -21,14 +21,15 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in LinkList component.
 
-| Name         | Type                  | Default    | Description                            |
-| :----------- | :-------------------- | :--------- | :------------------------------------- |
-| **children** | `React.Node`          |            | The content of the LinkList            |
-| dataTest     | `string`              |            | Optional prop for testing purposes.    |
-| id           | `string`              |            | Set `id` for `LinkList`                |
-| direction    | [`enum`](#enum)       | `"column"` | The size of the LinkList.              |
-| indent       | `boolean`             |            | Indenting LinkList item                |
-| spacing      | [`spacing`](#spacing) | `"medium"` | The spacing between LinkList children. |
+| Name         | Type                  | Default    | Description                                                        |
+| :----------- | :-------------------- | :--------- | :----------------------------------------------------------------- |
+| **children** | `React.Node`          |            | The content of the LinkList                                        |
+| dataTest     | `string`              |            | Optional prop for testing purposes.                                |
+| id           | `string`              |            | Set `id` for `LinkList`                                            |
+| direction    | [`enum`](#enum)       | `"column"` | The size of the LinkList.                                          |
+| indent       | `boolean`             |            | Indenting LinkList item                                            |
+| spacing      | [`spacing`](#spacing) | `"medium"` | The spacing between LinkList children.                             |
+| legacy       | `boolean`             | `false`    | If `true` will use `margin` for spacing, if `false` will use `gap` |
 
 ### enum
 

--- a/packages/orbit-components/src/LinkList/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/LinkList/__tests__/index.test.jsx
@@ -16,8 +16,11 @@ describe("#LinkList", () => {
 
     expect(screen.getByText("link 1")).toBeInTheDocument();
     expect(screen.getByTestId("kek")).toBeInTheDocument();
-    expect(screen.getByTestId("kek")).toHaveStyle({
-      gap: "40px",
+    expect(screen.getAllByRole("listitem")[0]).toHaveStyle({
+      marginBottom: "40px",
+    });
+    expect(screen.getAllByRole("listitem")[2]).toHaveStyle({
+      marginBottom: "0px",
     });
   });
 });

--- a/packages/orbit-components/src/LinkList/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/LinkList/__tests__/index.test.jsx
@@ -7,7 +7,7 @@ import LinkList from "..";
 describe("#LinkList", () => {
   it("should have expected dom output", () => {
     render(
-      <LinkList dataTest="kek" spacing="XXLarge">
+      <LinkList legacy dataTest="kek" spacing="XXLarge">
         <div>link 1</div>
         <div>link 2</div>
         <div>link 3</div>
@@ -21,6 +21,20 @@ describe("#LinkList", () => {
     });
     expect(screen.getAllByRole("listitem")[2]).toHaveStyle({
       marginBottom: "0px",
+    });
+  });
+
+  it("should have spacing based on gap", () => {
+    render(
+      <LinkList dataTest="kek" spacing="XXLarge">
+        <div>link 1</div>
+        <div>link 2</div>
+        <div>link 3</div>
+      </LinkList>,
+    );
+
+    expect(screen.getByTestId("kek")).toHaveStyle({
+      gap: "40px",
     });
   });
 });

--- a/packages/orbit-components/src/LinkList/index.d.ts
+++ b/packages/orbit-components/src/LinkList/index.d.ts
@@ -9,6 +9,7 @@ import { Spacing } from "../Stack";
 export interface Props extends Common.Global {
   readonly direction?: "column" | "row";
   readonly indent?: boolean;
+  readonly legacy?: boolean;
   readonly spacing?: Spacing;
   readonly children: React.ReactNode;
 }

--- a/packages/orbit-components/src/LinkList/index.jsx
+++ b/packages/orbit-components/src/LinkList/index.jsx
@@ -1,6 +1,7 @@
 // @flow
 import * as React from "react";
 import styled, { css } from "styled-components";
+import type { CSSRules } from "styled-components";
 
 import { left, rtlSpacing } from "../utils/rtl";
 import mq from "../utils/mediaQuery";
@@ -13,15 +14,16 @@ import getDirectionSpacingTemplate from "../Stack/helpers/getDirectionSpacingTem
 import type { Props } from ".";
 
 const StyledLinkList = styled.ul`
-  ${({ indent, direction, theme }) => css`
-  display: flex;
-  flex-direction: ${direction};
-  width: 100%;
-  margin: 0;
-  padding: 0;
-  padding-${left}: ${indent && theme.orbit.spaceXXSmall};
-  list-style: none;
-  font-size: ${theme.orbit.fontSizeTextNormal};
+  ${({ indent, direction, theme, legacy, spacing }) => css`
+    display: flex;
+    flex-direction: ${direction};
+    width: 100%;
+    margin: 0;
+    gap: ${!legacy && spacing && getSpacing({ theme })[spacing]};
+    padding: 0;
+    padding-${left}: ${indent && theme.orbit.spaceXXSmall};
+    list-style: none;
+    font-size: ${theme.orbit.fontSizeTextNormal};
   `};
 `;
 
@@ -30,7 +32,7 @@ StyledLinkList.defaultProps = {
   theme: defaultTheme,
 };
 
-const resolveSpacings = ({ spacing, direction, ...props }) => {
+const resolveSpacings = ({ spacing, legacy, direction, ...props }): CSSRules | null => {
   const margin =
     spacing &&
     direction &&
@@ -38,6 +40,8 @@ const resolveSpacings = ({ spacing, direction, ...props }) => {
       "__spacing__",
       getSpacing(props)[spacing],
     );
+
+  if (!legacy) return null;
 
   return css`
     margin: ${margin && rtlSpacing(margin)};
@@ -77,15 +81,22 @@ StyledNavigationLinkListChild.defaultProps = {
 const LinkList = ({
   direction = "column",
   indent,
+  legacy = false,
   spacing = SPACINGS.MEDIUM,
   children,
   dataTest,
 }: Props): React.Node => (
-  <StyledLinkList indent={indent} direction={direction} data-test={dataTest}>
+  <StyledLinkList
+    indent={indent}
+    direction={direction}
+    data-test={dataTest}
+    legacy={legacy}
+    spacing={spacing}
+  >
     {React.Children.map(children, item => {
       if (React.isValidElement(item)) {
         return (
-          <StyledNavigationLinkListChild direction={direction} spacing={spacing}>
+          <StyledNavigationLinkListChild direction={direction} spacing={spacing} legacy={legacy}>
             {item}
           </StyledNavigationLinkListChild>
         );

--- a/packages/orbit-components/src/LinkList/index.jsx
+++ b/packages/orbit-components/src/LinkList/index.jsx
@@ -2,26 +2,26 @@
 import * as React from "react";
 import styled, { css } from "styled-components";
 
-import { left } from "../utils/rtl";
+import { left, rtlSpacing } from "../utils/rtl";
 import mq from "../utils/mediaQuery";
 import { StyledTextLink } from "../TextLink";
 import defaultTheme from "../defaultTheme";
 import { SPACINGS } from "../utils/layout/consts";
 import getSpacing from "../Stack/helpers/getSpacing";
+import getDirectionSpacingTemplate from "../Stack/helpers/getDirectionSpacingTemplate";
 
 import type { Props } from ".";
 
 const StyledLinkList = styled.ul`
-  ${({ $direction, indent, theme, $spacing }) => css`
-    display: flex;
-    flex-direction: ${$direction};
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    gap: ${getSpacing({ theme })[$spacing]};
-    padding-${left}: ${indent && theme.orbit.spaceXXSmall};
-    list-style: none;
-    font-size: ${theme.orbit.fontSizeTextNormal};
+  ${({ indent, direction, theme }) => css`
+  display: flex;
+  flex-direction: ${direction};
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  padding-${left}: ${indent && theme.orbit.spaceXXSmall};
+  list-style: none;
+  font-size: ${theme.orbit.fontSizeTextNormal};
   `};
 `;
 
@@ -30,10 +30,29 @@ StyledLinkList.defaultProps = {
   theme: defaultTheme,
 };
 
+const resolveSpacings = ({ spacing, direction, ...props }) => {
+  const margin =
+    spacing &&
+    direction &&
+    String(getDirectionSpacingTemplate(direction)).replace(
+      "__spacing__",
+      getSpacing(props)[spacing],
+    );
+
+  return css`
+    margin: ${margin && rtlSpacing(margin)};
+    &:last-child {
+      margin: 0;
+    }
+  `;
+};
+
 const StyledNavigationLinkListChild = styled(({ theme, direction, ...props }) => <li {...props} />)`
   ${StyledTextLink} {
     text-decoration: none;
   }
+
+  ${resolveSpacings};
 
   ${({ direction }) =>
     direction === "column" &&
@@ -60,20 +79,13 @@ const LinkList = ({
   indent,
   spacing = SPACINGS.MEDIUM,
   children,
-  id,
   dataTest,
 }: Props): React.Node => (
-  <StyledLinkList
-    indent={indent}
-    $spacing={spacing}
-    $direction={direction}
-    data-test={dataTest}
-    id={id}
-  >
+  <StyledLinkList indent={indent} direction={direction} data-test={dataTest}>
     {React.Children.map(children, item => {
       if (React.isValidElement(item)) {
         return (
-          <StyledNavigationLinkListChild direction={direction}>
+          <StyledNavigationLinkListChild direction={direction} spacing={spacing}>
             {item}
           </StyledNavigationLinkListChild>
         );

--- a/packages/orbit-components/src/LinkList/index.jsx.flow
+++ b/packages/orbit-components/src/LinkList/index.jsx.flow
@@ -8,6 +8,7 @@ export type Props = {|
   ...Globals,
   direction?: "column" | "row",
   spacing?: Spacing,
+  legacy?: boolean,
   indent?: boolean,
   children: React.Node,
 |};

--- a/packages/orbit-components/src/Stack/README.md
+++ b/packages/orbit-components/src/Stack/README.md
@@ -40,6 +40,7 @@ Table below contains all types of the props available in Stack component.
 | spaceAfter   | `enum`                     |            | Additional `padding` to bottom of the Stack. [See this doc](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
 | tablet       | [`Object`](#media-queries) |            | Object for setting up properties for the tablet viewport. [See Media queries](#media-queries)                                                                  |
 | wrap         | `boolean`                  | `false`    | If `true`, the Stack will have `flex-wrap` set to `wrap`, otherwise it will be `nowrap`.                                                                       |
+| legacy       | `boolean`                  | `false`    | If `true`, the Stack will be using `margins` instead of `gap`                                                                                                  |
 
 ### Media Queries
 

--- a/packages/orbit-components/src/Stack/Stack.stories.jsx
+++ b/packages/orbit-components/src/Stack/Stack.stories.jsx
@@ -332,6 +332,7 @@ NestedExample.story = {
 };
 
 export const Playground = (): React.Node => {
+  const legacy = boolean("legacy", true);
   const dataTest = text("dataTest", "test");
   const flex = boolean("flex", true);
   const inline = boolean("Inline", false);
@@ -367,6 +368,7 @@ export const Playground = (): React.Node => {
       dataTest={dataTest}
       flex={flex}
       direction={direction}
+      legacy={legacy}
       align={align}
       justify={justify}
       wrap={wrap}

--- a/packages/orbit-components/src/Stack/helpers/__tests__/shouldUseFlex.test.js
+++ b/packages/orbit-components/src/Stack/helpers/__tests__/shouldUseFlex.test.js
@@ -1,0 +1,22 @@
+// @flow
+import shouldUseFlex from "../shouldUseFlex";
+
+describe("#shouldUseFlex", () => {
+  it("should return true", () => {
+    const props = {
+      children: "kek",
+      wrap: true,
+    };
+
+    expect(shouldUseFlex(props)).toBe(true);
+  });
+
+  it("should return false", () => {
+    const props = {
+      children: "kek",
+      spaceAfter: "large",
+    };
+
+    expect(shouldUseFlex(props)).toBe(false);
+  });
+});

--- a/packages/orbit-components/src/Stack/helpers/getChildrenMargin.js
+++ b/packages/orbit-components/src/Stack/helpers/getChildrenMargin.js
@@ -1,0 +1,43 @@
+// @flow
+import { css } from "styled-components";
+
+import getSpacing from "./getSpacing";
+import { rtlSpacing } from "../../utils/rtl";
+import { SPACINGS } from "../../utils/layout/consts";
+import getProperty from "./getProperty";
+import { QUERIES } from "../../utils/mediaQuery/consts";
+import type { GetChildrenMargin } from "./getChildrenMargin";
+import getDirectionSpacingTemplate from "./getDirectionSpacingTemplate";
+
+const isMobileViewport = viewport =>
+  viewport === "smallMobile" || viewport === "mediumMobile" || viewport === "largeMobile";
+
+const getChildrenMargin: GetChildrenMargin = ({ viewport, index, devices }) => props => {
+  if (props[viewport] || viewport === QUERIES.DESKTOP) {
+    const spacing = getProperty("spacing", { index, devices }, props);
+    if (spacing === SPACINGS.NONE) return false;
+    const isMobile = isMobileViewport(viewport);
+    const direction = getProperty("direction", { index, devices }, props);
+    const margin =
+      spacing &&
+      direction &&
+      String(getDirectionSpacingTemplate(direction)).replace(
+        "__spacing__",
+        getSpacing(props)[spacing],
+      );
+    return css`
+      & > * {
+        margin: ${margin && rtlSpacing(margin)}!important;
+        ${isMobile &&
+        css`
+          &:last-child {
+            margin: 0 !important;
+          }
+        `};
+      }
+    `;
+  }
+  return false;
+};
+
+export default getChildrenMargin;

--- a/packages/orbit-components/src/Stack/helpers/getChildrenMargin.js.flow
+++ b/packages/orbit-components/src/Stack/helpers/getChildrenMargin.js.flow
@@ -1,0 +1,14 @@
+// @flow
+import type { InterpolationBase } from "styled-components";
+
+import type { Devices } from "../../utils/mediaQuery/consts";
+import type { Props, SmallMobile } from "..";
+import type { ThemeProps } from "../../defaultTheme";
+
+export type GetChildrenMargin = ({|
+  viewport: Devices,
+  index: number,
+  devices: Devices[],
+|}) => ({| ...Props, ...SmallMobile, ...ThemeProps |}) => InterpolationBase;
+
+declare export default GetChildrenMargin;

--- a/packages/orbit-components/src/Stack/helpers/getDirectionSpacingTemplate.js
+++ b/packages/orbit-components/src/Stack/helpers/getDirectionSpacingTemplate.js
@@ -1,0 +1,20 @@
+// @flow
+import { DIRECTIONS } from "../../utils/layout/consts";
+import type { GetDirectionSpacingTemplate } from "./getDirectionSpacingTemplate";
+
+const getDirectionSpacingTemplate: GetDirectionSpacingTemplate = direction => {
+  switch (direction) {
+    case DIRECTIONS.COLUMN:
+      return "0 0 __spacing__ 0";
+    case DIRECTIONS.ROW:
+      return "0 __spacing__ 0 0";
+    case DIRECTIONS.COLUMNREVERSE:
+      return "__spacing__ 0 0 0";
+    case DIRECTIONS.ROWREVERSE:
+      return "0 0 0 __spacing__";
+    default:
+      return "0 0 __spacing__ 0";
+  }
+};
+
+export default getDirectionSpacingTemplate;

--- a/packages/orbit-components/src/Stack/helpers/getDirectionSpacingTemplate.js.flow
+++ b/packages/orbit-components/src/Stack/helpers/getDirectionSpacingTemplate.js.flow
@@ -1,0 +1,4 @@
+// @flow
+export type GetDirectionSpacingTemplate = (direction: ?string) => string | boolean;
+
+declare export default GetDirectionSpacingTemplate;

--- a/packages/orbit-components/src/Stack/helpers/getGap.js
+++ b/packages/orbit-components/src/Stack/helpers/getGap.js
@@ -4,10 +4,10 @@ import { css } from "styled-components";
 import getSpacing from "./getSpacing";
 import getProperty from "./getProperty";
 import { QUERIES } from "../../utils/mediaQuery/consts";
-import type { GetGap } from "./getGap";
 import { rtlSpacing } from "../../utils/rtl";
 import { DIRECTIONS } from "../../utils/layout/consts";
 import type { Direction, Spacing } from "..";
+import type { GetGap } from "./getGap";
 
 const getDirectionSpacingTemplate = (direction: Direction | Spacing): string => {
   switch (direction) {

--- a/packages/orbit-components/src/Stack/index.d.ts
+++ b/packages/orbit-components/src/Stack/index.d.ts
@@ -38,6 +38,7 @@ export interface Props extends Common.Global, Common.SpaceAfter {
   readonly wrap?: boolean;
   readonly grow?: boolean;
   readonly shrink?: boolean;
+  readonly legacy?: boolean;
   readonly basis?: string;
   readonly align?: Align;
   readonly justify?: Justify;

--- a/packages/orbit-components/src/Stack/index.jsx
+++ b/packages/orbit-components/src/Stack/index.jsx
@@ -7,9 +7,10 @@ import mediaQueries from "../utils/mediaQuery";
 import { ALIGNS, JUSTIFY, DIRECTIONS, SPACINGS } from "../utils/layout/consts";
 import { DEVICES } from "../utils/mediaQuery/consts";
 import { isDefined } from "../utils/layout";
-import getViewportFlexStyles from "./helpers/getViewportFlexStyles";
-import getGap from "./helpers/getGap";
 import shouldUseFlex from "./helpers/shouldUseFlex";
+import getViewportFlexStyles from "./helpers/getViewportFlexStyles";
+import getChildrenMargin from "./helpers/getChildrenMargin";
+import getGap from "./helpers/getGap";
 
 import type { Props } from ".";
 
@@ -25,12 +26,16 @@ const StyledStack = styled(({ className, element: Element, children, dataTest })
       viewport in mediaQueries
         ? mediaQueries[viewport](css`
             ${isDefined(props[viewport]) && getViewportFlexStyles(viewport)};
-            ${getGap({ viewport, index, devices })}
+            ${props.legacy
+              ? getChildrenMargin({ viewport, index, devices })
+              : getGap({ viewport, index, devices })};
           `)
         : viewport === "smallMobile" &&
           css`
             ${getViewportFlexStyles(viewport)};
-            ${getGap({ viewport, index, devices })}
+            ${props.legacy
+              ? getChildrenMargin({ viewport, index, devices })
+              : getGap({ viewport, index, devices })};
           `,
     )};
 `;
@@ -46,6 +51,7 @@ const Stack = (props: Props): React.Node => {
     inline = false,
     spacing = SPACINGS.MEDIUM,
     align = ALIGNS.START,
+    legacy = false,
     justify = JUSTIFY.START,
     grow = true,
     wrap = false,
@@ -80,6 +86,7 @@ const Stack = (props: Props): React.Node => {
   return (
     <StyledStack
       dataTest={dataTest}
+      legacy={legacy}
       flex={isFlex}
       smallMobile={smallMobile}
       mediumMobile={mediumMobile}

--- a/packages/orbit-components/src/Stack/index.jsx.flow
+++ b/packages/orbit-components/src/Stack/index.jsx.flow
@@ -48,6 +48,7 @@ export type Props = {|
   ...Globals,
   ...MediaQuery,
   +flex?: boolean,
+  +legacy?: boolean,
   +mediumMobile?: MediaQuery,
   +largeMobile?: MediaQuery,
   +tablet?: MediaQuery,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8263,7 +8263,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@>=16.9.0":
+"@types/react-dom@>=16.9.0", "@types/react-dom@^17.0.9":
   version "17.0.17"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
   integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==


### PR DESCRIPTION
We forgot about margin collapsing and that created unnecessary complications on FE repositories, let's revert for now and left it as a feature change. When everybody will be ready for that. 

For LinkList just reverted as it was before
 Storybook: https://orbit-mainframev-revert-spacing-changes.surge.sh