### PR TITLE
fix(SegmentedSwitch): incorrect defaultChecked prop name

### DIFF
--- a/packages/orbit-components/src/SegmentedSwitch/README.md
+++ b/packages/orbit-components/src/SegmentedSwitch/README.md
@@ -45,13 +45,13 @@ _Table below contains all types of the props available in the SegmentedSwitch co
 
 Table below contains all types of the props available for object in Option array.
 
-| Name         | Type               | Description                             |
-| :----------- | :----------------- | :-------------------------------------- |
-| **value**    | `string \| number` | The value of the Option.                |
-| label        | `string`           | The label for the Option.               |
-| defaultCheck | `boolean`          | Set option checked by default.          |
-| disabled     | `boolean`          | If `true`, the Option will be disabled. |
-| name         | `string`           | Name of the Option.                     |
+| Name           | Type               | Description                             |
+| :------------- | :----------------- | :-------------------------------------- |
+| **value**      | `string \| number` | The value of the Option.                |
+| label          | `string`           | The label for the Option.               |
+| defaultChecked | `boolean`          | Set option checked by default.          |
+| disabled       | `boolean`          | If `true`, the Option will be disabled. |
+| name           | `string`           | Name of the Option.                     |
 
 ## Functional specs
 

--- a/packages/orbit-components/src/SegmentedSwitch/index.d.ts
+++ b/packages/orbit-components/src/SegmentedSwitch/index.d.ts
@@ -12,7 +12,7 @@ export interface Option {
   readonly value: string | number;
   readonly disabled?: boolean;
   readonly name?: string;
-  readonly defaultCheck?: boolean;
+  readonly defaultChecked?: boolean;
 }
 
 export interface Props extends Common.Global {


### PR DESCRIPTION
It was being documented as `defaultCheck`, but it should be `defaultChecked`.
 Storybook: https://orbit-mainframev-fix-incorrect-defaultChecked-segmentedSwitch.surge.sh