### PR TITLE
chore: remove skipLibCheck from ts and add ts-check to lint-staged

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   "*.{js,flow,ts,tsx}": "eslint --fix --report-unused-disable-directives",
+  "*.{ts,tsx,d.ts}": () => "check:types",
   "*.{md,json,yaml,yml}": "prettier --write",
   "*.mdx": "eslint --fix --report-unused-disable-directives",
   "**/!(snippets)/*.mdx": "remark -q -u validate-links --no-config",

--- a/packages/orbit-components/tsconfig-build.json
+++ b/packages/orbit-components/tsconfig-build.json
@@ -4,6 +4,7 @@
     "rootDir": "src",
     "outDir": "lib",
     "declaration": true,
+    "skipLibCheck": true,
     "moduleResolution": "node",
     "importsNotUsedAsValues": "error",
     "emitDeclarationOnly": true

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,6 @@
     "esModuleInterop": true,
     "jsx": "react",
     "strict": true,
-    "skipLibCheck": true,
     "resolveJsonModule": true,
     "noImplicitAny": false,
     "useUnknownInCatchVariables": false


### PR DESCRIPTION
We had `skipLibCheck` set even before full migration to TS and it's migrated after we fully migrated 😄 
`skipLibCheck` in tsconfig is a confusing name because it also skips the declarations files of the project.

I removed that option from the main base config, if necessary, we can explicitly set it to the package's configs or docs, but for components, we need to have it removed, if errors will appear with some library, I think we can ignore them explicitly. 