### PR TITLE
fix: segmented switch outline and role

### DIFF
--- a/packages/orbit-components/src/Checkbox/index.tsx
+++ b/packages/orbit-components/src/Checkbox/index.tsx
@@ -157,7 +157,7 @@ const StyledInput = styled.input<StyledInputProps>`
   }
 
   &:focus + ${StyledIconContainer} {
-    ${defaultFocus}
+    ${defaultFocus};
   }
 `;
 

--- a/packages/orbit-components/src/InputField/helpers/formElementFocus.ts
+++ b/packages/orbit-components/src/InputField/helpers/formElementFocus.ts
@@ -1,5 +1,5 @@
 import { defaultFocus } from "../../utils/common";
 
-const formElementFocus = () => defaultFocus;
+const formElementFocus = (): typeof defaultFocus => defaultFocus;
 
 export default formElementFocus;

--- a/packages/orbit-components/src/Radio/index.tsx
+++ b/packages/orbit-components/src/Radio/index.tsx
@@ -134,7 +134,7 @@ const StyledInput = styled.input`
   }
 
   &:focus + ${StyledIconContainer} {
-    ${defaultFocus}
+    ${defaultFocus};
 
     ${media.largeMobile(css`
       border-width: 1px;

--- a/packages/orbit-components/src/SegmentedSwitch/SegmentedSwitch.stories.tsx
+++ b/packages/orbit-components/src/SegmentedSwitch/SegmentedSwitch.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { text, number, boolean } from "@storybook/addon-knobs";
+import { text, boolean } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 
 import SegmentedSwitch from ".";
@@ -12,7 +12,7 @@ export const Default = () => {
   const label = text("Label", "Gender");
   const help = text("Help", "When Chuck Norris plays dodgeball, the balls dodge him.");
   const error = text("Error", "Chuck Norris makes onions cry.");
-  const maxWidth = number("maxWidth", NaN);
+  const maxWidth = text("maxWidth", "");
   const showTooltip = boolean("showTooltip", false);
 
   return (

--- a/packages/orbit-components/src/SegmentedSwitch/SwitchSegment/index.tsx
+++ b/packages/orbit-components/src/SegmentedSwitch/SwitchSegment/index.tsx
@@ -60,7 +60,7 @@ const StyledInput = styled.input`
       z-index: 10;
       border-radius: 5px !important;
       color: ${theme.orbit.paletteInkNormal};
-      ${defaultFocus}
+      ${defaultFocus};
     }
   `};
 `;
@@ -90,6 +90,7 @@ const SwitchSegment = ({
         type="radio"
         role="switch"
         ref={ref}
+        aria-checked={Boolean(value)}
         onChange={onChange}
         onFocus={onFocus}
         disabled={disabled}

--- a/packages/orbit-components/src/SegmentedSwitch/SwitchSegment/index.tsx
+++ b/packages/orbit-components/src/SegmentedSwitch/SwitchSegment/index.tsx
@@ -88,6 +88,7 @@ const SwitchSegment = ({
         name={name || "switch-segment"}
         defaultChecked={defaultChecked}
         type="radio"
+        role="switch"
         ref={ref}
         onChange={onChange}
         onFocus={onFocus}

--- a/packages/orbit-components/src/Stepper/StepperStateless/index.tsx
+++ b/packages/orbit-components/src/Stepper/StepperStateless/index.tsx
@@ -108,6 +108,10 @@ const StyledStepperButton = styled(Button)`
   }
 `;
 
+StyledStepperButton.defaultProps = {
+  theme: defaultTheme,
+};
+
 const StepperStateless = ({
   maxWidth = "120px",
   disabled,

--- a/packages/orbit-components/src/Switch/index.tsx
+++ b/packages/orbit-components/src/Switch/index.tsx
@@ -84,7 +84,7 @@ const StyledSwitchInput = styled.input`
   padding: 0;
 
   &:focus + ${StyledSwitchButton} {
-    ${defaultFocus}
+    ${defaultFocus};
   }
 `;
 

--- a/packages/orbit-components/src/Tile/components/TileWrapper/index.tsx
+++ b/packages/orbit-components/src/Tile/components/TileWrapper/index.tsx
@@ -58,7 +58,7 @@ const StyledTileAnchor = styled.a`
     text-decoration: none;
     color: ${theme.orbit.paletteInkDark};
     &:focus {
-      ${defaultFocus}
+      ${defaultFocus};
       ${StyledIconRight} {
         color: ${theme.orbit.paletteInkLightHover};
       }

--- a/packages/orbit-components/src/utils/common/index.ts
+++ b/packages/orbit-components/src/utils/common/index.ts
@@ -2,12 +2,16 @@ import type { FlattenSimpleInterpolation } from "styled-components";
 import { css } from "styled-components";
 
 import type { ObjectProperty } from "../../common/types";
+import type defaultTheme from "../../defaultTheme";
 
 export const firstToUpper = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1);
 
-export const defaultFocus = (): FlattenSimpleInterpolation => css`
-  outline: 2px solid Highlight;
-  outline: 2px solid -webkit-focus-ring-color;
+export const defaultFocus = ({
+  theme,
+}: {
+  theme: typeof defaultTheme;
+}): FlattenSimpleInterpolation => css`
+  outline: 2px solid ${theme.orbit.paletteBlueNormal};
 `;
 
 const setValue = (value?: string | number): string | null => {


### PR DESCRIPTION
[Slack request](https://skypicker.slack.com/archives/CAMS40F7B/p1678724132897789)

As we decided to use the default browser outline instead of box-shadow before, which in my opinion is totally ok, however, there are situations like this one, when we rely on default input focus behavior and the color of the outline may be different depending on the browser, operating systems and user's preferences, that's why I think we should implicitly force it to be blue only, so requests like this will not appear anymore.  