### PR TITLE
fix(Button): fullWidth prop type was incorrectly set

### DIFF
--- a/packages/orbit-components/src/primitives/ButtonPrimitive/types.d.ts
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/types.d.ts
@@ -8,7 +8,7 @@ export type Size = "small" | "normal" | "large";
 
 export type FullWidthConditionalProps =
   | {
-      readonly fullWidth: true;
+      readonly fullWidth: boolean;
       readonly centered?: boolean;
     }
   | {


### PR DESCRIPTION
As reported [here](https://skypicker.slack.com/archives/C9B1H0ACW/p1679572113495029?thread_ts=1679569778.541529&cid=C9B1H0ACW).