### PR TITLE
fix(CarrierLogo): correct width when inlineStacked

### DIFF
--- a/packages/orbit-components/src/CarrierLogo/index.tsx
+++ b/packages/orbit-components/src/CarrierLogo/index.tsx
@@ -27,6 +27,12 @@ const getRenderSize = ({ theme, size }) => {
   return renderSizes[size];
 };
 
+const getWidth = ({ theme, size, inlineStacked, totalCarriers }) => {
+  if (inlineStacked) return "min-content";
+
+  return totalCarriers > 1 ? theme.orbit.widthCarrierLogo : `${getRenderSize({ theme, size })}px`;
+};
+
 const getCarrierLogoSize = ({ theme, carriersLength, size, inlineStacked }) => {
   const defaultSizes =
     carriersLength > 1 && !inlineStacked
@@ -101,9 +107,7 @@ export const StyledCarrierLogo = styled.div<{
     height: ${carriers.length > 1 && !inlineStacked
       ? theme.orbit.heightCarrierLogo
       : `${getRenderSize({ theme, size })}px`};
-    width: ${carriers.length > 1
-      ? theme.orbit.widthCarrierLogo
-      : `${getRenderSize({ theme, size })}px`};
+    width: ${getWidth({ theme, size, inlineStacked, totalCarriers: carriers.length })};
     display: flex;
     flex-direction: ${carriers.length > 1 && !inlineStacked ? "column" : "row"};
     flex-wrap: ${carriers.length > 2 && !inlineStacked && "wrap"};


### PR DESCRIPTION
Width was incorrectly set to a fixed value even when inlineStacked was set to true. This was detected when using the component for the first time.

**Before:**
<img width="97" alt="image" src="https://user-images.githubusercontent.com/6265045/208696171-e2f68889-9f27-496e-bf8c-95765c6830fa.png">


**After:**
<img width="89" alt="image" src="https://user-images.githubusercontent.com/6265045/208696051-36c2086f-131d-466d-9cfc-ef92ac6458b6.png">
