### PR TITLE
Remove state update from useErrorTooltip hook

### DIFF
--- a/packages/orbit-components/src/ErrorFormTooltip/__tests__/useErrorTooltip.test.tsx
+++ b/packages/orbit-components/src/ErrorFormTooltip/__tests__/useErrorTooltip.test.tsx
@@ -1,0 +1,56 @@
+import type { SyntheticEvent } from "react";
+import { renderHook, act } from "@testing-library/react-hooks/server";
+
+import useErrorTooltip from "../hooks/useErrorTooltip";
+
+describe("useErrorTooltip hook", () => {
+  it("should call onFocus and show the tooltip", async () => {
+    const onFocus = jest.fn();
+    const ev: unknown = jest.fn();
+
+    const { result, hydrate } = renderHook(() => useErrorTooltip({ onFocus, hasTooltip: true }));
+
+    hydrate();
+
+    expect(result.current.tooltipShown).toBeFalsy();
+
+    act(() => {
+      result.current.handleFocus(ev as SyntheticEvent<HTMLInputElement, Event>);
+    });
+
+    expect(onFocus).toHaveBeenCalledWith(ev);
+    expect(result.current.tooltipShown).toBeTruthy();
+  });
+
+  it("should only call onFocus if it has no tooltip", async () => {
+    const onFocus = jest.fn();
+    const ev: unknown = jest.fn();
+
+    const { result, hydrate } = renderHook(() => useErrorTooltip({ onFocus, hasTooltip: false }));
+
+    hydrate();
+
+    expect(result.current.tooltipShown).toBeFalsy();
+
+    act(() => {
+      result.current.handleFocus(ev as SyntheticEvent<HTMLInputElement, Event>);
+    });
+
+    expect(onFocus).toHaveBeenCalledWith(ev);
+    expect(result.current.tooltipShown).toBeFalsy();
+  });
+
+  it("should allow manual trigger of the tooltip visibility", async () => {
+    const { result, hydrate } = renderHook(() => useErrorTooltip({ hasTooltip: true }));
+
+    hydrate();
+
+    expect(result.current.tooltipShown).toBeFalsy();
+
+    act(() => {
+      result.current.setTooltipShown(true);
+    });
+
+    expect(result.current.tooltipShown).toBeTruthy();
+  });
+});

--- a/packages/orbit-components/src/ErrorFormTooltip/hooks/useErrorTooltip.ts
+++ b/packages/orbit-components/src/ErrorFormTooltip/hooks/useErrorTooltip.ts
@@ -5,8 +5,10 @@ import type { Event } from "../../common/types";
 
 const useErrorTooltip = <T = HTMLInputElement, K = HTMLLabelElement>({
   onFocus,
+  hasTooltip = true,
 }: {
   onFocus?: Event<React.SyntheticEvent<T>>;
+  hasTooltip?: boolean;
 }): {
   tooltipShown: boolean;
   tooltipShownHover: boolean;
@@ -24,9 +26,9 @@ const useErrorTooltip = <T = HTMLInputElement, K = HTMLLabelElement>({
   const handleFocus = useCallback(
     (ev: React.SyntheticEvent<T>) => {
       if (onFocus) onFocus(ev);
-      setTooltipShown(true);
+      if (hasTooltip) setTooltipShown(true);
     },
-    [onFocus],
+    [onFocus, hasTooltip],
   );
 
   return {

--- a/packages/orbit-components/src/InputField/index.tsx
+++ b/packages/orbit-components/src/InputField/index.tsx
@@ -406,6 +406,8 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   const forID = useRandomId();
   const inputId = id || forID;
 
+  const hasTooltip = Boolean(error || help);
+
   const {
     tooltipShown,
     tooltipShownHover,
@@ -414,7 +416,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
     labelRef,
     iconRef,
     handleFocus,
-  } = useErrorTooltip<HTMLInputElement, HTMLDivElement>({ onFocus });
+  } = useErrorTooltip<HTMLInputElement, HTMLDivElement>({ onFocus, hasTooltip });
 
   const shown = tooltipShown || tooltipShownHover;
   const fieldRef = React.useRef<HTMLElement | null>(null);
@@ -532,7 +534,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
           {suffix && <Suffix size={size}>{suffix}</Suffix>}
           <FakeInput size={size} disabled={disabled} error={error} />
         </InputContainer>
-        {!insideInputGroup && (
+        {!insideInputGroup && hasTooltip && (
           <ErrorFormTooltip
             help={help}
             id={`${inputId}-feedback`}

--- a/packages/orbit-components/src/InputFile/index.tsx
+++ b/packages/orbit-components/src/InputFile/index.tsx
@@ -126,6 +126,8 @@ const InputFile = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
     insideInputGroup,
   } = props;
 
+  const hasTooltip = Boolean(error || help);
+
   const {
     tooltipShown,
     tooltipShownHover,
@@ -134,7 +136,7 @@ const InputFile = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
     labelRef,
     iconRef,
     handleFocus,
-  } = useErrorTooltip({ onFocus });
+  } = useErrorTooltip({ onFocus, hasTooltip });
 
   const shown = tooltipShown || tooltipShownHover;
 
@@ -198,7 +200,7 @@ const InputFile = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
           />
         )}
       </FakeInput>
-      {!insideInputGroup && (
+      {!insideInputGroup && hasTooltip && (
         <ErrorFormTooltip
           help={help}
           error={error}

--- a/packages/orbit-components/src/SegmentedSwitch/index.tsx
+++ b/packages/orbit-components/src/SegmentedSwitch/index.tsx
@@ -55,18 +55,22 @@ const SegmentedSwitch = ({
   error,
   label,
 }: Props) => {
+  const hasTooltip = Boolean(error || help);
+
   const {
     tooltipShown,
     tooltipShownHover,
     setTooltipShown,
     setTooltipShownHover,
     labelRef,
-  } = useErrorTooltip({ onFocus });
+  } = useErrorTooltip({ onFocus, hasTooltip });
 
   React.useEffect(() => {
-    if (showTooltip) setTooltipShown(true);
-    else setTooltipShown(false);
-  }, [showTooltip]);
+    if (hasTooltip) {
+      if (showTooltip) setTooltipShown(true);
+      else setTooltipShown(false);
+    }
+  }, [showTooltip, hasTooltip, setTooltipShown]);
 
   return (
     <StyledWrapper spaceAfter={spaceAfter} data-test={dataTest} $maxWidth={maxWidth}>
@@ -94,7 +98,7 @@ const SegmentedSwitch = ({
           />
         ))}
       </Stack>
-      {(!!help || !!error) && (
+      {hasTooltip && (
         <ErrorFormTooltip
           help={help}
           error={error}

--- a/packages/orbit-components/src/Select/index.tsx
+++ b/packages/orbit-components/src/Select/index.tsx
@@ -297,6 +297,8 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
   const forID = useRandomId();
   const selectId = id || forID;
 
+  const hasTooltip = Boolean(error || help);
+
   const {
     tooltipShown,
     tooltipShownHover,
@@ -305,7 +307,7 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
     iconRef,
     setTooltipShown,
     handleFocus,
-  } = useErrorTooltip<HTMLSelectElement, HTMLDivElement>({ onFocus });
+  } = useErrorTooltip<HTMLSelectElement, HTMLDivElement>({ onFocus, hasTooltip });
 
   const inputRef = React.useRef<HTMLLabelElement | null>(null);
 
@@ -376,7 +378,7 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
           <ChevronDown color="secondary" />
         </SelectSuffix>
       </SelectContainer>
-      {!insideInputGroup && (
+      {!insideInputGroup && hasTooltip && (
         <ErrorFormTooltip
           id={`${selectId}-feedback`}
           help={help}

--- a/packages/orbit-components/src/Textarea/index.tsx
+++ b/packages/orbit-components/src/Textarea/index.tsx
@@ -149,6 +149,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, Props>((props, ref) => {
   const forID = useRandomId();
   const inputId = id || forID;
 
+  const hasTooltip = Boolean(error || help);
+
   const {
     tooltipShown,
     tooltipShownHover,
@@ -157,7 +159,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, Props>((props, ref) => {
     labelRef,
     iconRef,
     handleFocus,
-  } = useErrorTooltip({ onFocus });
+  } = useErrorTooltip({ onFocus, hasTooltip });
 
   const shown = tooltipShown || tooltipShownHover;
 
@@ -202,16 +204,18 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, Props>((props, ref) => {
         aria-describedby={shown ? `${inputId}-feedback` : undefined}
         aria-invalid={error ? true : undefined}
       />
-      <ErrorFormTooltip
-        id={`${inputId}-feedback`}
-        help={help}
-        inputSize={size}
-        helpClosable={helpClosable}
-        error={error}
-        onShown={setTooltipShown}
-        shown={shown}
-        referenceElement={labelRef}
-      />
+      {hasTooltip && (
+        <ErrorFormTooltip
+          id={`${inputId}-feedback`}
+          help={help}
+          inputSize={size}
+          helpClosable={helpClosable}
+          error={error}
+          onShown={setTooltipShown}
+          shown={shown}
+          referenceElement={labelRef}
+        />
+      )}
     </Field>
   );
 });


### PR DESCRIPTION
The `useErrorTooltip` hook now receives a new parameter that indicates if it has a tooltip to handle or not. If not, it avoids state update calls that were unnecessary.
Tests to the hook were also added.

All components using the hook were also updated to the correct usage.

[ORBIT-2464](https://kiwicom.atlassian.net/browse/ORBIT-2464)
After this is merged, an update on #3705 is advised, so it avoids further conflicts in the future.
