### PR TITLE
fix(Modal): border-radius on mobile

### DIFF
--- a/packages/orbit-components/src/Modal/index.tsx
+++ b/packages/orbit-components/src/Modal/index.tsx
@@ -197,6 +197,7 @@ const ModalWrapperContent = styled.div<{
   }) => css`
     position: absolute;
     box-sizing: border-box;
+    border-top-left-radius: ${!isMobileFullPage && "12px"};
     border-top-right-radius: ${!isMobileFullPage && "12px"};
     background-color: ${theme.orbit.backgroundModal};
     font-family: ${theme.orbit.fontFamily};


### PR DESCRIPTION
On mobile, the Modal had an incorrect border-top-left-radius.

[ORBIT-2578](https://kiwicom.atlassian.net/browse/ORBIT-2578)