### PR TITLE
feat: add inlineStacked property to CarrierLogo

### DIFF
--- a/docs/src/__examples__/CarrierLogo/MULTIPLE.tsx
+++ b/docs/src/__examples__/CarrierLogo/MULTIPLE.tsx
@@ -70,6 +70,32 @@ export default {
           },
         ]}
       />
+      <CarrierLogo
+        inlineStacked
+        rounded
+        carriers={[
+          {
+            code: "OK",
+            type: "airline",
+            name: "Czech Airlines",
+          },
+          {
+            code: "FR",
+            type: "airline",
+            name: "Ryanair",
+          },
+          {
+            code: "TO",
+            type: "airline",
+            name: "Transavia France",
+          },
+          {
+            code: "VY",
+            type: "airline",
+            name: "Vueling",
+          },
+        ]}
+      />
     </Stack>
   ),
 };

--- a/docs/src/documentation/03-components/08-visuals/carrierlogo/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/08-visuals/carrierlogo/01-guidelines.mdx
@@ -46,4 +46,7 @@ With two logos, they're in the top left and bottom right.
 With three, the second logo shifts to the bottom left and the third is present in the top right.
 With four, the logos take up all four corners.
 
+Optionally, it's also possible to display all logos inline, slightly stacked on top of each other.
+In that case, the size of each logo is bigger, as if there was only one.
+
 <ReactExample exampleId="CarrierLogo-multiple" />

--- a/packages/orbit-components/src/CarrierLogo/CarrierLogo.stories.tsx
+++ b/packages/orbit-components/src/CarrierLogo/CarrierLogo.stories.tsx
@@ -75,6 +75,27 @@ FourCarriers.story = {
   },
 };
 
+export const InlineStacked = () => {
+  const carrier = [
+    { code: "FR", name: "Ryanair" },
+    { code: "TO", name: "Transavia France" },
+    { code: "VY", name: "Vueling" },
+    { code: "OK", name: "Czech Airlines" },
+  ];
+
+  const carriersObject = object(carriersLabel, carrier);
+
+  return <CarrierLogo carriers={carriersObject} inlineStacked rounded />;
+};
+
+InlineStacked.story = {
+  name: "Inline stacked",
+
+  parameters: {
+    info: "Carrier logos are displayed inline, stacking on top of each other.",
+  },
+};
+
 export const NonExistingCarriers = () => {
   const carrier: Carrier[] = [
     { code: "LOL", name: "Lorem ipsum", type: "airline" },
@@ -121,6 +142,8 @@ NonExistingCarrier.story = {
 export const Rtl = () => (
   <RenderInRtl>
     <CarrierLogo
+      rounded
+      inlineStacked
       size="large"
       carriers={[
         { code: "FR", name: "Lorem ipsum", type: "airline" },

--- a/packages/orbit-components/src/CarrierLogo/README.md
+++ b/packages/orbit-components/src/CarrierLogo/README.md
@@ -16,13 +16,14 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in CarrierLogo component.
 
-| Name         | Type                    | Default   | Description                                                            |
-| :----------- | :---------------------- | :-------- | :--------------------------------------------------------------------- |
-| **carriers** | [`Carrier[]`](#carrier) |           | The content of the CarrierLogo, passed as array of objects.            |
-| dataTest     | `string`                |           | Optional prop for testing purposes.                                    |
-| id           | `string`                |           | Set `id` for `CarrierLogo`                                             |
-| size         | [`enum`](#enum)         | `"large"` | The size of the CarrierLogo. [See Functional specs](#functional-specs) |
-| rounded      | `boolean`               |           | Rounded carrier image                                                  |
+| Name          | Type                    | Default   | Description                                                            |
+| :------------ | :---------------------- | :-------- | :--------------------------------------------------------------------- |
+| **carriers**  | [`Carrier[]`](#carrier) |           | The content of the CarrierLogo, passed as array of objects.            |
+| dataTest      | `string`                |           | Optional prop for testing purposes.                                    |
+| id            | `string`                |           | Set `id` for `CarrierLogo`                                             |
+| size          | [`enum`](#enum)         | `"large"` | The size of the CarrierLogo. [See Functional specs](#functional-specs) |
+| rounded       | `boolean`               |           | Rounded carrier image                                                  |
+| inlineStacked | `boolean`               |           | Carrier logos are displayed inline, stacking on top of each other.     |
 
 ### Carrier
 

--- a/packages/orbit-components/src/CarrierLogo/types.ts
+++ b/packages/orbit-components/src/CarrierLogo/types.ts
@@ -16,4 +16,5 @@ export interface Props extends Common.Globals {
   readonly size?: Size;
   readonly rounded?: boolean;
   readonly carriers: Common.Carrier[];
+  readonly inlineStacked?: boolean;
 }


### PR DESCRIPTION
CarrierLogo now supports inline stacking of logos, as it is needed for the SHOT project.

<img width="417" alt="image" src="https://user-images.githubusercontent.com/6265045/201968043-8bc7fdfd-3e28-4f3a-b9d6-61ebaa956a54.png">
