### PR TITLE
fix(Itinerary): type colors were not being correctly applied

### DIFF
--- a/packages/orbit-components/src/Itinerary/Itinerary.stories.tsx
+++ b/packages/orbit-components/src/Itinerary/Itinerary.stories.tsx
@@ -342,10 +342,14 @@ export const Status = () => {
             />
             <ItinerarySegmentDetail duration="2h 30m" summary={<BadgeGroup />} content={content} />
             <ItinerarySegmentStop
+              type="success"
               city="Vienna"
               station="Vienna International Airport"
               date="Fri, 19.10"
               time="15:35"
+              cancelledCity="Brno"
+              cancelledStation="Brno Tuřany Airport"
+              cancelledTime="15:15"
             />
           </ItinerarySegment>
         </ItineraryStatus>

--- a/packages/orbit-components/src/Itinerary/ItineraryTemporaryText/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItineraryTemporaryText/index.tsx
@@ -12,7 +12,7 @@ import {
   SIZE_OPTIONS,
 } from "../../Text/consts";
 
-const getColorType = ({ type }: { type: TextProps["type"] }) => ({ theme }) => {
+const getColorType = ({ $type: type }: { $type: TextProps["type"] }) => ({ theme }) => {
   if (type === "secondary") return theme.orbit.colorTextSecondary;
   if (type === "info") return theme.orbit.paletteBlueDark;
   if (type === "success") return theme.orbit.paletteGreenDark;


### PR DESCRIPTION
After #3749 and #3760 this is, hopefully, the last fix related to this. By changing prop names, the prop drilling was not correct. This PR fixes that.
Also changed a story for better visibility of the feature.

**Before:**
<img width="1429" alt="image" src="https://user-images.githubusercontent.com/6265045/224962146-149f0626-2993-436f-9b27-f31b09243c4b.png">


**Now:**
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/6265045/224962177-ec85309e-10c1-4123-a8e5-93a795428e6a.png">

