### PR TITLE
fix(Button): export conditional types correctly

### DIFF
--- a/packages/orbit-components/src/Button/index.tsx
+++ b/packages/orbit-components/src/Button/index.tsx
@@ -7,9 +7,9 @@ import getCommonProps from "../primitives/ButtonPrimitive/common/getCommonProps"
 import useTheme from "../hooks/useTheme";
 import getButtonStyles from "./helpers/getButtonStyles";
 import getButtonIconForeground from "./helpers/getButtonIconForeground";
-import type { Props, FullWidthConditionalProps } from "./types";
+import type { Props } from "./types";
 
-const Button = React.forwardRef<HTMLButtonElement, Props & FullWidthConditionalProps>(
+const Button = React.forwardRef<HTMLButtonElement, Props>(
   ({ type = TYPE_OPTIONS.PRIMARY, size, disabled = false, ...props }, ref) => {
     const theme = useTheme();
     const propsWithTheme = { theme, size, ...props };

--- a/packages/orbit-components/src/Button/types.d.ts
+++ b/packages/orbit-components/src/Button/types.d.ts
@@ -16,7 +16,7 @@ export type Type =
 
 export type ButtonStates = "default" | "hover" | "active" | "focus";
 
-export type FullWidthConditionalProps =
+type FullWidthConditionalProps =
   | {
       readonly fullWidth: true;
       readonly centered?: boolean;
@@ -26,7 +26,9 @@ export type FullWidthConditionalProps =
       readonly centered?: never;
     };
 
-export interface Props extends ButtonCommonProps {
+interface ButtonProps extends ButtonCommonProps {
   readonly type?: Type;
   readonly size?: Size;
 }
+
+export type Props = ButtonProps & FullWidthConditionalProps;


### PR DESCRIPTION
Conditional type props were not being exported. They are now.