### PR TITLE
Fix Accordion Story + export StyledLabel from Radio + add default value to element prop in StyledText

### DIFF
--- a/packages/orbit-components/src/Accordion/Accordion.stories.tsx
+++ b/packages/orbit-components/src/Accordion/Accordion.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { action } from "@storybook/addon-actions";
 
 import Text from "../Text";
 import Button from "../Button";

--- a/packages/orbit-components/src/Radio/index.tsx
+++ b/packages/orbit-components/src/Radio/index.tsx
@@ -146,7 +146,7 @@ StyledInput.defaultProps = {
   theme: defaultTheme,
 };
 
-const StyledLabel = styled(({ disabled, theme, type, hasError, ...props }) => (
+export const StyledLabel = styled(({ disabled, theme, type, hasError, ...props }) => (
   <label {...props}>{props.children}</label>
 ))`
   ${({ theme, disabled }) => css`

--- a/packages/orbit-components/src/Text/index.tsx
+++ b/packages/orbit-components/src/Text/index.tsx
@@ -75,11 +75,13 @@ const getLineHeightToken = ({
   return lineHeightTokens[size];
 };
 
-export const StyledText = styled(({ element: TextElement, children, className, dataTest, id }) => (
-  <TextElement className={className} data-test={dataTest} id={id}>
-    {children}
-  </TextElement>
-))`
+export const StyledText = styled(
+  ({ element: TextElement = ELEMENT_OPTIONS.P, children, className, dataTest, id }) => (
+    <TextElement className={className} data-test={dataTest} id={id}>
+      {children}
+    </TextElement>
+  ),
+)`
   ${({
     theme,
     align,


### PR DESCRIPTION
This PR addresses multiple issues:
- The `Accordion` component had a broken story because of a missing import
- `StyledLabel` is now exported (to be used internally) on `Radio` component. It is not exported to be used by Orbit users, though.
- The `StyledText` component's `element` prop now has `p` as default value