### PR TITLE
chore(docs): fix text color instructions

### DIFF
--- a/docs/src/documentation/02-foundation/04-color/01-colors.mdx
+++ b/docs/src/documentation/02-foundation/04-color/01-colors.mdx
@@ -226,7 +226,7 @@ For more information about usage, see [Typography](/foundation/typography/) and 
 
 _Ink_ colors are generally used for typography and icons.
 
-<Guideline type="do" title="Use Ink Normal as the main text color">
+<Guideline type="do" title="Use Ink Dark as the main text color">
 
 Even better, rely on the value of <InlineToken name ="colorTextPrimary" />
 as it properly supports theming.


### PR DESCRIPTION
As reported in Slack, docs were outdated from what changed in 4.0.0