### PR TITLE
feat(Popover): add renderTimeout prop

### DIFF
--- a/docs/src/__examples__/Popover/DEFAULT.tsx
+++ b/docs/src/__examples__/Popover/DEFAULT.tsx
@@ -42,6 +42,7 @@ export default {
         { name: "fixed", type: "boolean", defaultValue: false },
         { name: "width", type: "text", defaultValue: "" },
         { name: "maxHeight", type: "text", defaultValue: "" },
+        { name: "renderTimeout", type: "number", defaultValue: 0 },
         {
           name: "placement",
           type: "select",

--- a/packages/orbit-components/src/Popover/Popover.stories.tsx
+++ b/packages/orbit-components/src/Popover/Popover.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import styled, { css } from "styled-components";
-import { withKnobs, text, select, boolean, object } from "@storybook/addon-knobs";
+import { withKnobs, text, select, boolean, object, number } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 
 import Tooltip from "../Tooltip";
@@ -425,6 +425,7 @@ ScrollingContent.story = {
 };
 
 export const Playground = () => {
+  const renderTimeout = number("renderTimeout", 0);
   const dataTest = text("dataTest", "test");
   const placement = select("placement", Object.values(PLACEMENTS), PLACEMENTS.BOTTOM_START);
   const width = text("width", "350px");
@@ -442,6 +443,7 @@ export const Playground = () => {
       <Popover
         width={width}
         maxHeight={maxHeight}
+        renderTimeout={renderTimeout}
         dataTest={dataTest}
         offset={offset}
         content={content}

--- a/packages/orbit-components/src/Popover/README.md
+++ b/packages/orbit-components/src/Popover/README.md
@@ -6,7 +6,7 @@ To implement Popover component into your project you'll need to add the import:
 import Popover from "@kiwicom/orbit-components/lib/Popover";
 ```
 
-After adding import into your project you can use it simply like:
+After adding import to your project you can use it simply like:
 
 ```jsx
 <Popover content="Your content">
@@ -16,7 +16,7 @@ After adding import into your project you can use it simply like:
 
 ## Props
 
-Table below contains all types of the props available in the Popover component.
+The table below contains all types of props available in the Popover component.
 
 | Name           | Type                     | Default             | Description                                                                                                                                      |
 | :------------- | :----------------------- | :------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -40,6 +40,7 @@ Table below contains all types of the props available in the Popover component.
 | noFlip         | `boolean`                | `false`             | Turns off automatic flipping of the Popover when there is not enough space                                                                       |
 | allowOverflow  | `boolean`                | `false`             | Allows the Popover to be cut off instead of moving it while scrolling to keep it visible.                                                        |
 | labelClose     | `React.Node`             | `Close`             | The label for close button.                                                                                                                      |
+| renderTimeout  | `number`                 | `0`                 | The timeout for rendering the Popover.                                                                                                           |
 
 ## enum
 
@@ -78,7 +79,7 @@ Table below contains all types of the props available in the Popover component.
 
 - Actions are a way to override default close behavior with your own actions, mainly `Buttons` keep in mind that one of the actions should close the popover.
 
-- The Popover component supports rendering of many different components inside its children. You can use combination of e.g. Text, Stack, ListChoice for example:
+- The Popover component supports rendering of many different components inside its children. You can use a combination of e.g. Text, Stack, ListChoice for example:
 
 ```jsx
 <Popover

--- a/packages/orbit-components/src/Popover/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Popover/__tests__/index.test.tsx
@@ -44,7 +44,6 @@ describe("Popover", () => {
     expect(onClose).toHaveBeenCalled();
     // Needs to flush async `floating-ui` hooks
     // https://github.com/floating-ui/floating-ui/issues/1520
-    // $FlowFixMe
     await act(async () => {});
   });
 
@@ -65,7 +64,6 @@ describe("Popover", () => {
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
     // Needs to flush async `floating-ui` hooks
     // https://github.com/floating-ui/floating-ui/issues/1520
-    // $FlowFixMe
     await act(async () => {});
   });
 
@@ -78,7 +76,6 @@ describe("Popover", () => {
     expect(screen.getByText("kek").closest("div")).toHaveStyle({ padding: "0" });
     // Needs to flush async `floating-ui` hooks
     // https://github.com/floating-ui/floating-ui/issues/1520
-    // $FlowFixMe
     await act(async () => {});
   });
 
@@ -95,7 +92,6 @@ describe("Popover", () => {
     expect(screen.getByRole("tooltip")).toHaveStyle({ top: "10" });
     // Needs to flush async `floating-ui` hooks
     // https://github.com/floating-ui/floating-ui/issues/1520
-    // $FlowFixMe
     await act(async () => {});
   });
 
@@ -112,7 +108,6 @@ describe("Popover", () => {
     await waitForElementToBeRemoved(screen.queryByTestId("popover"));
     // Needs to flush async `floating-ui` hooks
     // https://github.com/floating-ui/floating-ui/issues/1520
-    // $FlowFixMe
     await act(async () => {});
   });
 });

--- a/packages/orbit-components/src/Popover/index.js.flow
+++ b/packages/orbit-components/src/Popover/index.js.flow
@@ -24,6 +24,7 @@ export type Props = {|
   +allowOverflow?: boolean,
   +noFlip?: boolean,
   +noPadding?: boolean,
+  +renderTimeout?: number,
   +overlapped?: boolean,
   +fixed?: boolean,
   +actions?: React.Node,

--- a/packages/orbit-components/src/Popover/index.tsx
+++ b/packages/orbit-components/src/Popover/index.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import styled from "styled-components";
 
 import useStateWithTimeout from "../hooks/useStateWithTimeout";
-import useTheme from "../hooks/useTheme";
 import { PLACEMENTS } from "../common/consts";
 import PopoverContent from "./components/ContentWrapper";
 import Portal from "../Portal";
@@ -27,6 +26,7 @@ const Popover = ({
   lockScrolling = true,
   noFlip,
   labelClose = "Close",
+  renderTimeout = 0,
   allowOverflow,
   noPadding,
   width,
@@ -37,15 +37,13 @@ const Popover = ({
 }: Props) => {
   const ref = React.useRef<HTMLDivElement | null>(null);
 
-  const theme = useTheme();
-
   const [shown, setShown, setShownWithTimeout, clearShownTimeout] = useStateWithTimeout<boolean>(
     false,
-    parseFloat(theme.orbit.durationFast) * 1000,
+    renderTimeout,
   );
 
   const [render, setRender, setRenderWithTimeout, clearRenderTimeout] =
-    useStateWithTimeout<boolean>(false, parseFloat(theme.orbit.durationFast) * 1000);
+    useStateWithTimeout<boolean>(false, renderTimeout);
 
   const resolveCallback = React.useCallback(
     state => {

--- a/packages/orbit-components/src/Popover/types.d.ts
+++ b/packages/orbit-components/src/Popover/types.d.ts
@@ -19,6 +19,7 @@ export interface Props extends Common.Globals {
   readonly width?: string;
   readonly maxHeight?: string;
   readonly noPadding?: boolean;
+  readonly renderTimeout?: number;
   readonly allowOverflow?: boolean;
   readonly noFlip?: boolean;
   readonly overlapped?: boolean;


### PR DESCRIPTION
It was asked [here](https://skypicker.slack.com/archives/CAMS40F7B/p1683046391312509) and [here](https://skypicker.slack.com/archives/CAMS40F7B/p1677168767536869). 

In my opinion, we should not have that delay we had before, although, it looks like setTimeout here was also used for removing the flickering on the initial render. It works fine with 0, because of the nature of the event loop. So I decided to keep the hook, but reduce the timeout to 0, just to look it more visually faster. 

Added the prop to control that, if somebody still would need to have control, but I won't be useful much, just for case.

Also, do not think we should be 100% neat on that and mark it as breaking change. Can be as normal feature by mentioning that we just reduced the timeout.

