### PR TITLE
Fix: default margins on text

### DIFF
--- a/packages/orbit-components/src/Illustration/Illustration.stories.tsx
+++ b/packages/orbit-components/src/Illustration/Illustration.stories.tsx
@@ -4,7 +4,6 @@ import { select, text } from "@storybook/addon-knobs";
 // @ts-expect-error currently not resolving mts properly
 import { NAMES } from "./consts.mts";
 import { SIZE_OPTIONS } from "../primitives/IllustrationPrimitive/consts";
-import SPACINGS_AFTER from "../common/getSpacingToken/consts";
 import IllustrationPrimitiveList from "../primitives/IllustrationPrimitive/IllustrationPrimitiveList";
 import type { Name } from "./types";
 
@@ -19,9 +18,8 @@ export const Playground = () => {
   const name = select("Name", Object.values(NAMES), "Accommodation") as Name;
   const dataTest = text("dataTest", "test");
   const alt = text("alt", "");
-  const spaceAfter = select("spaceAfter", Object.values(SPACINGS_AFTER), SPACINGS_AFTER.NORMAL);
   return (
-    <Illustration size={size} name={name} dataTest={dataTest} spaceAfter={spaceAfter} alt={alt} />
+    <Illustration size={size} name={name} dataTest={dataTest} margin={{ bottom: 12 }} alt={alt} />
   );
 };
 

--- a/packages/orbit-components/src/Text/Text.stories.tsx
+++ b/packages/orbit-components/src/Text/Text.stories.tsx
@@ -8,7 +8,6 @@ import {
   ALIGN_OPTIONS,
   ELEMENT_OPTIONS,
 } from "./consts";
-import SPACINGS_AFTER from "../common/getSpacingToken/consts";
 import RenderInRtl from "../utils/rtl/RenderInRtl";
 
 import Text from ".";
@@ -116,7 +115,6 @@ export const Playground = () => {
   const strikeThrough = boolean("StrikeThrough", false);
   const italic = boolean("Italic", false);
   const children = text("Text", customText);
-  const spaceAfter = select("spaceAfter", Object.values(SPACINGS_AFTER), SPACINGS_AFTER.SMALL);
   const dataTest = text("dataTest", "test");
   const id = text("id", "ID");
   const withBackground = boolean("withBackground", false);
@@ -134,7 +132,6 @@ export const Playground = () => {
       uppercase={uppercase}
       italic={italic}
       dataTest={dataTest}
-      spaceAfter={spaceAfter}
     >
       {children}
     </Text>

--- a/packages/orbit-components/src/Text/index.tsx
+++ b/packages/orbit-components/src/Text/index.tsx
@@ -102,6 +102,7 @@ export const StyledText = styled(({ element: TextElement, children, className, d
     text-transform: ${uppercase && `uppercase`};
     text-decoration: ${strikeThrough && `line-through`};
     font-style: ${italic && `italic`};
+    margin: 0;
     ${marginUtility(margin)};
 
     a:not(${StyledTextLink}) {


### PR DESCRIPTION
When adding the margin prop, the default value of 0 was incorrectly replaced by the browser default value on `Text`component.

This also removed the deprecated `spaceAfter` props from storybook knobs on `Text` and `Illustration` components.
