### PR TITLE
fix: missing onShow prop for MobileDialog inside Tooltip 

### DIFF
--- a/packages/orbit-components/src/Tooltip/index.jsx
+++ b/packages/orbit-components/src/Tooltip/index.jsx
@@ -47,6 +47,7 @@ const Tooltip = ({
       dataTest={dataTest}
       tabIndex={tabIndex}
       id={id}
+      onShow={onShow}
       enabled={enabled}
       lockScrolling={lockScrolling}
       content={content}

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/README.md
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/README.md
@@ -30,6 +30,7 @@ Table below contains all types of the props available in the MobileDialogPrimiti
 | stopPropagation      | `boolean`          |         | If `true` the click event on children won't bubble. Useful when you use MobileDialogPrimitive inside another clickable element.                     |
 | lockScrolling        | `boolean`          | `true`  | Whether to prevent scrolling of the rest of the page while ModalDialogPrimitive is open. This is on by default to provide a better user experience. |
 | tabIndex             | `string \| number` | `"0"`   | Specifies the tab order of an element                                                                                                               |
+| onShow               | `() => void`       |         | Fires when MobileDialog appears                                                                                                                     |
 
 ## Functional specs
 

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/__tests__/index.test.jsx
@@ -18,15 +18,17 @@ afterAll(() => {
 });
 describe("MobileDialogPrimitive", () => {
   it("should have expected DOM output", () => {
+    const onShown = jest.fn();
     render(
       // eslint-disable-next-line jsx-a11y/tabindex-no-positive
-      <MobileDialog tabIndex="1" dataTest="test" content="My text link">
+      <MobileDialog tabIndex="1" dataTest="test" onShow={onShown} content="My text link">
         children
       </MobileDialog>,
     );
     const children = screen.getByText("children");
     expect(children).toHaveAttribute("tabindex", "1");
     userEvent.click(children);
+    expect(onShown).toHaveBeenCalledTimes(1);
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByTestId("test")).toBeInTheDocument();
     expect(screen.getByText("My text link")).toBeInTheDocument();

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.d.ts
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.d.ts
@@ -11,6 +11,7 @@ export interface Props extends Common.Global {
   readonly enabled?: boolean;
   readonly lockScrolling?: boolean;
   readonly tabIndex?: string | number;
+  readonly onShow?: () => void | Promise<void>;
   readonly renderInPortal?: boolean;
   readonly content: React.ReactNode;
   readonly stopPropagation?: boolean;

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.jsx
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.jsx
@@ -12,6 +12,7 @@ import type { Props } from ".";
 const MobileDialog = ({
   children,
   enabled = true,
+  onShow,
   renderInPortal = true,
   tabIndex = "0",
   dataTest,
@@ -27,7 +28,7 @@ const MobileDialog = ({
     setRenderWithTimeout,
     clearRenderTimeout,
   ] = useStateWithTimeout<boolean>(false, 200);
-  const [shown, setshown, setshownWithTimeout] = useStateWithTimeout<boolean>(false, 200);
+  const [shown, setShown, setShownWithTimeout] = useStateWithTimeout<boolean>(false, 200);
   const mobileDialogID = useRandomId();
 
   const handleInMobile = React.useCallback(
@@ -38,10 +39,11 @@ const MobileDialog = ({
       }
 
       setRender(true);
-      setshownWithTimeout(true);
+      if (onShow) onShow();
+      setShownWithTimeout(true);
       clearRenderTimeout();
     },
-    [clearRenderTimeout, setRender, setshownWithTimeout, stopPropagation],
+    [clearRenderTimeout, setRender, setShownWithTimeout, stopPropagation],
   );
 
   const handleOutMobile = React.useCallback(
@@ -49,10 +51,10 @@ const MobileDialog = ({
       if (stopPropagation) {
         ev.stopPropagation();
       }
-      setshown(false);
+      setShown(false);
       setRenderWithTimeout(false);
     },
-    [setRenderWithTimeout, setshown, stopPropagation],
+    [setRenderWithTimeout, setShown, stopPropagation],
   );
 
   if (!enabled) return children;

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.jsx.flow
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/index.jsx.flow
@@ -10,6 +10,7 @@ export type Props = {|
   lockScrolling?: boolean,
   renderInPortal?: boolean,
   content: React.Node,
+  onShow?: () => void | Promise<void>,
   stopPropagation?: boolean,
   removeUnderlinedText?: boolean,
   block?: boolean,


### PR DESCRIPTION
[Slack request #1](https://skypicker.slack.com/archives/CAMS40F7B/p1666695579504919)
[Slack request #2](https://skypicker.slack.com/archives/CAMS40F7B/p1666696607559829)
 Storybook: https://orbit-mainframev-fix-missing-on-shown.surge.sh