### PR TITLE
docs(Collapse): fix link pointing to wrong page

### DIFF
--- a/docs/src/documentation/03-components/07-interaction/collapse/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/07-interaction/collapse/01-guidelines.mdx
@@ -17,7 +17,7 @@ redirect_from:
 - For structured information to show one section at a time---use an [accordion](/components/structure/accordion/).
 - For information and/or actions outside the scope of the screen---use a [popover](/components/overlay/popover/).
 - For explanations connected to specific elements---use a [tooltip](/components/overlay/tooltip/).
-- For actions outside the main flow---use a [dialog](/components/overlay/tooltip/) (for simple choices)
+- For actions outside the main flow---use a [dialog](/components/overlay/dialog/) (for simple choices)
   or a [modal](/components/overlay/modal/) (for more structure or options).
 
 ## Component status


### PR DESCRIPTION
# This Pull Request meets the following criteria:

- [ ] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components has both `.flow` and `d.ts` files and are exported in `index.js.flow` and `index.d.ts`
