### PR TITLE
Fix: form label line height

### DIFF
--- a/packages/orbit-components/src/FormLabel/index.tsx
+++ b/packages/orbit-components/src/FormLabel/index.tsx
@@ -78,7 +78,7 @@ const FormLabel = styled(
     font-size: ${theme.orbit.fontSizeFormLabel};
     font-weight: ${theme.orbit.fontWeightMedium};
     color: ${!filled || disabled ? theme.orbit.colorFormLabel : theme.orbit.colorFormLabelFilled};
-    line-height: ${theme.orbit.lineHeightTextSmall};
+    line-height: ${theme.orbit.lineHeightTextNormal};
     margin-bottom: ${theme.orbit.spaceXXSmall};
   `}
 `;

--- a/packages/orbit-components/src/InputGroup/index.tsx
+++ b/packages/orbit-components/src/InputGroup/index.tsx
@@ -46,7 +46,7 @@ const getFakeGroupMarginTop = ({
   theme: typeof defaultTheme;
 }) => {
   if (!label) return false;
-  return `calc(${theme.orbit.lineHeightTextSmall} + ${theme.orbit.spaceXXSmall})`;
+  return `calc(${theme.orbit.lineHeightTextNormal} + ${theme.orbit.spaceXXSmall})`;
 };
 
 const FakeGroup = styled.span<{

--- a/packages/orbit-components/src/SegmentedSwitch/SwitchSegment/index.tsx
+++ b/packages/orbit-components/src/SegmentedSwitch/SwitchSegment/index.tsx
@@ -23,7 +23,7 @@ export const StyledText = styled.div`
     background: ${theme.orbit.paletteWhite};
     color: ${theme.orbit.paletteInkNormal};
     border: 0;
-    padding: 11px 12px;
+    padding: 13px 12px;
     color: ${theme.orbit.paletteInkLight};
     font-family: ${theme.orbit.fontFamily};
     font-weight: ${theme.orbit.fontWeightMedium};


### PR DESCRIPTION
As reported here, the difference in the line-height of the form labels was causing misalignment between components that use it. Adjusting the line-height allows all input components to have the same height and alignment.

This also includes a fix in the SegmentedSwitch option height, so it matches Figma