### PR TITLE
fix(CarrierLogo): remove shadow from inlineStacked variation

### DIFF
--- a/packages/orbit-components/src/CarrierLogo/index.tsx
+++ b/packages/orbit-components/src/CarrierLogo/index.tsx
@@ -80,7 +80,6 @@ const StyledImage = styled.img.attrs<StyledProps>(
     height: ${getCarrierLogoSize};
     width: ${getCarrierLogoSize};
     border: ${inlineStacked && `1px solid ${theme.orbit.paletteWhite}`};
-    box-shadow: ${inlineStacked && `${theme.orbit.boxShadowFixed}, ${theme.orbit.boxShadowRaised}`};
 
     &:not(:first-child) {
       margin-${left}: ${inlineStacked && `calc(-1 * ${theme.orbit.spaceXSmall})`};


### PR DESCRIPTION
As decided [here](https://skypicker.slack.com/archives/GSGN9BN6Q/p1678786374077159)