### PR TITLE
fix(Stack): fix gap issue for iOS Safar < 14.1

### DIFF
--- a/packages/orbit-components/src/Stack/helpers/getGap.ts
+++ b/packages/orbit-components/src/Stack/helpers/getGap.ts
@@ -41,9 +41,16 @@ const getGap = ({ index, devices }: { index: number; devices: Devices[] }) => (
       getSpacing(props.theme)[spacing],
     );
 
+  // workaround to make it work on Safari iOS < 14.1
+  // TODO: remove that after dropping support for iOS < 14.1
   if (props.flex) {
     return css`
       gap: ${gap};
+      @supports (-webkit-touch-callout: none) and (not (translate: none)) {
+        & > *:not(:last-child) {
+          margin: ${margin && rtlSpacing(margin)} !important;
+        }
+      }
     `;
   }
 


### PR DESCRIPTION
[Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1678714906521569)

Based on [`-webkit-touch-callout`](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-touch-callout) and `supports` query. It's being used only on iOS Safari, that allow us to trigger only it. 

tested on iOS Safari 13

![Screenshot 2023-03-13 at 17 12 59](https://user-images.githubusercontent.com/14054752/224761046-4400f73c-3038-4834-97f2-620af2d2385f.png)
