### PR TITLE
feat(docs): fix type of onChange prop of Tabs

### DIFF
--- a/packages/orbit-components/src/Tabs/README.md
+++ b/packages/orbit-components/src/Tabs/README.md
@@ -36,7 +36,7 @@ Table below contains all types of the props available in Tabs component.
 | dataTest        | `string`                         |         | Optional prop for testing purposes.                                                                          |
 | defaultSelected | `number`                         | `0`     | Optional prop to set the initial active tab index. Use only if you do not want to control state on your side |
 | children        | `React.node`                     |         | Required prop that should contain the `TabList`, `TabPanels` components.                                     |
-| onChange        | `event => void \| Promise<void>` |         | Function for handling onChange. Use only if you do not want to control state on your side.                   |
+| onChange        | `(selectedIndex: number) => void \| Promise<void>` |         | Function for handling onChange. Use only if you do not want to control state on your side.                   |
 
 ### TabList
 


### PR DESCRIPTION
# This Pull Request meets the following criteria:

- [ ] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components has both `.flow` and `d.ts` files and are exported in `index.js.flow` and `index.d.ts`
