### PR TITLE
fix(Card): inconsistent expanded state is now impossible

### DIFF
--- a/packages/orbit-components/src/Card/CardSection/types.d.ts
+++ b/packages/orbit-components/src/Card/CardSection/types.d.ts
@@ -6,19 +6,30 @@ import type * as React from "react";
 import type * as Common from "../../common/types";
 import type { As } from "../../Heading/types";
 
-export interface Props extends Common.Globals {
+type ExpandableConditionalProps =
+  | {
+      readonly expandable?: false;
+      readonly expanded?: never;
+      readonly initialExpanded?: never;
+    }
+  | {
+      readonly expandable: true;
+      readonly expanded?: boolean;
+      readonly initialExpanded?: boolean;
+    };
+
+interface CardProps extends Common.Globals {
   readonly title?: React.ReactNode;
   readonly titleAs?: As;
   readonly icon?: React.ReactNode;
   readonly description?: React.ReactNode;
   readonly children?: React.ReactNode;
-  readonly expandable?: boolean;
-  readonly initialExpanded?: boolean;
   readonly actions?: React.ReactNode;
-  readonly expanded?: boolean;
   readonly noSeparator?: boolean;
   readonly onClose?: Common.Callback;
   readonly onExpand?: Common.Callback;
   readonly onClick?: Common.Callback;
   readonly header?: React.ReactNode;
 }
+
+export type Props = CardProps & ExpandableConditionalProps;

--- a/packages/orbit-components/src/Card/README.md
+++ b/packages/orbit-components/src/Card/README.md
@@ -49,24 +49,24 @@ import Card, { CardSection } from "@kiwicom/orbit-components/lib/Card";
 
 #### Props
 
-| Name            | Type                       | Default | Description                                                                                                                                                |
-| :-------------- | :------------------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| actions         | `React.Node`               |         | Actions which will be rendered on the right side                                                                                                           |
-| children        | `React.Node`               |         | The content of the CardSection.                                                                                                                            |
-| dataTest        | `string`                   |         | Optional prop for testing purposes.                                                                                                                        |
-| description     | `React.Node`               |         | The description of the CardSection                                                                                                                         |
-| expandable      | `boolean`                  | `false` | If `true`, the CardSection will be expandable.                                                                                                             |
-| expanded        | `boolean`                  |         | If you pass either `true` or `false` the CardSection component will controlled component and you will have to manage the state via `onExpand` or `onClose` |
-| header          | `React.Node`               |         | The header of the CardSection. Useful when you need different layout than combination of e.g. `title` and `description` properties.                        |
-| icon            | `React.Node`               |         | Displayed icon on the left side of the CardSection.                                                                                                        |
-| initialExpanded | `boolean`                  | `false` | Initial state of expandable CardSection when it mounts in uncontrolled variant                                                                             |
-| noSeparator     | `Boolean`                  |         | Optional prop to turn off Separator between `header` and `children`                                                                                        |
-| onClick         | `event => void \| Promise` |         | Function for handling the onClick event.                                                                                                                   |
+| Name            | Type                       | Default | Description                                                                                                                                                                                             |
+| :-------------- | :------------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| actions         | `React.Node`               |         | Actions which will be rendered on the right side                                                                                                                                                        |
+| children        | `React.Node`               |         | The content of the CardSection.                                                                                                                                                                         |
+| dataTest        | `string`                   |         | Optional prop for testing purposes.                                                                                                                                                                     |
+| description     | `React.Node`               |         | The description of the CardSection                                                                                                                                                                      |
+| expandable      | `boolean`                  | `false` | If `true`, the CardSection will be expandable.                                                                                                                                                          |
+| expanded        | `boolean`                  |         | If you pass either `true` or `false` the CardSection component will controlled component and you will have to manage the state via `onExpand` or `onClose`. Can only be used if `expandable` is `true`. |
+| header          | `React.Node`               |         | The header of the CardSection. Useful when you need different layout than combination of e.g. `title` and `description` properties.                                                                     |
+| icon            | `React.Node`               |         | Displayed icon on the left side of the CardSection.                                                                                                                                                     |
+| initialExpanded | `boolean`                  | `false` | Initial state of expandable CardSection when it mounts in uncontrolled variant. Can only be used if `expandable` is `true`.                                                                             |
+| noSeparator     | `Boolean`                  |         | Optional prop to turn off Separator between `header` and `children`                                                                                                                                     |
+| onClick         | `event => void \| Promise` |         | Function for handling the onClick event.                                                                                                                                                                |
 |                 |
-| onClose         | `() => void \| Promise`    |         | Callback that is triggered when section is closing                                                                                                         |
-| onExpand        | `() => void \| Promise`    |         | Callback that is triggered when section is expanding                                                                                                       |
-| title           | `React.Node`               |         | The title of the CardSection                                                                                                                               |
-| titleAs         | [`enum`](#enum)            | `"h2"`  | The element used for the root node of the title of CardSection.                                                                                            |
+| onClose         | `() => void \| Promise`    |         | Callback that is triggered when section is closing                                                                                                                                                      |
+| onExpand        | `() => void \| Promise`    |         | Callback that is triggered when section is expanding                                                                                                                                                    |
+| title           | `React.Node`               |         | The title of the CardSection                                                                                                                                                                            |
+| titleAs         | [`enum`](#enum)            | `"h2"`  | The element used for the root node of the title of CardSection.                                                                                                                                         |
 
 ### enum
 


### PR DESCRIPTION
It is now impossible to define `expanded` or `initialExpanded` when `expandable` is not defined