### PR TITLE
feat(Tab): add min-width to avoid text wrap

### DIFF
--- a/packages/orbit-components/src/Tabs/components/Tab/index.tsx
+++ b/packages/orbit-components/src/Tabs/components/Tab/index.tsx
@@ -44,6 +44,7 @@ const StyledTab = styled.button<{
     display: flex;
     border: 0;
     flex: 1;
+    min-width: fit-content;
     position: relative;
     appearance: none;
     flex-direction: row;


### PR DESCRIPTION
As requested [here](https://www.figma.com/file/t1UrPvmfjrRZGgLKhZwiSW?node-id=3090:12761#434710865), text should not wrap, but instead grow indefinitely. 