### PR TITLE
fix(Tooltip): background color

### DIFF
--- a/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/resolveBackgroundColor.ts
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/helpers/resolveBackgroundColor.ts
@@ -12,7 +12,7 @@ const backgroundColor = ({
   if (error) return theme.orbit.paletteRedNormal;
   if (help) return theme.orbit.paletteBlueNormal;
 
-  return theme.orbit.paletteInkNormal;
+  return theme.orbit.paletteInkDark;
 };
 
 export default backgroundColor;


### PR DESCRIPTION
The background color of the tooltip was incorrect, as noticed during pair programming.