### PR TITLE
fix(Select): remove white bg from container

### DIFF
--- a/packages/orbit-components/src/Select/index.tsx
+++ b/packages/orbit-components/src/Select/index.tsx
@@ -184,15 +184,12 @@ StyledSelect.defaultProps = {
 };
 
 export const SelectContainer = styled.div`
-  ${({ theme }) => css`
-    position: relative;
-    display: flex;
-    align-items: center;
-    background: ${theme.orbit.backgroundInput};
-    width: 100%;
-    box-sizing: border-box;
-    cursor: pointer;
-  `};
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  cursor: pointer;
 `;
 
 SelectContainer.defaultProps = {


### PR DESCRIPTION
The Select component had a white background on its container, that would conflict with the border-radius effect.

Before:
<img width="389" alt="image" src="https://user-images.githubusercontent.com/6265045/219065907-dc3aa043-c5c2-4149-8ab0-c7b2739b2047.png">

After:
<img width="389" alt="image" src="https://user-images.githubusercontent.com/6265045/219065858-d2c45ede-6ce8-464b-a91b-1b2d39d23eea.png">


Resolves #3695 