### PR TITLE
fix(Box): wrap property was calculated incorrectly

### DIFF
--- a/packages/orbit-components/src/Box/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Box/__tests__/index.test.tsx
@@ -86,7 +86,7 @@ describe("#Box", () => {
 
   it("should have display flex", () => {
     render(
-      <Box dataTest={dataTest} display="flex" wrap="wrap" direction="row" grow={0} shrink={0}>
+      <Box dataTest={dataTest} display="flex" wrap="nowrap" direction="row" grow={0} shrink={0}>
         kek
       </Box>,
     );
@@ -95,7 +95,7 @@ describe("#Box", () => {
     expect(screen.getByTestId(dataTest)).toHaveStyle({ flexDirection: "row" });
     expect(screen.getByTestId(dataTest)).toHaveStyle({ flexShrink: "0" });
     expect(screen.getByTestId(dataTest)).toHaveStyle({ flexGrow: "0" });
-    expect(screen.getByTestId(dataTest)).toHaveStyle({ flexWrap: "wrap" });
+    expect(screen.getByTestId(dataTest)).toHaveStyle({ flexWrap: "nowrap" });
   });
 
   it.each(Object.values(DIRECTIONS))("should have directions", direction => {

--- a/packages/orbit-components/src/Box/normalize.ts
+++ b/packages/orbit-components/src/Box/normalize.ts
@@ -2,7 +2,7 @@ import { WIDTH_AND_HEIGHT } from "./consts";
 import { TOKENS } from "../utils/layout/consts";
 import type { ThemeProps, Theme } from "../defaultTheme";
 import { firstToUpper } from "../utils/common";
-import { getJustify, getAlign, formatCSS, getDirection, getWrap, isDefined } from "../utils/layout";
+import { getJustify, getAlign, formatCSS, getDirection, isDefined } from "../utils/layout";
 import type { MediaQueryObject, Elevation, SpacingToken, SpacingObject, Props } from "./types";
 
 const normalizeSpacing = (
@@ -58,7 +58,7 @@ const norm = ({ val, key, theme }): string | void => {
     direction: formatCSS("flex-direction", getDirection(val)),
     grow: formatCSS("flex-grow", val),
     shrink: formatCSS("flex-shrink", val),
-    wrap: formatCSS("flex-wrap", getWrap(val)),
+    wrap: formatCSS("flex-wrap", val),
     textAlign: formatCSS("text-align", val),
     minWidth: formatCSS("min-width", val),
     maxWidth: formatCSS("max-width", val),


### PR DESCRIPTION
The wrap property in Box component was evaluating its value wrongly.
One test was also changed so it actually failed before and passes now.

[Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1669201347964819)