### PR TITLE
feat: remove default margin top from modal header

### DIFF
--- a/packages/orbit-components/src/Modal/ModalHeader/index.tsx
+++ b/packages/orbit-components/src/Modal/ModalHeader/index.tsx
@@ -154,8 +154,19 @@ MobileHeader.defaultProps = {
   theme: defaultTheme,
 };
 
-const StyledModalHeaderContent = styled.div<{ description?: boolean }>`
-  margin-top: ${({ description }) => (description ? "32px" : "16px")};
+const getModalHeaderContentMargin = ({ hasHeader, hasDescription, hasChildren }) => {
+  if (!hasHeader && hasChildren) return "0";
+
+  return hasDescription ? "32px" : "16px";
+};
+
+const StyledModalHeaderContent = styled.div<{
+  hasHeader: boolean;
+  hasDescription: boolean;
+  hasChildren: boolean;
+}>`
+  margin-top: ${({ hasHeader, hasDescription, hasChildren }) =>
+    getModalHeaderContentMargin({ hasHeader, hasDescription, hasChildren })};
 `;
 
 const ModalHeader = ({
@@ -202,7 +213,13 @@ const ModalHeader = ({
         </ModalTitle>
       )}
       {children && (
-        <StyledModalHeaderContent description={!!description}>{children}</StyledModalHeaderContent>
+        <StyledModalHeaderContent
+          hasHeader={!!hasHeader}
+          hasChildren={!!children}
+          hasDescription={!!description}
+        >
+          {children}
+        </StyledModalHeaderContent>
       )}
       {title && hasMobileHeader && (
         <MobileHeader role="presentation" isMobileFullPage={isMobileFullPage}>

--- a/packages/orbit-components/src/Modal/index.tsx
+++ b/packages/orbit-components/src/Modal/index.tsx
@@ -677,6 +677,6 @@ const Modal = React.forwardRef<Instance, Props>(
 Modal.displayName = "Modal";
 export default Modal;
 
-export { default as ModalHeader } from "./ModalHeader";
+export { default as ModalHeader, ModalHeading } from "./ModalHeader";
 export { default as ModalSection } from "./ModalSection";
 export { default as ModalFooter } from "./ModalFooter";


### PR DESCRIPTION
[Slack thread](https://skypicker.slack.com/archives/CAMS40F7B/p1670580968891149).

This is a visual breaking change because there can be users relying on the margin.