### PR TITLE
fix(Itinerary): only display chevron if Banner is clickable

### DIFF
--- a/packages/orbit-components/src/Itinerary/Itinerary.stories.tsx
+++ b/packages/orbit-components/src/Itinerary/Itinerary.stories.tsx
@@ -651,6 +651,8 @@ export const InsideModal = () => {
 };
 
 export const MultipleBanners = () => {
+  const [isOpenedModal, setIsOpenedModal] = React.useState(false);
+
   return (
     <>
       <Heading type="title2">Throwaway ticketing</Heading>
@@ -659,7 +661,7 @@ export const MultipleBanners = () => {
           <ItinerarySegment
             banner={
               <Stack direction="column" align="stretch" spacing="XSmall">
-                <ItinerarySegmentBanner>
+                <ItinerarySegmentBanner onClick={() => setIsOpenedModal(true)}>
                   <ItineraryBadgeList>
                     <ItineraryBadgeListItem type="info" icon={<StarFull color="info" />}>
                       <Text as="span" type="info" weight="bold">
@@ -782,6 +784,17 @@ export const MultipleBanners = () => {
           </ItinerarySegment>
         </ItineraryStatus>
       </Itinerary>
+      {isOpenedModal && (
+        <Modal
+          hasCloseButton
+          onClose={ev => {
+            ev.stopPropagation();
+            setIsOpenedModal(false);
+          }}
+        >
+          <ModalSection>Throwaway ticketing info</ModalSection>
+        </Modal>
+      )}
     </>
   );
 };

--- a/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentBanner/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentBanner/index.tsx
@@ -46,7 +46,7 @@ const ItinerarySegmentBanner = ({ onClick, children }: Props) => {
       }}
     >
       <div>{children}</div>
-      <ChevronRight color="secondary" />
+      {onClick && <ChevronRight color="secondary" />}
     </StyledBannerWrapper>
   );
 };


### PR DESCRIPTION
An `ItinerarySegmentBanner` was always displaying a chevron, even if it was not clickable. This is now controlled and the chevron is only displayed if `onClick` is defined.

[ORBIT-2576](https://kiwicom.atlassian.net/browse/ORBIT-2576)