### PR TITLE
chore: setup ssh for tracking action

### DIFF
--- a/.github/workflows/cron-tracking.yml
+++ b/.github/workflows/cron-tracking.yml
@@ -11,14 +11,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-known-hosts: ${{ secrets.SSH_HOST }}
 
       - name: Node
         uses: ./.github/actions/node
 
       - name: Update tracking
+        uses: LuisEnMarroquin/setup-ssh-action@v2.0.0
+        with:
+          SSHKEY: ${{ secrets.SSH_KEY }}
         run: |
           yarn tracking build
           yarn tracking orbit-tracking


### PR DESCRIPTION
fixed action for tracking, it should have correct ssh to execute all scripts we have for tracking