### PR TITLE
refactor(docs): rename trail to breadcrumbs

### DIFF
--- a/docs/__tests__/__snapshots__/gatsby-node.test.ts.snap
+++ b/docs/__tests__/__snapshots__/gatsby-node.test.ts.snap
@@ -1,10 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gatsby-node registering documents should create trail nodes 1`] = `
+exports[`gatsby-node registering documents should create breadcrumb nodes 1`] = `
 Array [
   Object {
-    "file": "01-getting-started/01-for-designers/01-kiwi.mdx",
-    "trail": Array [
+    "breadcrumbs": Array [
       Object {
         "name": "Getting started",
         "url": "/getting-started/",
@@ -14,10 +13,10 @@ Array [
         "url": "/getting-started/for-designers/",
       },
     ],
+    "file": "01-getting-started/01-for-designers/01-kiwi.mdx",
   },
   Object {
-    "file": "01-getting-started/02-for-developers.mdx",
-    "trail": Array [
+    "breadcrumbs": Array [
       Object {
         "name": "Getting started",
         "url": "/getting-started/",
@@ -27,6 +26,7 @@ Array [
         "url": "/getting-started/for-developers/",
       },
     ],
+    "file": "01-getting-started/02-for-developers.mdx",
   },
 ]
 `;

--- a/docs/__tests__/gatsby-node.test.ts
+++ b/docs/__tests__/gatsby-node.test.ts
@@ -65,7 +65,7 @@ const cache = {
   set: async (key, value) => cacheMap.set(key, value),
 };
 
-async function createTrails() {
+async function createBreadcrumbs() {
   const files = globby.sync(ROOT);
 
   await Promise.all(
@@ -78,7 +78,7 @@ async function createTrails() {
       }),
   );
 
-  const trails = await Promise.all(
+  const breadcrumbs = await Promise.all(
     files
       .filter(file => !file.endsWith("meta.yml"))
       .sort()
@@ -95,11 +95,11 @@ async function createTrails() {
         // @ts-expect-error TODO
         await onCreateNode({ cache, node, getNode, actions });
         // @ts-expect-error TODO
-        return { file: relativePath, trail: node.fields.trail };
+        return { file: relativePath, breadcrumbs: node.fields.breadcrumbs };
       }),
   );
 
-  return trails;
+  return breadcrumbs;
 }
 
 afterEach(() => {
@@ -170,7 +170,7 @@ describe("gatsby-node", () => {
       `);
     });
 
-    it("should create trail nodes", async () => {
+    it("should create breadcrumb nodes", async () => {
       vol.fromJSON(
         {
           "./01-getting-started/meta.yml": dedent`
@@ -196,7 +196,7 @@ describe("gatsby-node", () => {
         ROOT,
       );
 
-      expect(await createTrails()).toMatchSnapshot();
+      expect(await createBreadcrumbs()).toMatchSnapshot();
     });
   });
 
@@ -247,7 +247,7 @@ describe("gatsby-node", () => {
         ROOT,
       );
 
-      await createTrails();
+      await createBreadcrumbs();
       // @ts-expect-error TODO
       await createPages({
         graphql: () =>

--- a/docs/src/components/Breadcrumbs.tsx
+++ b/docs/src/components/Breadcrumbs.tsx
@@ -22,25 +22,25 @@ const StyledListItem = styled.li<{ current: boolean }>`
 `;
 
 interface Props {
-  trail: Array<{
+  breadcrumbs: Array<{
     name: string;
     url: string;
   }>;
 }
 
-const Breadcrumbs = ({ trail }: Props) => {
+const Breadcrumbs = ({ breadcrumbs }: Props) => {
   const root = { name: "Orbit.kiwi", url: "/" };
-  const fullTrail = [root, ...trail];
+  const fullBreadcrumbs = [root, ...breadcrumbs];
   return (
     <StyledList role="navigation" aria-label="breadcrumbs">
-      {fullTrail.map(({ name, url }, i) => {
-        const current = i === fullTrail.length - 1;
+      {fullBreadcrumbs.map(({ name, url }, i) => {
+        const current = i === fullBreadcrumbs.length - 1;
         return (
           <StyledListItem key={url} current={current}>
             <Link to={url} aria-label={name} aria-current={current && "page"}>
               {name}
             </Link>
-            {i + 1 !== fullTrail.length && <span>/</span>}
+            {i + 1 !== fullBreadcrumbs.length && <span>/</span>}
           </StyledListItem>
         );
       })}

--- a/docs/src/components/DocLayout/index.tsx
+++ b/docs/src/components/DocLayout/index.tsx
@@ -78,7 +78,7 @@ interface Props {
   path: string;
   tabs?: TabObject[];
   title?: string;
-  trail?: Array<{
+  breadcrumbs?: Array<{
     name: string;
     url: string;
   }>;
@@ -94,7 +94,7 @@ export default function DocLayout({
   path,
   tabs,
   title,
-  trail = title ? [{ name: title, url: path }] : undefined,
+  breadcrumbs = title ? [{ name: title, url: path }] : undefined,
   custom,
 }: Props) {
   const [tableOfContents] = useTableOfContents();
@@ -103,7 +103,11 @@ export default function DocLayout({
   return (
     <>
       <Head
-        title={title ? getDocumentPageTitle(title, trail ? trail.map(t => t.name) : []) : "Orbit"}
+        title={
+          title
+            ? getDocumentPageTitle(title, breadcrumbs ? breadcrumbs.map(t => t.name) : [])
+            : "Orbit"
+        }
         hasSiteName={Boolean(title)}
         description={description}
         path={path}
@@ -149,7 +153,7 @@ export default function DocLayout({
                 </StyledProse>
               ) : (
                 <>
-                  {trail && <Breadcrumbs trail={trail} />}
+                  {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
                   <Box padding={{ bottom: "medium" }}>
                     <Stack inline align="center" spaceAfter="small">
                       <AddBookmark title={title} description={description} />

--- a/docs/src/components/DocNavigation/__tests__/index.test.tsx
+++ b/docs/src/components/DocNavigation/__tests__/index.test.tsx
@@ -1,8 +1,8 @@
-import { groupTrails } from "..";
+import { groupBreadcrumbs } from "..";
 
 describe("DocNavigation", () => {
-  it("should group trails into navigation items", () => {
-    const navigation = groupTrails({
+  it("should group breadcrumbs into navigation items", () => {
+    const navigation = groupBreadcrumbs({
       content: [
         [
           { name: "Getting started", url: "/getting-started/", hasReactTab: false },

--- a/docs/src/components/Search/SearchModal.tsx
+++ b/docs/src/components/Search/SearchModal.tsx
@@ -33,7 +33,7 @@ interface QueryResponse {
     nodes: Array<{
       fields: {
         slug: string;
-        trail: Array<{
+        breadcrumbs: Array<{
           name: string;
         }>;
       };
@@ -91,7 +91,7 @@ export default function SearchModal({ onClose }: Props) {
         nodes {
           fields {
             slug
-            trail {
+            breadcrumbs {
               name
             }
           }
@@ -131,7 +131,7 @@ export default function SearchModal({ onClose }: Props) {
 
   const documents = React.useMemo<SearchResult[]>(() => {
     const mdxPages = data.allMdx.nodes.map(node => {
-      const breadcrumbs = node.fields ? node.fields.trail.map(({ name }) => name) : [];
+      const breadcrumbs = node.fields ? node.fields.breadcrumbs.map(({ name }) => name) : [];
       return {
         name: breadcrumbs.join(" "),
         breadcrumbs,

--- a/docs/src/templates/Doc.tsx
+++ b/docs/src/templates/Doc.tsx
@@ -13,7 +13,7 @@ interface Props extends PageRendererProps {
         headerLink: string;
         slug: string;
         title: string;
-        trail: Array<{
+        breadcrumbs: Array<{
           name: string;
           url: string;
         }>;
@@ -50,7 +50,7 @@ export default function Doc({ data, location }: Props) {
       path={fields.slug}
       tabs={usedTabs}
       title={fields.title}
-      trail={fields.trail}
+      breadcrumbs={fields.breadcrumbs}
     >
       <MDXRenderer>{body}</MDXRenderer>
     </DocLayout>
@@ -65,7 +65,7 @@ export const query = graphql`
         headerLink
         slug
         title
-        trail {
+        breadcrumbs {
           name
           url
         }

--- a/docs/src/templates/Overview.tsx
+++ b/docs/src/templates/Overview.tsx
@@ -12,7 +12,7 @@ interface Props extends PageRendererProps {
   pageContext: {
     slug: string;
     title: string;
-    trail: Array<{
+    breadcrumbs: Array<{
       name: string;
       url: string;
     }>;
@@ -26,7 +26,7 @@ interface Props extends PageRendererProps {
 }
 
 const Overview = ({ location, pageContext }: Props) => {
-  const { slug, title, trail, pages } = pageContext;
+  const { slug, title, breadcrumbs, pages } = pageContext;
   const [devMode] = useDevMode();
   const [render, setRender] = React.useState(false);
 
@@ -40,7 +40,13 @@ const Overview = ({ location, pageContext }: Props) => {
 
   return (
     render && (
-      <DocLayout location={location} path={slug} title={title} trail={trail} noElevation>
+      <DocLayout
+        location={location}
+        path={slug}
+        title={title}
+        breadcrumbs={breadcrumbs}
+        noElevation
+      >
         <Grid
           columns="1fr"
           gap="2rem"

--- a/docs/src/utils/document.ts
+++ b/docs/src/utils/document.ts
@@ -1,12 +1,12 @@
-export function getDocumentPageTitle(title: string, trail: string[] = []): string {
-  if (trail.includes("Components")) {
+export function getDocumentPageTitle(title: string, breadcrumbs: string[] = []): string {
+  if (breadcrumbs.includes("Components")) {
     return `${title} component`;
   }
-  if (trail.includes("Hooks")) {
+  if (breadcrumbs.includes("Hooks")) {
     return `${title} hook`;
   }
   if (
-    trail.includes("Getting started") &&
+    breadcrumbs.includes("Getting started") &&
     (title === "For designers" || title === "For developers")
   ) {
     return `Getting started: ${title}`;

--- a/docs/utils/document.ts
+++ b/docs/utils/document.ts
@@ -15,10 +15,10 @@ export function getParentUrl(url) {
   return path.join(path.dirname(url), "/");
 }
 
-export async function getDocumentTrail(cache, url, trail = []) {
-  if (url === "/") return trail;
+export async function getDocumentBreadcrumbs(cache, url, breadcrumbs = []) {
+  if (url === "/") return breadcrumbs;
   const { title } = await cache.get(url);
 
   // @ts-expect-error TODO
-  return getDocumentTrail(cache, getParentUrl(url), [{ name: title, url }, ...trail]);
+  return getDocumentBreadcrumbs(cache, getParentUrl(url), [{ name: title, url }, ...breadcrumbs]);
 }


### PR DESCRIPTION
On docs, the `trail` field was renamed to `breadcrumbs` as it is considered more accurate.
 Storybook: https://orbit-mainframev-refactor-rename-trail-to-breadcrumbs.surge.sh