### PR TITLE
feat(InputField): set autoCorrect and autoCapitalize explicitly to off

### DIFF
--- a/packages/orbit-components/src/InputField/index.tsx
+++ b/packages/orbit-components/src/InputField/index.tsx
@@ -251,6 +251,8 @@ Suffix.defaultProps = {
 interface StyledInputProps extends Partial<Props> {
   min: number;
   max: number;
+  autoCorrect: string;
+  autoCapitalize: string;
   ariaLabelledby?: string;
 }
 
@@ -500,6 +502,8 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             ariaLabelledby={!label ? inputId : undefined}
             inlineLabel={inlineLabel}
             readOnly={readOnly}
+            autoCapitalize="off"
+            autoCorrect="off"
             autoComplete={autoComplete}
             autoFocus={autoFocus}
             id={inputId}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#autocorrect

[why](https://baymard.com/labs/touch-keyboard-types)