### PR TITLE
feat(Button): add centered prop for fullWidth

### DIFF
--- a/packages/orbit-components/src/Button/Button.stories.tsx
+++ b/packages/orbit-components/src/Button/Button.stories.tsx
@@ -83,6 +83,49 @@ ButtonWithIcons.story = {
   },
 };
 
+export const FullWidthButtons = () => {
+  const children = text("Children", "Button");
+  const type = select("Type", Object.values(TYPE_OPTIONS), TYPE_OPTIONS.PRIMARY);
+  const size = select("Size", Object.values(SIZE_OPTIONS), SIZE_OPTIONS.NORMAL);
+  const IconLeft = getIcon(getIcons("iconLeft", "PlusCircle"));
+  const IconRight = getIcon(getIcons("iconRight", "ChevronDown"));
+
+  return (
+    <Stack spacing="small" direction="column">
+      <Button
+        onClick={action("clicked")}
+        fullWidth
+        type={type}
+        size={size}
+        iconLeft={IconLeft && <IconLeft />}
+        iconRight={IconRight && <IconRight />}
+      >
+        {children}
+      </Button>
+      <Button
+        onClick={action("clicked")}
+        centered
+        fullWidth
+        type={type}
+        size={size}
+        iconLeft={IconLeft && <IconLeft />}
+        iconRight={IconRight && <IconRight />}
+      >
+        {children}
+      </Button>
+    </Stack>
+  );
+};
+
+FullWidthButtons.story = {
+  name: "Full width buttons",
+
+  parameters: {
+    info:
+      "By default, a full width Button renders with the children centered. However, if icons are used, the content will align to the left by default. In such scenario, the centered prop can be used to center everything.",
+  },
+};
+
 export const SubtleButtons = () => {
   const children = text("Children", "Button");
   const IconLeft = getIcon(getIcons("iconLeft", "CloseCircle"));

--- a/packages/orbit-components/src/Button/README.md
+++ b/packages/orbit-components/src/Button/README.md
@@ -22,6 +22,7 @@ Table below contains all types of the props available in Button component.
 | ariaExpanded | `boolean`                  |             | Tells screen reader the controlled element from `ariaControls` is expanded                                                                                     |
 | asComponent  | `string \| React.Element`  | `"button"`  | The component used for the root node.                                                                                                                          |
 | fullWidth    | `boolean`                  | `false`     | If `true`, the Button will grow up to the full width of its container.                                                                                         |
+| centered     | `boolean`                  | `false`     | Can only be used when `fullWidth` is true and if `iconLeft` and/or `iconRight` are defined. If `centered` prop is `true`, the Button will center everything.   |
 | circled      | `boolean`                  | `false`     | If `true`, the Button will have circular shape.                                                                                                                |
 | children     | `React.Node`               |             | The content of the Button. [See Functional specs](#functional-specs)                                                                                           |
 | dataTest     | `string`                   |             | Optional prop for testing purposes.                                                                                                                            |
@@ -79,6 +80,8 @@ Table below contains all types of the props available in Button component.
   ```jsx
   const YourComponent = props => <div {...props}>YourComponent</div>;
   ```
+
+- By default, a full width Button renders with the children centered. However, if `iconLeft` and/or `iconRight` are defined, the content will align to the left by default. In such scenario, the `centered` prop can be used to center everything.
 
 ## Accessibility
 

--- a/packages/orbit-components/src/Button/index.tsx
+++ b/packages/orbit-components/src/Button/index.tsx
@@ -7,9 +7,9 @@ import getCommonProps from "../primitives/ButtonPrimitive/common/getCommonProps"
 import useTheme from "../hooks/useTheme";
 import getButtonStyles from "./helpers/getButtonStyles";
 import getButtonIconForeground from "./helpers/getButtonIconForeground";
-import type { Props } from "./types";
+import type { Props, FullWidthConditionalProps } from "./types";
 
-const Button = React.forwardRef<HTMLButtonElement, Props>(
+const Button = React.forwardRef<HTMLButtonElement, Props & FullWidthConditionalProps>(
   ({ type = TYPE_OPTIONS.PRIMARY, size, disabled = false, ...props }, ref) => {
     const theme = useTheme();
     const propsWithTheme = { theme, size, ...props };

--- a/packages/orbit-components/src/Button/types.d.ts
+++ b/packages/orbit-components/src/Button/types.d.ts
@@ -16,6 +16,16 @@ export type Type =
 
 export type ButtonStates = "default" | "hover" | "active" | "focus";
 
+export type FullWidthConditionalProps =
+  | {
+      readonly fullWidth: true;
+      readonly centered?: boolean;
+    }
+  | {
+      readonly fullWidth?: false;
+      readonly centered?: never;
+    };
+
 export interface Props extends ButtonCommonProps {
   readonly type?: Type;
   readonly size?: Size;

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/common/__tests__/__snapshots__/getCommonProps.test.ts.snap
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/common/__tests__/__snapshots__/getCommonProps.test.ts.snap
@@ -23,3 +23,15 @@ Object {
   "width": undefined,
 }
 `;
+
+exports[`ButtonPrimitive: getCommonProps function should match: undefined contentWidth and center align 1`] = `
+Object {
+  "contentAlign": "center",
+  "contentWidth": undefined,
+  "fontSize": "14px",
+  "fontWeight": "500",
+  "height": "44px",
+  "padding": "0 16px",
+  "width": undefined,
+}
+`;

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/common/__tests__/getCommonProps.test.ts
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/common/__tests__/getCommonProps.test.ts
@@ -21,4 +21,9 @@ describe("ButtonPrimitive: getCommonProps function", () => {
       }),
     ).toMatchSnapshot();
   });
+  it("should match: undefined contentWidth and center align", () => {
+    const fullWidth = true;
+    const centered = true;
+    expect(getCommonProps({ fullWidth, centered, theme })).toMatchSnapshot();
+  });
 });

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/common/getCommonProps.ts
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/common/getCommonProps.ts
@@ -7,7 +7,15 @@ import type { Theme } from "../../../defaultTheme";
 export interface Params
   extends Pick<
     ButtonCommonProps,
-    "iconRight" | "contentAlign" | "contentWidth" | "iconLeft" | "width" | "iconRight" | "children"
+    | "iconRight"
+    | "contentAlign"
+    | "contentWidth"
+    | "iconLeft"
+    | "width"
+    | "iconRight"
+    | "children"
+    | "fullWidth"
+    | "centered"
   > {
   size?: Size;
   theme: Theme;
@@ -27,11 +35,15 @@ const getCommonProps = ({
   iconRight,
   contentAlign,
   contentWidth,
+  fullWidth,
+  centered,
   iconLeft,
   children,
 }: Params): Output => {
   const onlyIcon = Boolean((iconLeft || iconRight) && !children);
-  const hasCenteredContent = Boolean(onlyIcon || (children && !(iconLeft || iconRight)));
+  const hasCenteredContent = Boolean(
+    onlyIcon || (children && !(iconLeft || iconRight)) || (fullWidth && centered),
+  );
 
   return {
     ...getSizeToken(size, theme),
@@ -39,7 +51,7 @@ const getCommonProps = ({
     padding: getPadding(onlyIcon, iconRight, iconLeft, size, theme),
     fontWeight: theme.orbit.fontWeightMedium,
     contentAlign: contentAlign || (onlyIcon || hasCenteredContent ? "center" : "space-between"),
-    contentWidth: contentWidth || "100%",
+    contentWidth: contentWidth || (fullWidth && centered ? undefined : "100%"),
   };
 };
 

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/components/ButtonPrimitiveContentChildren.tsx
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/components/ButtonPrimitiveContentChildren.tsx
@@ -5,16 +5,17 @@ import { left } from "../../../utils/rtl";
 import defaultTheme from "../../../defaultTheme";
 
 interface Props {
+  centered?: boolean;
   hasIcon: boolean;
   contentWidth?: string | null;
 }
 
 const StyledButtonPrimitiveContentChildren = styled.div<Props>`
-  ${({ hasIcon, contentWidth }) => css`
+  ${({ hasIcon, contentWidth, centered }) => css`
     display: inline-block;
     width: ${contentWidth};
-    text-align: ${hasIcon && left};
     line-height: 1;
+    text-align: ${hasIcon && !centered && left};
   `}
 `;
 
@@ -26,8 +27,13 @@ const ButtonPrimitiveContentChildren = ({
   children,
   hasIcon,
   contentWidth,
+  centered,
 }: React.PropsWithChildren<Props>) => (
-  <StyledButtonPrimitiveContentChildren hasIcon={hasIcon} contentWidth={contentWidth}>
+  <StyledButtonPrimitiveContentChildren
+    hasIcon={hasIcon}
+    contentWidth={contentWidth}
+    centered={centered}
+  >
     {children}
   </StyledButtonPrimitiveContentChildren>
 );

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.tsx
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.tsx
@@ -221,6 +221,8 @@ const ButtonPrimitive = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, 
       icons = { width: null, height: null, leftMargin: null, rightMargin: null },
       contentAlign = "center",
       contentWidth,
+      fullWidth,
+      centered,
     } = props;
     const { width, height, leftMargin, rightMargin } = icons;
     const isDisabled = loading || disabled;
@@ -239,6 +241,7 @@ const ButtonPrimitive = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, 
             <ButtonPrimitiveContentChildren
               hasIcon={Boolean(iconLeft || iconRight)}
               contentWidth={contentWidth}
+              centered={fullWidth && centered}
             >
               {children}
             </ButtonPrimitiveContentChildren>

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/types.d.ts
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/types.d.ts
@@ -12,6 +12,7 @@ export interface ButtonCommonProps extends Common.Globals, Common.SpaceAfter {
   readonly ariaCurrent?: string;
   readonly ariaExpanded?: boolean;
   readonly ariaLabelledby?: string;
+  readonly centered?: boolean;
   readonly children?: React.ReactNode;
   readonly circled?: boolean;
   readonly underlined?: boolean;


### PR DESCRIPTION
It is now possible to center the content of a fullWidth button.