### PR TITLE
Docs: add custom topbar links + fix tabs documentation page

### DIFF
--- a/docs/gatsby-node.ts
+++ b/docs/gatsby-node.ts
@@ -148,10 +148,19 @@ export const onCreateNode = async ({ cache, node, getNode, actions, reporter }) 
       return "";
     };
 
+    const headerLink =
+      metaFileData.headerLink || getLinkForComponents() || node.frontmatter.headerLink;
+
     createNodeField({
       node,
       name: "headerLink",
-      value: getLinkForComponents() || node.frontmatter.headerLink || metaFileData.headerLink,
+      value: headerLink,
+    });
+
+    createNodeField({
+      node,
+      name: "hasHeaderLink",
+      value: metaFileData.hasHeaderLink ?? Boolean(headerLink),
     });
 
     if (node.fields.collection === "documentation") {
@@ -260,6 +269,7 @@ export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] 
       title: String!
       breadcrumbs: [BreadcrumbsPart]
       storybookLink: String
+      headerLink: String
     }
 
     type BreadcrumbsPart {

--- a/docs/gatsby-node.ts
+++ b/docs/gatsby-node.ts
@@ -93,6 +93,12 @@ export const onCreateNode = async ({ cache, node, getNode, actions, reporter }) 
 
     createNodeField({
       node,
+      name: "hasStorybook",
+      value: metaFileData.hasStorybook ?? dir.startsWith("/03-components"),
+    });
+
+    createNodeField({
+      node,
       name: "storybookLink",
       value: metaFileData.storybook,
     });
@@ -245,8 +251,11 @@ export const onPreBuild = async () => {
   await parseChangelog();
 };
 
-export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] = ({ actions }) => {
-  actions.createTypes(
+export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] = ({
+  actions,
+  schema,
+}) => {
+  const typeDefs = [
     `
     type Mdx implements Node {
       frontmatter: MdxFrontmatter!
@@ -261,21 +270,26 @@ export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] 
       type: String
     }
 
-    type MdxFields {
-      collection: String!
-      description: String
-      slug: String!
-      tabCollection: String
-      title: String!
-      breadcrumbs: [BreadcrumbsPart]
-      storybookLink: String
-      headerLink: String
-    }
-
     type BreadcrumbsPart {
       name: String!
       url: String!
     }
-  `,
-  );
+    `,
+    schema.buildObjectType({
+      name: "MdxFields",
+      fields: {
+        breadcrumbs: "[BreadcrumbsPart]",
+        collection: "String!",
+        description: "String",
+        slug: "String!",
+        tabCollection: "String",
+        title: "String!",
+        storybookLink: "String",
+        headerLink: "String",
+        hasHeaderLink: "Boolean",
+        hasStorybook: "Boolean",
+      },
+    }),
+  ];
+  actions.createTypes(typeDefs);
 };

--- a/docs/gatsby-node.ts
+++ b/docs/gatsby-node.ts
@@ -93,6 +93,12 @@ export const onCreateNode = async ({ cache, node, getNode, actions, reporter }) 
 
     createNodeField({
       node,
+      name: "storybookLink",
+      value: metaFileData.storybook,
+    });
+
+    createNodeField({
+      node,
       name: "slug",
       value: getDocumentUrl(fileUrl, hasTabs),
     });
@@ -253,6 +259,7 @@ export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] 
       tabCollection: String
       title: String!
       breadcrumbs: [BreadcrumbsPart]
+      storybookLink: String
     }
 
     type BreadcrumbsPart {

--- a/docs/src/components/DocLayout/TopBar.tsx
+++ b/docs/src/components/DocLayout/TopBar.tsx
@@ -104,7 +104,7 @@ const TopBar = ({
               {headerLink && (
                 <Hide on={["smallMobile", "mediumMobile"]}>
                   <Stack flex spacing="XXSmall">
-                    <HeaderButtonLink href={headerLink} />
+                    {headerLink !== "false" && <HeaderButtonLink href={headerLink} />}
                     {title && storybookLink !== "false" && (
                       <ButtonLink
                         type="secondary"

--- a/docs/src/components/DocLayout/TopBar.tsx
+++ b/docs/src/components/DocLayout/TopBar.tsx
@@ -55,7 +55,7 @@ const TopBar = ({
   hasStorybook,
   storybookLink,
 }) => {
-  const hasTabs = tabs && tabs.length > 1;
+  const hasTabs = tabs && tabs.length > 0;
   const hasLowerLayer = hasTabs || hasHeaderLink || hasStorybook;
 
   return custom ? (

--- a/docs/src/components/DocLayout/TopBar.tsx
+++ b/docs/src/components/DocLayout/TopBar.tsx
@@ -52,6 +52,7 @@ const TopBar = ({
   headerLink,
   breadcrumbs,
   description,
+  storybookLink,
 }) => {
   return custom ? (
     <StyledProse
@@ -104,13 +105,15 @@ const TopBar = ({
                 <Hide on={["smallMobile", "mediumMobile"]}>
                   <Stack flex spacing="XXSmall">
                     <HeaderButtonLink href={headerLink} />
-                    {title && (
+                    {title && storybookLink !== "false" && (
                       <ButtonLink
                         type="secondary"
                         size="large"
                         iconLeft={<StorybookLogo />}
                         external
-                        href={`https://kiwicom.github.io/orbit/?path=/story/${title.toLowerCase()}`}
+                        href={`https://kiwicom.github.io/orbit/?path=/story/${
+                          storybookLink ?? title.toLowerCase()
+                        }`}
                       />
                     )}
                   </Stack>

--- a/docs/src/components/DocLayout/TopBar.tsx
+++ b/docs/src/components/DocLayout/TopBar.tsx
@@ -14,11 +14,10 @@ const StyledDescription = styled.span`
   line-height: 22px;
 `;
 
-const StyledWrapper = styled.div<{ hasBg?: boolean }>`
-  ${({ theme, hasBg }) => css`
+const StyledWrapper = styled.div`
+  ${({ theme }) => css`
     position: relative;
-    background: ${hasBg &&
-    `linear-gradient(
+    background: ${`linear-gradient(
       85.39deg,
       ${theme.orbit.paletteWhiteHover} 3.73%,
       ${theme.orbit.paletteCloudLight} 53.77%
@@ -49,11 +48,16 @@ const TopBar = ({
   tabs,
   location,
   tocHasItems,
+  hasHeaderLink,
   headerLink,
   breadcrumbs,
   description,
+  hasStorybook,
   storybookLink,
 }) => {
+  const hasTabs = tabs && tabs.length > 1;
+  const hasLowerLayer = hasTabs || hasHeaderLink || hasStorybook;
+
   return custom ? (
     <StyledProse
       padding={
@@ -66,10 +70,17 @@ const TopBar = ({
       {children}
     </StyledProse>
   ) : (
-    <StyledWrapper hasBg={tabs && tabs.length > 0}>
-      <Box padding={{ top: "XXLarge", left: "XXLarge", right: "XXLarge" }}>
+    <StyledWrapper>
+      <Box
+        padding={{
+          top: "XXLarge",
+          left: "XXLarge",
+          right: "XXLarge",
+          bottom: hasLowerLayer ? "none" : "XXLarge",
+        }}
+      >
         {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
-        <Box padding={{ bottom: "medium" }}>
+        <Box padding={{ bottom: hasLowerLayer ? "medium" : "none" }}>
           <Stack inline align="center" spaceAfter="small">
             <AddBookmark title={title} description={description} />
             <div
@@ -92,33 +103,31 @@ const TopBar = ({
             </Box>
           )}
         </Box>
-        {(tabs || headerLink) && (
+        {hasLowerLayer && (
           <Box
             display="flex"
             align="end"
-            justify={tabs && tabs.length > 0 ? "between" : "end"}
+            justify={hasTabs ? "between" : "end"}
             tablet={{ maxWidth: tocHasItems ? "80%" : "100%" }}
           >
             <StyledTopWrapper $hasTabs={Boolean(tabs)}>
-              {tabs && <Tabs activeTab={location.pathname} tabs={tabs} />}
-              {headerLink && (
-                <Hide on={["smallMobile", "mediumMobile"]}>
-                  <Stack flex spacing="XXSmall">
-                    {headerLink !== "false" && <HeaderButtonLink href={headerLink} />}
-                    {title && storybookLink !== "false" && (
-                      <ButtonLink
-                        type="secondary"
-                        size="large"
-                        iconLeft={<StorybookLogo />}
-                        external
-                        href={`https://kiwicom.github.io/orbit/?path=/story/${
-                          storybookLink ?? title.toLowerCase()
-                        }`}
-                      />
-                    )}
-                  </Stack>
-                </Hide>
-              )}
+              {hasTabs && <Tabs activeTab={location.pathname} tabs={tabs} />}
+              <Hide on={["smallMobile", "mediumMobile"]}>
+                <Stack flex spacing="XXSmall">
+                  {hasHeaderLink && headerLink && <HeaderButtonLink href={headerLink} />}
+                  {hasStorybook && (storybookLink || title) && (
+                    <ButtonLink
+                      type="secondary"
+                      size="large"
+                      iconLeft={<StorybookLogo />}
+                      external
+                      href={`https://kiwicom.github.io/orbit/?path=/story/${
+                        storybookLink ?? title.toLowerCase()
+                      }`}
+                    />
+                  )}
+                </Stack>
+              </Hide>
             </StyledTopWrapper>
           </Box>
         )}

--- a/docs/src/components/DocLayout/index.tsx
+++ b/docs/src/components/DocLayout/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { css } from "styled-components";
-import { Collapse, Grid, Hide, Stack } from "@kiwicom/orbit-components";
+import { Collapse, Grid, Hide } from "@kiwicom/orbit-components";
 import { MDXProvider } from "@mdx-js/react";
 import { WindowLocation } from "@reach/router";
 
@@ -52,6 +52,7 @@ interface Props {
     url: string;
   }>;
   custom?: boolean;
+  storybookLink?: null | string;
 }
 
 export default function DocLayout({
@@ -65,6 +66,7 @@ export default function DocLayout({
   title,
   breadcrumbs = title ? [{ name: title, url: path }] : undefined,
   custom,
+  storybookLink,
 }: Props) {
   const [tableOfContents] = useTableOfContents();
   const tocHasItems = tableOfContents.length > 0;
@@ -126,6 +128,7 @@ export default function DocLayout({
                 custom={custom}
                 noElevation={noElevation}
                 title={title}
+                storybookLink={storybookLink}
               >
                 {children}
               </TopBar>

--- a/docs/src/components/DocLayout/index.tsx
+++ b/docs/src/components/DocLayout/index.tsx
@@ -41,6 +41,7 @@ import TopBar from "./TopBar";
 interface Props {
   children: React.ReactNode;
   description?: string;
+  hasHeaderLink?: boolean;
   headerLink?: string;
   location: WindowLocation;
   noElevation?: boolean;
@@ -52,12 +53,15 @@ interface Props {
     url: string;
   }>;
   custom?: boolean;
-  storybookLink?: null | string;
+  noTopBar?: boolean;
+  hasStorybook?: boolean;
+  storybookLink?: string;
 }
 
 export default function DocLayout({
   children,
   description,
+  hasHeaderLink,
   headerLink,
   location,
   noElevation,
@@ -66,6 +70,8 @@ export default function DocLayout({
   title,
   breadcrumbs = title ? [{ name: title, url: path }] : undefined,
   custom,
+  noTopBar,
+  hasStorybook,
   storybookLink,
 }: Props) {
   const [tableOfContents] = useTableOfContents();
@@ -111,27 +117,31 @@ export default function DocLayout({
             `}
           >
             <Hide on={["smallMobile", "mediumMobile", "largeMobile", "tablet", "desktop"]}>
-              <StyledDocNavigationWidth hasOutdent={tabs && tabs.length > 0}>
+              <StyledDocNavigationWidth>
                 <StyledDocNavigationWrapper>
                   <DocNavigation currentUrl={path} />
                 </StyledDocNavigationWrapper>
               </StyledDocNavigationWidth>
             </Hide>
-            <StyledMiddle hasBorder={tabs && tabs.length > 0}>
-              <TopBar
-                breadcrumbs={breadcrumbs}
-                headerLink={headerLink}
-                tocHasItems={tocHasItems}
-                tabs={tabs}
-                location={location}
-                description={description}
-                custom={custom}
-                noElevation={noElevation}
-                title={title}
-                storybookLink={storybookLink}
-              >
-                {children}
-              </TopBar>
+            <StyledMiddle>
+              {!noTopBar && (
+                <TopBar
+                  breadcrumbs={breadcrumbs}
+                  hasHeaderLink={hasHeaderLink}
+                  headerLink={headerLink}
+                  tocHasItems={tocHasItems}
+                  tabs={tabs}
+                  location={location}
+                  description={description}
+                  custom={custom}
+                  noElevation={noElevation}
+                  title={title}
+                  hasStorybook={hasStorybook}
+                  storybookLink={storybookLink}
+                >
+                  {children}
+                </TopBar>
+              )}
               <StyledMain>
                 <StyledMobileOutdent>
                   <Grid columns="100%" tablet={{ columns: `${tocHasItems ? "80% 20%" : "100%"}` }}>
@@ -147,7 +157,7 @@ export default function DocLayout({
                         noElevation
                           ? { top: "none", bottom: "XLarge", left: "XLarge", right: "XLarge" }
                           : {
-                              top: "XLarge",
+                              top: "XXLarge",
                               bottom: "XXLarge",
                               left: "XLarge",
                               right: "XLarge",

--- a/docs/src/components/DocLayout/primitives/StyledDocNavigationWidth.tsx
+++ b/docs/src/components/DocLayout/primitives/StyledDocNavigationWidth.tsx
@@ -1,22 +1,20 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
-const StyledDocNavigationWidth = styled.div<{ hasOutdent?: boolean }>`
-  ${({ hasOutdent }) => css`
-    position: relative;
-    width: 22ch;
-    margin-right: ${hasOutdent && "1rem"};
-    height: 100%;
-    &::after {
-      content: "";
-      display: block;
-      position: absolute;
-      width: 100%;
-      height: 52px;
-      bottom: 0;
-      pointer-events: none;
-      background-image: linear-gradient(to top, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
-    }
-  `}
+const StyledDocNavigationWidth = styled.div`
+  position: relative;
+  width: 22ch;
+  margin-right: 1rem;
+  height: 100%;
+  &::after {
+    content: "";
+    display: block;
+    position: absolute;
+    width: 100%;
+    height: 52px;
+    bottom: 0;
+    pointer-events: none;
+    background-image: linear-gradient(to top, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
+  }
 `;
 
 export default StyledDocNavigationWidth;

--- a/docs/src/components/DocLayout/primitives/StyledMiddle.tsx
+++ b/docs/src/components/DocLayout/primitives/StyledMiddle.tsx
@@ -1,14 +1,14 @@
 import styled, { css } from "styled-components";
 import { mediaQueries } from "@kiwicom/orbit-components";
 
-const StyledMiddle = styled.div<{ hasBorder?: boolean }>`
-  ${({ theme, hasBorder }) => css`
+const StyledMiddle = styled.div`
+  ${({ theme }) => css`
     display: flex;
     flex-direction: column;
     margin: 0 auto;
     width: 100%;
     box-sizing: content-box;
-    border-left: ${hasBorder && `1px solid ${theme.orbit.paletteCloudNormal}`};
+    border-left: 1px solid ${theme.orbit.paletteCloudNormal};
     ${mediaQueries.largeDesktop(css`
       > * + * {
         margin-left: ${theme.orbit.spaceLarge};

--- a/docs/src/documentation/02-foundation/10-typography/01-general.mdx
+++ b/docs/src/documentation/02-foundation/10-typography/01-general.mdx
@@ -1,5 +1,5 @@
 ---
-title: Colors
+title: General
 description: Typography is critical for communicating the hierarchy of a page.
 ---
 

--- a/docs/src/documentation/03-components/02-structure/tabs/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/02-structure/tabs/01-guidelines.mdx
@@ -1,6 +1,5 @@
 ---
-title: Tabs
-description: Separates content into groups within a single context.
+title: Guidelines
 redirect_from:
   - /components/tabs/
 ---

--- a/docs/src/documentation/03-components/02-structure/tabs/meta.yml
+++ b/docs/src/documentation/03-components/02-structure/tabs/meta.yml
@@ -1,0 +1,5 @@
+title: Tabs
+description: Separates content into groups within a single context.
+type: tabs
+hasStorybook: false
+hasHeaderLink: false

--- a/docs/src/pages/404.tsx
+++ b/docs/src/pages/404.tsx
@@ -10,7 +10,7 @@ export default function PageNotFound({ location }: PageProps) {
   const [searchOpen, setSearchOpen] = React.useState<boolean>(false);
 
   return (
-    <DocLayout custom noElevation title="Page not found" location={location} path="/">
+    <DocLayout custom noElevation title="Page not found" location={location} path="/" noTopBar>
       <Stack flex>
         <Stack spacing="XLarge">
           <Stack spacing="small">

--- a/docs/src/templates/Doc.tsx
+++ b/docs/src/templates/Doc.tsx
@@ -13,6 +13,7 @@ interface Props extends PageRendererProps {
         headerLink: string;
         slug: string;
         title: string;
+        storybookLink: null | string;
         breadcrumbs: Array<{
           name: string;
           url: string;
@@ -51,6 +52,7 @@ export default function Doc({ data, location }: Props) {
       tabs={usedTabs}
       title={fields.title}
       breadcrumbs={fields.breadcrumbs}
+      storybookLink={fields.storybookLink}
     >
       <MDXRenderer>{body}</MDXRenderer>
     </DocLayout>
@@ -65,6 +67,7 @@ export const query = graphql`
         headerLink
         slug
         title
+        storybookLink
         breadcrumbs {
           name
           url

--- a/docs/src/templates/Doc.tsx
+++ b/docs/src/templates/Doc.tsx
@@ -10,10 +10,12 @@ interface Props extends PageRendererProps {
     mdx: {
       fields: {
         description: string;
+        hasHeaderLink: boolean;
         headerLink: string;
         slug: string;
         title: string;
-        storybookLink: null | string;
+        hasStorybook: boolean;
+        storybookLink: string;
         breadcrumbs: Array<{
           name: string;
           url: string;
@@ -46,12 +48,14 @@ export default function Doc({ data, location }: Props) {
   return (
     <DocLayout
       description={fields.description}
+      hasHeaderLink={fields.hasHeaderLink}
       headerLink={fields.headerLink}
       location={location}
       path={fields.slug}
       tabs={usedTabs}
       title={fields.title}
       breadcrumbs={fields.breadcrumbs}
+      hasStorybook={fields.hasStorybook}
       storybookLink={fields.storybookLink}
     >
       <MDXRenderer>{body}</MDXRenderer>
@@ -64,9 +68,11 @@ export const query = graphql`
     mdx(id: { eq: $id }) {
       fields {
         description
+        hasHeaderLink
         headerLink
         slug
         title
+        hasStorybook
         storybookLink
         breadcrumbs {
           name

--- a/docs/src/templates/Overview.tsx
+++ b/docs/src/templates/Overview.tsx
@@ -40,13 +40,7 @@ const Overview = ({ location, pageContext }: Props) => {
 
   return (
     render && (
-      <DocLayout
-        location={location}
-        path={slug}
-        title={title}
-        breadcrumbs={breadcrumbs}
-        noElevation
-      >
+      <DocLayout location={location} path={slug} title={title} breadcrumbs={breadcrumbs}>
         <Grid
           columns="1fr"
           gap="2rem"


### PR DESCRIPTION
It is now possible to add custom storybook and headerlinks (usually for Github) on the meta.yml file.
This also allows to hide the button when it is defined to `false`.

The Tabs documentation page was broken and is now fixed.
 Storybook: https://orbit-mainframev-docs-add-custom-topbar-links.surge.sh