### PR TITLE
fix(Card): remove additional padding in CardSection

### DIFF
--- a/packages/orbit-components/src/Card/CardSection/components/SectionContent.tsx
+++ b/packages/orbit-components/src/Card/CardSection/components/SectionContent.tsx
@@ -31,9 +31,9 @@ const StyledCardSectionContent = styled.div<Partial<Props>>`
     transition: ${transition(["padding", "border-top"], "fast", "linear")};
 
     ${mq.largeMobile(css`
-      padding-top: ${theme.orbit.spaceLarge};
+      padding-top: ${hasPaddingTop && theme.orbit.spaceLarge};
     `)}
-  `}
+  `};
 `;
 
 StyledCardSectionContent.defaultProps = {


### PR DESCRIPTION
Looks like redundant padding, check how currently it looks with "onlySection" in storybook