### PR TITLE
fix(ItinerarySeparator): rename imported Props to avoid naming conflict

### DIFF
--- a/packages/orbit-components/src/Itinerary/ItinerarySeparator/types.d.ts
+++ b/packages/orbit-components/src/Itinerary/ItinerarySeparator/types.d.ts
@@ -1,9 +1,9 @@
 import type * as React from "react";
 
-import type { Props } from "../../Separator/types";
+import type { Props as SeparatorProps } from "../../Separator/types";
 
 export interface Props {
   readonly children?: React.ReactNode;
-  readonly type?: Props["type"];
-  readonly color?: Props["color"];
+  readonly type?: SeparatorProps["type"];
+  readonly color?: SeparatorProps["color"];
 }


### PR DESCRIPTION
Otherwise, TypeScript would report the following error:
```
 Import declaration conflicts with local declaration of 'Props'.
```

# This Pull Request meets the following criteria:

- [ ] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components has both `.flow` and `d.ts` files and are exported in `index.js.flow` and `index.d.ts`
