### PR TITLE
fix(Heading): add missing role='heading' for div rendered as Heading

### DIFF
--- a/packages/orbit-components/src/Heading/index.tsx
+++ b/packages/orbit-components/src/Heading/index.tsx
@@ -50,6 +50,7 @@ export const StyledHeading = styled(
       className={className}
       data-test={dataTest}
       data-a11y-section={dataA11ySection}
+      role={Component === "div" ? "heading" : undefined}
       id={id}
     >
       {children}


### PR DESCRIPTION
https://www.a11yproject.com/posts/how-to-accessible-heading-structure/

about our discussion inside the repo analysis doc. I think it's a better approach, do not to introduce a breaking change without forcing users to pick an element. 