### PR TITLE
test: remove test warnings

### DIFF
--- a/packages/orbit-components/src/Box/index.jsx
+++ b/packages/orbit-components/src/Box/index.jsx
@@ -10,8 +10,8 @@ import normalize from "./normalize";
 import type { Props } from ".";
 
 const StyledBox: any = styled(
-  ({ className, asComponent: Element, children, dataTest, id, ref }) => (
-    <Element className={className} data-test={dataTest} id={id} ref={ref}>
+  ({ className, asComponent: Element, children, dataTest, id, forwardRef }) => (
+    <Element className={className} data-test={dataTest} id={id} ref={forwardRef}>
       {children}
     </Element>
   ),
@@ -56,7 +56,7 @@ const Box: React.AbstractComponent<Props, HTMLDivElement> = React.forwardRef<Pro
 
     return (
       <StyledBox
-        ref={ref}
+        forwardRef={ref}
         asComponent={as}
         id={id}
         dataTest={dataTest}

--- a/packages/orbit-components/src/ErrorFormTooltip/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/ErrorFormTooltip/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ErrorFormTooltip from "..";
@@ -18,7 +18,7 @@ describe("ErrorFormTooltip", () => {
     expect(onShown).toHaveBeenCalled();
   });
 
-  it("should have help", () => {
+  it("should have help", async () => {
     const onShown = jest.fn();
     render(<ErrorFormTooltip dataTest="test" onShown={onShown} shown help="help" />);
 
@@ -27,5 +27,9 @@ describe("ErrorFormTooltip", () => {
 
     userEvent.click(screen.getByLabelText("close"));
     expect(onShown).toHaveBeenCalled();
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 });

--- a/packages/orbit-components/src/InputField/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/InputField/__tests__/index.test.jsx
@@ -66,7 +66,9 @@ describe("InputField", () => {
     fireEvent.focus(input); // userEvent.tab() doesn't work because of tabIndex="-1"
     expect(screen.getByTestId("help")).toBeInTheDocument();
     expect(container.firstChild).toHaveStyle({ marginBottom: defaultTheme.orbit.spaceSmall });
-    // $FlowFixMe:TODO
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
     await act(async () => {});
   });
 
@@ -145,7 +147,9 @@ describe("InputField", () => {
       userEvent.tab();
       expect(screen.queryByTestId("help")).not.toBeInTheDocument();
       expect(screen.getByTestId("error")).toBeInTheDocument();
-      // $FlowFixMe:TODO
+      // Needs to flush async `floating-ui` hooks
+      // https://github.com/floating-ui/floating-ui/issues/1520
+      // $FlowFixMe
       await act(async () => {});
     });
   });
@@ -171,7 +175,9 @@ describe("InputField", () => {
       userEvent.tab();
       expect(screen.queryByText("Second")).not.toBeInTheDocument();
       expect(screen.getByText("Third")).toBeVisible();
-      // $FlowFixMe:TODO
+      // Needs to flush async `floating-ui` hooks
+      // https://github.com/floating-ui/floating-ui/issues/1520
+      // $FlowFixMe
       await act(async () => {});
     });
   });

--- a/packages/orbit-components/src/InputGroup/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/InputGroup/__tests__/index.test.jsx
@@ -41,7 +41,9 @@ describe("InputGroup", () => {
 
     userEvent.tab();
     expect(screen.getByText("help message")).toBeInTheDocument();
-    // $FlowFixMe:TODO
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
     await act(async () => {});
   });
   it("should render error message", async () => {
@@ -53,7 +55,9 @@ describe("InputGroup", () => {
 
     userEvent.tab();
     expect(screen.getByText("error message")).toBeInTheDocument();
-    // $FlowFixMe:TODO
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
     await act(async () => {});
   });
 

--- a/packages/orbit-components/src/LinkList/index.jsx
+++ b/packages/orbit-components/src/LinkList/index.jsx
@@ -14,12 +14,12 @@ import getDirectionSpacingTemplate from "../Stack/helpers/getDirectionSpacingTem
 import type { Props } from ".";
 
 const StyledLinkList = styled.ul`
-  ${({ indent, direction, theme, legacy, spacing }) => css`
+  ${({ indent, direction, theme, $legacy, spacing }) => css`
     display: flex;
     flex-direction: ${direction};
     width: 100%;
     margin: 0;
-    gap: ${!legacy && spacing && getSpacing({ theme })[spacing]};
+    gap: ${!$legacy && spacing && getSpacing({ theme })[spacing]};
     padding: 0;
     padding-${left}: ${indent && theme.orbit.spaceXXSmall};
     list-style: none;
@@ -32,7 +32,7 @@ StyledLinkList.defaultProps = {
   theme: defaultTheme,
 };
 
-const resolveSpacings = ({ spacing, legacy, direction, ...props }): CSSRules | null => {
+const resolveSpacings = ({ spacing, $legacy, direction, ...props }): CSSRules | null => {
   const margin =
     spacing &&
     direction &&
@@ -41,7 +41,7 @@ const resolveSpacings = ({ spacing, legacy, direction, ...props }): CSSRules | n
       getSpacing(props)[spacing],
     );
 
-  if (!legacy) return null;
+  if (!$legacy) return null;
 
   return css`
     margin: ${margin && rtlSpacing(margin)};
@@ -90,13 +90,13 @@ const LinkList = ({
     indent={indent}
     direction={direction}
     data-test={dataTest}
-    legacy={legacy}
+    $legacy={legacy}
     spacing={spacing}
   >
     {React.Children.map(children, item => {
       if (React.isValidElement(item)) {
         return (
-          <StyledNavigationLinkListChild direction={direction} spacing={spacing} legacy={legacy}>
+          <StyledNavigationLinkListChild direction={direction} spacing={spacing} $legacy={legacy}>
             {item}
           </StyledNavigationLinkListChild>
         );

--- a/packages/orbit-components/src/Popover/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/Popover/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { screen, render, waitForElementToBeRemoved } from "@testing-library/react";
+import { screen, render, act, waitForElementToBeRemoved } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Tooltip from "../../Tooltip";
@@ -17,7 +17,7 @@ jest.mock("../../hooks/useMediaQuery", () => {
 });
 
 describe("Popover", () => {
-  it("should have expected DOM output", () => {
+  it("should have expected DOM output", async () => {
     const content = "Message for a user";
     const position = "bottom";
     const onOpen = jest.fn();
@@ -43,9 +43,13 @@ describe("Popover", () => {
     const closeButton = screen.getByRole("button", { name: "Close" });
     userEvent.click(closeButton);
     expect(onClose).toHaveBeenCalled();
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 
-  it("should have actions", () => {
+  it("should have actions", async () => {
     const actions = (
       <Stack direction="row" justify="between">
         <Button type="secondary" size="small">
@@ -60,18 +64,26 @@ describe("Popover", () => {
       </Popover>,
     );
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 
-  it("should have no padding", () => {
+  it("should have no padding", async () => {
     render(
       <Popover noPadding opened dataTest="test" content="kek">
         bur
       </Popover>,
     );
     expect(screen.getByText("kek").closest("div")).toHaveStyle({ padding: "0" });
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 
-  it("should have offset", () => {
+  it("should have offset", async () => {
     render(
       <Popover opened offset={{ top: 10, left: 20 }} content="kek">
         <Button type="secondary" size="small">
@@ -82,6 +94,10 @@ describe("Popover", () => {
 
     // default is 4px
     expect(screen.getByRole("tooltip")).toHaveStyle({ top: "10" });
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 
   it("with tooltip", async () => {
@@ -95,5 +111,9 @@ describe("Popover", () => {
     expect(overlay).toBeInTheDocument();
     if (overlay) userEvent.click(overlay);
     await waitForElementToBeRemoved(screen.queryByTestId("popover"));
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 });

--- a/packages/orbit-components/src/SegmentedSwitch/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/SegmentedSwitch/__tests__/index.test.jsx
@@ -1,12 +1,12 @@
 // @flow
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import SegmentedSwitch from "..";
 
 describe("SegmentedSwitch", () => {
-  it("should have expected DOM output", () => {
+  it("should have expected DOM output", async () => {
     const onChange = jest.fn();
     const onFocus = jest.fn();
     const label = "label";
@@ -35,9 +35,13 @@ describe("SegmentedSwitch", () => {
     userEvent.click(screen.getByLabelText("Female"));
     expect(screen.getByDisplayValue("Female")).toBeInTheDocument();
     expect(onChange).toHaveBeenCalled();
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 
-  it("should have error", () => {
+  it("should have error", async () => {
     const error = "Error message";
     const label = "Gender";
 
@@ -56,9 +60,13 @@ describe("SegmentedSwitch", () => {
     userEvent.hover(screen.getByText(label));
     expect(screen.getByText(error)).toBeInTheDocument();
     expect(screen.getByLabelText("Female")).toBeDisabled();
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 
-  it("should have help", () => {
+  it("should have help", async () => {
     const help = "Help message";
 
     render(
@@ -75,5 +83,9 @@ describe("SegmentedSwitch", () => {
 
     userEvent.hover(screen.getByText("Gender"));
     expect(screen.getByText(help)).toBeInTheDocument();
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 });

--- a/packages/orbit-components/src/Textarea/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/Textarea/__tests__/index.test.jsx
@@ -68,7 +68,9 @@ describe("Textarea", () => {
     userEvent.tab();
     expect(screen.getByText("error")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toHaveStyle({ padding: "8px 12px" });
-    // $FlowFixMe: jest
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
     await act(async () => {});
   });
 });

--- a/packages/orbit-components/src/Tooltip/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/Tooltip/__tests__/index.test.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Tooltip from "..";
@@ -14,7 +14,7 @@ jest.mock("../../hooks/useMediaQuery", () => {
 });
 
 describe("Tooltip", () => {
-  it("it should render Tooltip", () => {
+  it("it should render Tooltip", async () => {
     const content = "Write some message to the user";
     const onShow = jest.fn();
 
@@ -27,5 +27,9 @@ describe("Tooltip", () => {
     expect(screen.getByText("kek")).toBeInTheDocument();
     userEvent.hover(screen.getByText("kek"));
     expect(onShow).toHaveBeenCalled();
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 });

--- a/packages/orbit-components/src/deprecated/InputStepper/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/deprecated/InputStepper/__tests__/index.test.jsx
@@ -44,14 +44,18 @@ describe("InputStepper", () => {
     render(<InputStepper label="Label" help="help message" />);
     userEvent.tab();
     expect(screen.getByText("help message")).toBeInTheDocument();
-    // $FlowFixMe:TODO
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
     await act(async () => {});
   });
   it("should render error message", async () => {
     render(<InputStepper label="Label" error="error message" />);
     userEvent.tab();
     expect(screen.getByText("error message")).toBeInTheDocument();
-    // $FlowFixMe:TODO
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
     await act(async () => {});
   });
   it("should not be able to change value by typing", () => {

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/__tests__/index.test.jsx
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/__tests__/index.test.jsx
@@ -1,13 +1,13 @@
 // @flow
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Tooltip from "..";
 import Airplane from "../../../icons/Airplane";
 
 describe("Tooltip", () => {
-  it("it should match snapshot", () => {
+  it("it should match snapshot", async () => {
     const content = "Write some message to the user";
     const { container } = render(
       <Tooltip content={content}>
@@ -16,9 +16,13 @@ describe("Tooltip", () => {
     );
 
     expect(container.firstChild).toMatchSnapshot();
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 
-  it("should call onClick 1 time", () => {
+  it("should call onClick 1 time", async () => {
     const content = "Write some message to the user";
     const onClick = jest.fn();
 
@@ -41,9 +45,13 @@ describe("Tooltip", () => {
     userEvent.click(screen.getByText(content));
 
     expect(onClick).toHaveBeenCalledTimes(1);
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 
-  it("should call onClick 2 times", () => {
+  it("should call onClick 2 times", async () => {
     const content = "Write some message to the user";
     const onClick = jest.fn();
 
@@ -65,5 +73,9 @@ describe("Tooltip", () => {
     userEvent.click(screen.getByText(content));
 
     expect(onClick).toHaveBeenCalledTimes(2);
+    // Needs to flush async `floating-ui` hooks
+    // https://github.com/floating-ui/floating-ui/issues/1520
+    // $FlowFixMe
+    await act(async () => {});
   });
 });


### PR DESCRIPTION
Removed the test warnings. One issue is connected with `react-popper` and there is nothing that we can do currently, only hide that test warnings. 
 Storybook: https://orbit-mainframev-fix-test-warnings.surge.sh