### PR TITLE
fix: d.ts lint issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,7 +94,7 @@ module.exports = {
       },
     },
     {
-      files: ["*.ts?(x)", "*.mts"],
+      files: ["*.ts?(x)", "*.mts", "*.d.ts"],
       extends: [
         // disables core ESLint rules which are handled by TypeScript
         "plugin:@typescript-eslint/eslint-recommended",
@@ -146,6 +146,7 @@ module.exports = {
         "react/jsx-filename-extension": ["error", { extensions: [".tsx"] }],
         "import/named": "off",
         "import/namespace": "off",
+        "import/no-unresolved": "error",
         "import/default": "off",
         "import/no-named-as-default-member": "off",
       },
@@ -167,6 +168,7 @@ module.exports = {
     {
       files: "*.d.ts",
       rules: {
+        "no-undef": "error",
         "react/prefer-stateless-function": "off",
       },
     },

--- a/docs/styled.d.ts
+++ b/docs/styled.d.ts
@@ -1,5 +1,6 @@
 import "styled-components";
 import { OrbitProvider } from "@kiwicom/orbit-components";
+import React from "react";
 
 type ThemeShape = React.ComponentProps<typeof OrbitProvider>["theme"];
 

--- a/packages/orbit-components/src/Illustration/TYPESCRIPT_TEMPLATE.template
+++ b/packages/orbit-components/src/Illustration/TYPESCRIPT_TEMPLATE.template
@@ -1,6 +1,8 @@
 /*
   DOCUMENTATION: https://orbit.kiwi/components/illustration/
 */
+import type React from "react";
+
 import type * as Common from "../common/types";
 
 export type Name =%NAMES%

--- a/packages/orbit-components/src/Tabs/components/Tab/types.d.ts
+++ b/packages/orbit-components/src/Tabs/components/Tab/types.d.ts
@@ -1,3 +1,5 @@
+import type React from "react";
+
 import type { Globals } from "../../../common/types";
 import type { TYPE_OPTIONS } from "./consts";
 

--- a/packages/orbit-components/src/Tabs/components/TabList/types.d.ts
+++ b/packages/orbit-components/src/Tabs/components/TabList/types.d.ts
@@ -1,5 +1,8 @@
+import type React from "react";
+
 import type { Globals, ObjectProperty } from "../../../common/types";
 import type { Spacing } from "../../../Stack/types";
+import type { ObjectProperty } from "../../../utils/common";
 
 export interface Props extends Globals {
   children: React.ReactNode;

--- a/packages/orbit-components/src/Tabs/components/TabList/types.d.ts
+++ b/packages/orbit-components/src/Tabs/components/TabList/types.d.ts
@@ -1,4 +1,4 @@
-import type { Globals } from "../../../common/types";
+import type { Globals, ObjectProperty } from "../../../common/types";
 import type { Spacing } from "../../../Stack/types";
 
 export interface Props extends Globals {

--- a/packages/orbit-components/src/Tabs/components/TabPanel/types.d.ts
+++ b/packages/orbit-components/src/Tabs/components/TabPanel/types.d.ts
@@ -1,3 +1,5 @@
+import type React from "react";
+
 import type { Globals, ObjectProperty } from "../../../common/types";
 
 export interface Props extends Globals {

--- a/packages/orbit-components/src/Tabs/components/TabPanels/types.d.ts
+++ b/packages/orbit-components/src/Tabs/components/TabPanels/types.d.ts
@@ -1,5 +1,5 @@
 import type { Globals } from "../../../common/types";
-import type { Props as TabPanelProps } from "../TabPanel";
+import type { Props as TabPanelProps } from "../TabPanel/types";
 
 export interface Props extends Globals {
   children: React.ReactElement<TabPanelProps> | React.ReactElement<TabPanelProps>[];

--- a/packages/orbit-components/src/Tabs/components/TabPanels/types.d.ts
+++ b/packages/orbit-components/src/Tabs/components/TabPanels/types.d.ts
@@ -1,3 +1,5 @@
+import type React from "react";
+
 import type { Globals } from "../../../common/types";
 import type { Props as TabPanelProps } from "../TabPanel/types";
 

--- a/packages/orbit-components/src/Tabs/types.d.ts
+++ b/packages/orbit-components/src/Tabs/types.d.ts
@@ -1,3 +1,5 @@
+import type React from "react";
+
 import type { Spacing } from "../Stack/types";
 import type { Globals } from "../common/types";
 

--- a/packages/orbit-components/src/primitives/IllustrationPrimitive/types.d.ts
+++ b/packages/orbit-components/src/primitives/IllustrationPrimitive/types.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 
+import type React from "react";
+
 import type * as Common from "../../common/types";
 
 export type Size = "extraSmall" | "small" | "medium" | "large" | "display";


### PR DESCRIPTION
added `no-undef` rule in order to prevent such issues as in `Tabs` component with unresolved types
includes #3754 