### PR TITLE
fix(Timeline): correctly align text inside a Modal

### DIFF
--- a/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepDesktop.tsx
+++ b/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepDesktop.tsx
@@ -44,7 +44,9 @@ const TimelineStepDesktop = ({
     <Stack inline shrink direction="column" align="center" spaceAfter="large">
       {subLabel && (
         <StyledText>
-          <Text size="small">{subLabel}</Text>
+          <Text align="center" size="small">
+            {subLabel}
+          </Text>
         </StyledText>
       )}
       <StyledRelative inner>
@@ -60,7 +62,9 @@ const TimelineStepDesktop = ({
       </StyledRelative>
       <Stack flex align="center" spacing="XSmall" direction="column">
         <StyledText active={active || (last && type === "success")}>
-          <Text weight="bold">{label}</Text>
+          <Text align="center" weight="bold">
+            {label}
+          </Text>
         </StyledText>
         <StyledDescription active={active || (last && type === "success")}>
           <Text align="center">{children}</Text>


### PR DESCRIPTION
The Step title of the Itinerary was not horizontally centered when the text wrapped into multiple lines. This fixes that problem.

**Before:**
<img width="763" alt="image" src="https://user-images.githubusercontent.com/6265045/223744508-a9905c9e-92e2-490f-b6ec-c08f1d336e7b.png">

**After:**
<img width="756" alt="image" src="https://user-images.githubusercontent.com/6265045/223744545-d95bfc93-bb4b-4d24-a690-739844a4c43e.png">
