### PR TITLE
feat(Button): add line-height: 1

### DIFF
--- a/packages/orbit-components/src/primitives/ButtonPrimitive/components/ButtonPrimitiveContentChildren.tsx
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/components/ButtonPrimitiveContentChildren.tsx
@@ -14,6 +14,7 @@ const StyledButtonPrimitiveContentChildren = styled.div<Props>`
     display: inline-block;
     width: ${contentWidth};
     text-align: ${hasIcon && left};
+    line-height: 1;
   `}
 `;
 


### PR DESCRIPTION
This avoid multi-line text inside button to be misaligned

[Slack context](https://skypicker.slack.com/archives/CAMS40F7B/p1669886645300519)