### PR TITLE
fix(AlertButton): padding was not correct when there was an icon

### DIFF
--- a/packages/orbit-components/src/Alert/AlertButton/index.tsx
+++ b/packages/orbit-components/src/Alert/AlertButton/index.tsx
@@ -11,7 +11,7 @@ import { SIZE_OPTIONS } from "../../primitives/ButtonPrimitive/common/consts";
 import type { Props } from "./types";
 
 const AlertButton = React.forwardRef<HTMLButtonElement, Props>(
-  ({ type = TYPE_OPTIONS.INFO, children, disabled = false, ...props }, ref) => {
+  ({ type = TYPE_OPTIONS.INFO, disabled = false, ...props }, ref) => {
     const theme = useTheme();
     const propsWithTheme = { theme, ...props };
     const commonProps = getCommonProps({ ...propsWithTheme, size: SIZE_OPTIONS.SMALL });
@@ -29,9 +29,7 @@ const AlertButton = React.forwardRef<HTMLButtonElement, Props>(
         {...buttonStyles}
         {...commonProps}
         {...icons}
-      >
-        {children}
-      </ButtonPrimitive>
+      />
     );
   },
 );


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/CAMS40F7B/p1679666899559119).

The `children` prop was needed for padding calculation but was being captured and not passed to the function.