### PR TITLE
fix(ItinerarySegment): fix incorrect counting of elements

### DIFF
--- a/packages/orbit-components/src/Itinerary/ItinerarySegment/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItinerarySegment/index.tsx
@@ -58,11 +58,11 @@ const ItinerarySegment = ({
               index: i,
               opened,
               toggleOpened: () => setOpened(prev => !prev),
-              last: i === React.Children.count(children) - 1,
+              last: i === content.length - 1,
               isNextHidden: Boolean(content[i + 1]?.props?.hidden),
               isPrevHidden: Boolean(content[i - 1]?.props?.hidden),
               isBanner: !!banner,
-              count: React.Children.count(children),
+              count: content.length,
               isHidden: !!(el.props && el.props.hidden),
               noElevation: !!noElevation,
             }}


### PR DESCRIPTION
Fixes the issue with incorrect counting of elements. React.Children.count counts elements that are not even rendered.  