### PR TITLE
Fix Itinerary expand issues

### DIFF
--- a/packages/orbit-components/src/Itinerary/Itinerary.stories.tsx
+++ b/packages/orbit-components/src/Itinerary/Itinerary.stories.tsx
@@ -248,8 +248,13 @@ export const Status = () => {
   return (
     <>
       <Itinerary>
-        <ItineraryStatus type="critical" label="Rescheduled · 4h later" spaceAfter="medium">
-          <ItinerarySegment noElevation>
+        <ItineraryStatus
+          type="critical"
+          label="Rescheduled · 4h later"
+          spaceAfter="medium"
+          actionable={false}
+        >
+          <ItinerarySegment noElevation actionable={false}>
             <ItinerarySegmentStop
               city="Prague"
               station="Václav Havel Airport Prague (PRG)"
@@ -258,7 +263,7 @@ export const Status = () => {
               time="14:05"
               cancelledTime="12:50"
             />
-            <ItinerarySegmentDetail duration="2h 30m" summary={<BadgeGroup />} content={content} />
+            <ItinerarySegmentDetail duration="2h 30m" summary={<BadgeGroup />} />
             <ItinerarySegmentStop
               city="Vienna"
               type="critical"

--- a/packages/orbit-components/src/Itinerary/ItinerarySegment/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItinerarySegment/index.tsx
@@ -57,7 +57,9 @@ const ItinerarySegment = ({
             value={{
               index: i,
               opened,
-              toggleOpened: () => setOpened(prev => !prev),
+              toggleOpened: () => {
+                if (document && document.getSelection()?.type !== "Range") setOpened(prev => !prev);
+              },
               last: i === content.length - 1,
               isNextHidden: Boolean(content[i + 1]?.props?.hidden),
               isPrevHidden: Boolean(content[i - 1]?.props?.hidden),

--- a/packages/orbit-components/src/Itinerary/ItineraryStatus/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItineraryStatus/index.tsx
@@ -39,8 +39,12 @@ const resolveColor = (status: Status, isHeader?: boolean) => ({ theme }: ThemePr
   return border[status];
 };
 
-const StyledWrapper = styled.div<{ $type: Status; spaceAfter: Common.SpaceAfterSizes }>`
-  ${({ theme, $type }) => css`
+const StyledWrapper = styled.div<{
+  $type: Status;
+  spaceAfter: Common.SpaceAfterSizes;
+  actionable?: boolean;
+}>`
+  ${({ theme, $type, actionable }) => css`
     display: flex;
     box-sizing: border-box;
     flex-direction: column;
@@ -49,9 +53,13 @@ const StyledWrapper = styled.div<{ $type: Status; spaceAfter: Common.SpaceAfterS
     border-${left}: ${theme.orbit.borderRadiusNormal} solid ${$type && resolveColor($type)};
     box-shadow: ${theme.orbit.boxShadowFixed};
     margin-bottom: ${getSpacingToken};
-    &:hover {
-      outline: none;
-      box-shadow: ${theme.orbit.boxShadowActionActive};
+    ${
+      actionable &&
+      css`
+        &:hover {
+          box-shadow: ${theme.orbit.boxShadowActionActive};
+        }
+      `
     }
   `}
 `;
@@ -106,9 +114,16 @@ const StatusIcon = ({ type }: { type: Status }) => {
   }
 };
 
-const ItineraryStatus = ({ type, label, spaceAfter = "medium", children, offset = 0 }: Props) => {
+const ItineraryStatus = ({
+  type,
+  label,
+  spaceAfter = "medium",
+  children,
+  offset = 0,
+  actionable = true,
+}: Props) => {
   return (
-    <StyledWrapper $type={type} spaceAfter={spaceAfter}>
+    <StyledWrapper $type={type} spaceAfter={spaceAfter} actionable={actionable}>
       <StyledStatusHeader $type={type}>
         <StyledStatusText $offset={offset}>
           <Stack flex spacing="XSmall" align="center">

--- a/packages/orbit-components/src/Itinerary/ItineraryStatus/types.d.ts
+++ b/packages/orbit-components/src/Itinerary/ItineraryStatus/types.d.ts
@@ -5,6 +5,7 @@ import type * as Common from "../../common/types";
 export type Status = "warning" | "critical" | "info" | "success" | "neutral";
 
 export interface Props extends Common.SpaceAfter {
+  readonly actionable?: boolean;
   /** Type of the status  */
   readonly type: Status;
   /** Label of the status */

--- a/packages/orbit-components/src/Itinerary/README.md
+++ b/packages/orbit-components/src/Itinerary/README.md
@@ -60,7 +60,6 @@ ItinerarySegment component serves as a wrapper of atomic units `ItinerarySegment
 | spaceAfter  | `enum`            |                    |         | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
 | actionable  | `boolean`         |                    | `true`  | Applies actionable styles for ItinerarySegment wrapper                                                                                                         |
 | banner      | `React.Node`      |                    |         | Additional information for `ItinerarySegment`                                                                                                                  |
-|             |
 
 ## ItinerarySegmentStop
 
@@ -70,8 +69,8 @@ ItinerarySegmentStop is an atomic unit of the Itinerary component, shows two loc
 
 | Name             | Type                | Required           | Default       | Description                                              |
 | ---------------- | ------------------- | ------------------ | ------------- | -------------------------------------------------------- |
-| date             | `React.Node`        | :heavy_check_mark: |               | The date of `ItinerarySegmentStop`                       |
-| time             | `React.Node`        | :heavy_check_mark: |               | The time of `ItinerarySegmentStop`                       |
+| date             | `React.Node`        |                    |               | The date of `ItinerarySegmentStop`                       |
+| time             | `React.Node`        |                    |               | The time of `ItinerarySegmentStop`                       |
 | cancelledTime    | `React.Node`        |                    |               | The cancelled time of `ItinerarySegmentStop`             |
 | cancelledDate    | `React.Node`        |                    |               | The cancelled date of `ItinerarySegmentStop`             |
 | cancelledStation | `React.Node`        |                    |               | The cancelled station of `ItinerarySegmentStop`          |
@@ -91,12 +90,13 @@ ItineraryStatus is a wrapper for `ItinerarySegment` or group of segments. Shows 
 
 ### Props
 
-| Name     | Type                | Required           | Default | Description                                |
-| -------- | ------------------- | ------------------ | ------- | ------------------------------------------ |
-| type     | [`Status`](#status) |                    |         | The type of `ItineraryStatus` component    |
-| label    | `React.Node`        |                    |         | The label of the `ItineraryStatus`         |
-| offset   | `number`            |                    | `0`     | The offset for the label                   |
-| children | `React.ReactNode`   | :heavy_check_mark: |         | The content of `ItineraryStatus` component |
+| Name       | Type                | Required           | Default | Description                                   |
+| ---------- | ------------------- | ------------------ | ------- | --------------------------------------------- |
+| type       | [`Status`](#status) |                    |         | The type of `ItineraryStatus` component       |
+| label      | `React.Node`        |                    |         | The label of the `ItineraryStatus`            |
+| offset     | `number`            |                    | `0`     | The offset for the label                      |
+| actionable | `boolean`           |                    | true    | Applies actionable styles for ItineraryStatus |
+| children   | `React.ReactNode`   | :heavy_check_mark: |         | The content of `ItineraryStatus` component    |
 
 ## ItinerarySegmentDetail
 


### PR DESCRIPTION
This addresses two issues:

- Text can now be selected inside the expanded part of ItinerarySegmentDetails without triggering the close action
- When a segment was wrapped in ItineraryStatus, it would always have the actionable style. It can now be controlled. (A story was updated to display this use case)

Docs were also updated regarding new and required props.

[Slack thread](https://skypicker.slack.com/archives/CAMS40F7B/p1678437139773419)