### PR TITLE
Docs: minor adjustments (ToC and Foundation before Components)

### DIFF
--- a/docs/src/components/DocLayout/primitives/StyledMobileTocWrapper.ts
+++ b/docs/src/components/DocLayout/primitives/StyledMobileTocWrapper.ts
@@ -3,7 +3,6 @@ import styled from "styled-components";
 const StyledMobileTocWrapper = styled.div`
   margin-top: 0px !important;
   > div {
-    display: flex;
     width: 100%;
   }
   + * {

--- a/docs/src/components/Navbar/Links.tsx
+++ b/docs/src/components/Navbar/Links.tsx
@@ -80,7 +80,7 @@ const LinkList = ({ isDesktop, links }: { isDesktop?: boolean; links: Props["lin
 );
 
 const Links = ({
-  links = ["Components", "Foundation", "Tokens", "Guides", "Accessibility"],
+  links = ["Foundation", "Components", "Tokens", "Guides", "Accessibility"],
 }: Props) => {
   return (
     <>

--- a/docs/src/components/Search/SearchButton.tsx
+++ b/docs/src/components/Search/SearchButton.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Stack, Button } from "@kiwicom/orbit-components";
 import styled, { css } from "styled-components";
 import { Search as SearchIcon } from "@kiwicom/orbit-components/icons";
+import { convertHexToRgba } from "@kiwicom/orbit-design-tokens";
 
 import useOs from "../../hooks/useOs";
 
@@ -10,6 +11,14 @@ interface Props {
 }
 
 type Type = "primary" | "secondary";
+
+const StyledSearchButtonWrapper = styled.div`
+  ${({ theme }) => css`
+    > button {
+      background: ${convertHexToRgba(theme.orbit.paletteProductNormal, 10)};
+    }
+  `}
+`;
 
 const StyledWrapper = styled.div<{ type: Type }>`
   ${({ theme, type }) => css`
@@ -50,12 +59,14 @@ export const KeyboardShortcuts = ({ type = "primary" }: { type: Type }) => {
 
 const SearchButton = ({ onClick }: Props) => {
   return (
-    <Button size="large" type="primarySubtle" circled iconLeft={<SearchIcon />} onClick={onClick}>
-      <Stack inline align="center" spacing="XSmall">
-        <p>Search</p>
-        <KeyboardShortcuts type="primary" />
-      </Stack>
-    </Button>
+    <StyledSearchButtonWrapper>
+      <Button size="large" type="primarySubtle" circled iconLeft={<SearchIcon />} onClick={onClick}>
+        <Stack inline align="center" spacing="XSmall">
+          <p>Search</p>
+          <KeyboardShortcuts type="primary" />
+        </Stack>
+      </Button>
+    </StyledSearchButtonWrapper>
   );
 };
 


### PR DESCRIPTION
This addresses two requests made [here](https://skypicker.slack.com/archives/GSGN9BN6Q/p1667480757876079), [here](https://skypicker.slack.com/archives/GSGN9BN6Q/p1667480796161609) and [here](https://skypicker.slack.com/archives/GSGN9BN6Q/p1667412776648439?thread_ts=1667213430.557639&cid=GSGN9BN6Q).

Table of Contents is now no longer visible in desktop and tablets.
The order of the Foundation and Components links on the Navbar was changed.
SearchButton color is now according to the design.
 Storybook: https://orbit-mainframev-docs-minor-adjustments.surge.sh