### PR TITLE
fix(Timeline): fix the last bold line in TimelineStep on desktop

### DIFF
--- a/packages/orbit-components/src/Timeline/TimelineStep/primitives/StyledProgressLine.ts
+++ b/packages/orbit-components/src/Timeline/TimelineStep/primitives/StyledProgressLine.ts
@@ -46,7 +46,7 @@ const StyledProgressLine = styled.span<{
     position: ${!desktop && "absolute"};
     top: ${!desktop && "15px"};
     border-width: 1px;
-    border-style: ${!nextStatus && !last ? "dashed" : "solid"};
+    border-style: ${!status ? "dashed" : "solid"};
     ${getBorderStyle({ desktop, theme, status, nextStatus, prevStatus, last })};
     ${left}: ${!desktop && "11px"};
     width: ${desktop && "50%"};


### PR DESCRIPTION
Current: ![Screenshot 2023-02-16 at 16 30 44](https://user-images.githubusercontent.com/14054752/219411754-cae7b289-3147-4d5c-a52f-7ebc8403a716.png)

Fixed: 
![Screenshot 2023-02-16 at 16 31 54](https://user-images.githubusercontent.com/14054752/219412050-9ef14336-6716-4820-b5e7-b5351095abf2.png)

