### PR TITLE
Allow "start" and "end" align, deprecate rtl/textAlign

### DIFF
--- a/docs/src/__examples__/Box/DEFAULT.tsx
+++ b/docs/src/__examples__/Box/DEFAULT.tsx
@@ -93,7 +93,7 @@ export default {
         {
           name: "textAlign",
           type: "select",
-          options: ["left", "center", "right"],
+          options: ["start", "end", "left", "center", "right"],
           defaultValue: "center",
         },
         {

--- a/docs/src/__examples__/Text/ALIGN.tsx
+++ b/docs/src/__examples__/Text/ALIGN.tsx
@@ -4,7 +4,9 @@ import { Text } from "@kiwicom/orbit-components";
 export default {
   Example: () => <Text>Text aligned to the left</Text>,
   exampleVariants: [
-    { name: "Left", code: "() => <Text>Text aligned to the left</Text>" },
+    { name: "Start", code: `() => <Text align="start">Text aligned to "start"</Text>` },
+    { name: "End", code: `() => <Text align="end">Text aligned to "end"</Text>` },
+    { name: "Left", code: `() => <Text align="left">Text aligned to the left</Text>` },
     { name: "Center", code: `() => <Text align="center">Centered text</Text>` },
     { name: "Right", code: `() => <Text align="right">Text aligned to the right</Text>` },
     {

--- a/docs/src/__examples__/Text/DEFAULT.tsx
+++ b/docs/src/__examples__/Text/DEFAULT.tsx
@@ -33,7 +33,7 @@ export default {
         {
           name: "align",
           type: "select",
-          options: ["left", "center", "right", "justify"],
+          options: ["start", "end", "left", "center", "right", "justify"],
           defaultValue: "left",
         },
         {

--- a/packages/orbit-components/src/Box/Box.stories.tsx
+++ b/packages/orbit-components/src/Box/Box.stories.tsx
@@ -52,6 +52,8 @@ enum JUSTIFY {
 }
 
 enum TEXT_ALIGN {
+  START = "start",
+  END = "end",
   LEFT = "left",
   RIGHT = "right",
   CENTER = "center",

--- a/packages/orbit-components/src/Box/README.md
+++ b/packages/orbit-components/src/Box/README.md
@@ -110,7 +110,7 @@ All this properties - objects have the some own properties and none is required.
 ### textAlign
 
 | textAlign  |
-|:-----------|
+| :--------- |
 | `"start"`  |
 | `"end"`    |
 | `"left"`   |

--- a/packages/orbit-components/src/Box/README.md
+++ b/packages/orbit-components/src/Box/README.md
@@ -110,7 +110,9 @@ All this properties - objects have the some own properties and none is required.
 ### textAlign
 
 | textAlign  |
-| :--------- |
+|:-----------|
+| `"start"`  |
+| `"end"`    |
 | `"left"`   |
 | `"center"` |
 | `"right"`  |

--- a/packages/orbit-components/src/Box/index.js.flow
+++ b/packages/orbit-components/src/Box/index.js.flow
@@ -136,7 +136,7 @@ export type Props = {|
   +bottom?: string,
   +align?: "start" | "end" | "center" | "stretch",
   +justify?: "center" | "start" | "end" | "between" | "around",
-  +textAlign?: "left" | "right" | "center",
+  +textAlign?: "start" | "end" | "left" | "right" | "center",
   +elevation?: Elevation,
   +color?: ColorTokens,
   +background?: ColorTokens,

--- a/packages/orbit-components/src/Box/types.d.ts
+++ b/packages/orbit-components/src/Box/types.d.ts
@@ -148,7 +148,7 @@ export interface Props extends Common.Globals {
   readonly bottom?: string;
   readonly align?: "start" | "end" | "center" | "stretch";
   readonly justify?: "center" | "start" | "end" | "between" | "around";
-  readonly textAlign?: "left" | "right" | "center";
+  readonly textAlign?: "start" | "end" | "left" | "right" | "center";
   readonly elevation?: Elevation;
   readonly color?: ColorTokens;
   readonly background?: ColorTokens;

--- a/packages/orbit-components/src/Table/TableCell/consts.ts
+++ b/packages/orbit-components/src/Table/TableCell/consts.ts
@@ -1,4 +1,6 @@
 export enum ALIGN_OPTIONS {
+  START = "start",
+  END = "end",
   LEFT = "left",
   CENTER = "center",
   RIGHT = "right",

--- a/packages/orbit-components/src/Table/TableCell/index.js.flow
+++ b/packages/orbit-components/src/Table/TableCell/index.js.flow
@@ -4,7 +4,7 @@ import type { StyledComponent } from "styled-components";
 
 import type { Globals } from "../../common/common.js.flow";
 
-type Align = "left" | "center" | "right";
+type Align = "start" | "end" | "left" | "center" | "right";
 type As = "th" | "td";
 type Scope = "col" | "row" | "colgroup" | "rowgroup";
 type WhiteSpace = "normal" | "nowrap" | "pre" | "pre-line" | "pre-wrap";

--- a/packages/orbit-components/src/Table/TableCell/types.d.ts
+++ b/packages/orbit-components/src/Table/TableCell/types.d.ts
@@ -2,7 +2,7 @@
 // Project: http://github.com/kiwicom/orbit
 import type { SharedProps } from "../types";
 
-export type Align = "left" | "center" | "right";
+export type Align = "start" | "end" | "left" | "center" | "right";
 export type As = "th" | "td";
 export type Scope = "col" | "row" | "colgroup" | "rowgroup";
 export type WhiteSpace = "normal" | "nowrap" | "pre" | "pre-line" | "pre-wrap";

--- a/packages/orbit-components/src/Text/README.md
+++ b/packages/orbit-components/src/Text/README.md
@@ -36,10 +36,10 @@ Table below contains all types of the props available in the Text component.
 
 | type          | align       | as       | size       | weight     |
 | :------------ | :---------- | :------- | :--------- | :--------- |
-| `"primary"`   | `"left"`    | `"p"`    | `"small"`  | `"normal"` |
-| `"secondary"` | `"center"`  | `"span"` | `"normal"` | `"medium"` |
-| `"info"`      | `"right"`   | `"div"`  | `"large"`  | `"bold"`   |
-| `"success"`   | `"justify"` |          |            |            |
-| `"warning"`   |             |          |            |            |
-| `"critical"`  |             |          |            |            |
+| `"primary"`   | `"start"`   | `"p"`    | `"small"`  | `"normal"` |
+| `"secondary"` | `"end"`     | `"span"` | `"normal"` | `"medium"` |
+| `"info"`      | `"left"`    | `"div"`  | `"large"`  | `"bold"`   |
+| `"success"`   | `"center"`  |          |            |            |
+| `"warning"`   | `"right"`   |          |            |            |
+| `"critical"`  | `"justify"` |          |            |            |
 | `"white"`     |             |          |            |            |

--- a/packages/orbit-components/src/Text/consts.ts
+++ b/packages/orbit-components/src/Text/consts.ts
@@ -21,6 +21,8 @@ export enum WEIGHT_OPTIONS {
 }
 
 export enum ALIGN_OPTIONS {
+  START = "start",
+  END = "end",
   LEFT = "left",
   CENTER = "center",
   RIGHT = "right",

--- a/packages/orbit-components/src/Text/index.js.flow
+++ b/packages/orbit-components/src/Text/index.js.flow
@@ -8,7 +8,7 @@ import type { StyledComponent } from "styled-components";
 import type { spaceAfter } from "../common/getSpacingToken/index.js.flow";
 import type { Globals, ObjectProperty } from "../common/common.js.flow";
 
-type Align = "left" | "center" | "right" | "justify";
+type Align = "start" | "end" | "left" | "center" | "right" | "justify";
 type As = "p" | "span" | "div";
 type Type = "primary" | "secondary" | "info" | "success" | "warning" | "critical" | "white";
 type Size = "large" | "normal" | "small";

--- a/packages/orbit-components/src/Text/types.d.ts
+++ b/packages/orbit-components/src/Text/types.d.ts
@@ -5,7 +5,7 @@ import type * as React from "react";
 
 import type * as Common from "../common/types";
 
-type Align = "left" | "center" | "right" | "justify";
+type Align = "start" | "end" | "left" | "center" | "right" | "justify";
 type As = "p" | "span" | "div";
 
 export type Type =

--- a/packages/orbit-components/src/utils/rtl/index.js.flow
+++ b/packages/orbit-components/src/utils/rtl/index.js.flow
@@ -7,7 +7,7 @@ export type RtlSpacing = (value: string) => ({ ...ThemeProps, ... }) => string;
 
 export type BorderRadius = (value: string) => ({ ...ThemeProps, ... }) => string;
 
-export type TextAlign = (value: "left" | "right") => ({ ...ThemeProps, ... }) => string;
+export type TextAlign = (value: "start" | "end" | "left" | "right" | "center") => ({ ...ThemeProps, ... }) => string;
 
 export type Translate3d = (value: string) => ({ ...ThemeProps, ... }) => string;
 

--- a/packages/orbit-components/src/utils/rtl/index.ts
+++ b/packages/orbit-components/src/utils/rtl/index.ts
@@ -28,9 +28,14 @@ export const borderRadius: BorderRadius =
     return parts.length === 4 ? [parts[1], parts[0], parts[3], parts[2]].join(" ") : value;
   };
 
+/// @deprecated Use "start" or "end" instead.
 export const textAlign: TextAlign =
   (value: string) =>
   ({ theme }: { theme: Theme }): string => {
+    if (["start", "end"].includes(value)) {
+      return value;
+    }
+
     if (theme.rtl) {
       if (value === "left") {
         return leftToRight("left", "right")({ theme });

--- a/packages/orbit-components/src/utils/rtl/types.d.ts
+++ b/packages/orbit-components/src/utils/rtl/types.d.ts
@@ -6,6 +6,8 @@ export type RtlSpacing = (value: string) => (theme: ThemeProps) => string;
 
 export type BorderRadius = (value: string) => (theme: ThemeProps) => string;
 
-export type TextAlign = (value: "left" | "right" | "center") => (theme: ThemeProps) => string;
+export type TextAlign = (
+  value: "start" | "end" | "left" | "right" | "center",
+) => (theme: ThemeProps) => string;
 
 export type Translate3d = (value: string) => (themeProps: ThemeProps) => string;


### PR DESCRIPTION
The utility functions for text alignment `left` and `right` in `packages/orbit-components/src/utils/rtl/index.ts` have their native versions directly in css -- "start" and "end". I think it would be nice if we could use those directly. Since this looked simple, I decided to shoot a MR, but if I missed some nontrivial things, feel free to take this MR as just a feature request 😄

## This Pull Request meets the following criteria:

- [x] Tests have been added/adjusted for my new feature
- [x] New Components are registered in index.js of my project
- [x] New Components has both `.flow` and `d.ts` files and are exported in `index.js.flow` and `index.d.ts`
