### PR TITLE
fix: labels to accept string only where it's needed

### DIFF
--- a/packages/orbit-components/src/Alert/README.md
+++ b/packages/orbit-components/src/Alert/README.md
@@ -29,7 +29,7 @@ The table below contains all types of the props available in Alert component.
 | title         | `Translation`                   |          | The title of the Alert.                                                                                                                                        |
 | **type**      | [`enum`](#enum)                 | `"info"` | The type of Alert.                                                                                                                                             |
 | suppressed    | `boolean`                       |          | If `suppressed` is on, Alert will not have colored background                                                                                                  |
-| labelClose    | `React.Node`                    |          | The label of the close button.                                                                                                                                 |
+| labelClose    | `string`                        |          | The label of the close button.                                                                                                                                 |
 
 ### enum
 

--- a/packages/orbit-components/src/Alert/index.js.flow
+++ b/packages/orbit-components/src/Alert/index.js.flow
@@ -18,7 +18,7 @@ export type Props = {|
   +closable?: boolean,
   +suppressed?: boolean,
   +inlineActions?: React.Node,
-  +labelClose?: React.Node,
+  +labelClose?: string,
   +onClose?: () => void | Promise<any>,
   ...Globals,
   ...spaceAfter,

--- a/packages/orbit-components/src/Alert/index.tsx
+++ b/packages/orbit-components/src/Alert/index.tsx
@@ -251,7 +251,7 @@ const AlertCloseButton = ({
 }: {
   hasChildren: boolean;
   dataTest: string;
-  labelClose?: React.ReactNode;
+  labelClose?: string;
   onClick?: Common.Callback;
   icon: React.ReactNode;
 }) => {

--- a/packages/orbit-components/src/Alert/types.d.ts
+++ b/packages/orbit-components/src/Alert/types.d.ts
@@ -13,7 +13,7 @@ export interface Props extends Common.Globals, Common.SpaceAfter {
   readonly icon?: React.ReactNode;
   readonly closable?: boolean;
   readonly inlineActions?: React.ReactNode;
-  readonly labelClose?: React.ReactNode;
+  readonly labelClose?: string;
   readonly onClose?: Common.Callback;
   readonly suppressed?: boolean;
 }

--- a/packages/orbit-components/src/BaggageStepper/types.d.ts
+++ b/packages/orbit-components/src/BaggageStepper/types.d.ts
@@ -5,7 +5,6 @@ import type * as React from "react";
 
 import type * as Common from "../common/types";
 
-type Title = string | ((param?: any) => string);
 // InputEvent
 export type Event = Common.Event<React.SyntheticEvent<HTMLInputElement | HTMLButtonElement>>;
 
@@ -15,8 +14,8 @@ export interface SharedProps extends Common.Globals {
   readonly maxValue?: number;
   readonly minValue?: number;
   // Deviation from other BaggageStepper properties
-  readonly titleIncrement?: Title;
-  readonly titleDecrement?: Title;
+  readonly titleIncrement?: string;
+  readonly titleDecrement?: string;
   // Deviation from common event format onChange
   readonly onFocus?: Event;
   readonly onBlur?: Event;

--- a/packages/orbit-components/src/Card/CardSection/components/SectionHeader.tsx
+++ b/packages/orbit-components/src/Card/CardSection/components/SectionHeader.tsx
@@ -48,7 +48,7 @@ interface Props {
   dataA11ySection?: string;
   header?: React.ReactNode;
   expandable?: boolean;
-  labelClose?: React.ReactNode;
+  labelClose?: string;
   expanded?: boolean;
   handleKeyDown: React.KeyboardEventHandler<HTMLDivElement>;
   onClick?: React.MouseEventHandler<HTMLDivElement>;

--- a/packages/orbit-components/src/Card/README.md
+++ b/packages/orbit-components/src/Card/README.md
@@ -31,7 +31,7 @@ Table below contains all types of the props available in the Card component.
 | title       | `React.Node`                 |         | The title of the Card                                                                                          |
 | titleAs     | [`enum`](#enum)              | `"h2"`  | The element used for the root node of the title of Card.                                                       |
 | margin      | `string \| number \| Object` |         | Utility prop to set margin.                                                                                    |
-| labelClose  | `React.Node`                 | `Close` | Property for passing translation string to close Button.                                                       |
+| labelClose  | `string`                     | `Close` | Property for passing translation string to close Button.                                                       |
 
 ### CardSection
 

--- a/packages/orbit-components/src/Card/components/Header/types.d.ts
+++ b/packages/orbit-components/src/Card/components/Header/types.d.ts
@@ -10,7 +10,7 @@ export interface Props {
   onClose?: Common.Event<React.SyntheticEvent<HTMLButtonElement | HTMLAnchorElement>>;
   title?: React.ReactNode;
   titleAs?: As;
-  labelClose?: React.ReactNode;
+  labelClose?: string;
   isSection?: boolean;
   dataA11ySection?: string;
   expandable?: boolean;

--- a/packages/orbit-components/src/Card/index.js.flow
+++ b/packages/orbit-components/src/Card/index.js.flow
@@ -17,7 +17,7 @@ export type Props = {|
   +margin?: string | number | ObjectProperty,
   +description?: React.Node,
   +icon?: React.Node,
-  +labelClose?: React.Node,
+  +labelClose?: string,
   +actions?: React.Node,
   +onClose?: () => void | Promise<any>,
   +loading?: boolean,

--- a/packages/orbit-components/src/Card/types.d.ts
+++ b/packages/orbit-components/src/Card/types.d.ts
@@ -14,7 +14,7 @@ export interface Props extends Common.Globals, Common.SpaceAfter {
   readonly titleAs?: As;
   readonly margin?: React.CSSProperties["margin"] | Common.ObjectProperty;
   readonly description?: React.ReactNode;
-  readonly labelClose?: React.ReactNode;
+  readonly labelClose?: string;
   /**
    * @deprecated icon prop is no longer supported. Icons can still be added manually, if needed.
    */

--- a/packages/orbit-components/src/Drawer/README.md
+++ b/packages/orbit-components/src/Drawer/README.md
@@ -31,7 +31,7 @@ Table below contains all types of the props available in the Drawer component.
 | width         | `string`                | `"320px"` | The width of the Drawer.                                                                                                              |
 | lockScrolling | `boolean`               | `true`    | Whether to prevent scrolling of the rest of the page while Drawer is open. This is on by default to provide a better user experience. |
 | fixedHeader   | `boolean`               |           | If `true` the DrawerHeader will be fixed to the top.                                                                                  |
-| labelHide     | `React.Node`            | `Hide`    | Label for the close button.                                                                                                           |
+| labelHide     | `string`                | `Hide`    | Label for the close button.                                                                                                           |
 
 ### enum
 

--- a/packages/orbit-components/src/Drawer/components/types.d.ts
+++ b/packages/orbit-components/src/Drawer/components/types.d.ts
@@ -1,11 +1,9 @@
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 
-import type React from "react";
-
 import type * as Common from "../../common/types";
 
 export interface Props {
   readonly onClick?: Common.Callback;
-  readonly title?: React.ReactNode;
+  readonly title?: string;
 }

--- a/packages/orbit-components/src/Drawer/index.js.flow
+++ b/packages/orbit-components/src/Drawer/index.js.flow
@@ -13,7 +13,7 @@ export type Props = {|
   +lockScrolling?: boolean,
   +noPadding?: boolean,
   +fixedHeader?: boolean,
-  +labelHide?: React.Node,
+  +labelHide?: string,
   +onClose?: OnClose,
   +position?: Position,
   +shown: boolean,

--- a/packages/orbit-components/src/Drawer/types.d.ts
+++ b/packages/orbit-components/src/Drawer/types.d.ts
@@ -16,7 +16,7 @@ export interface Props extends Common.Globals {
   readonly fixedHeader?: boolean;
   readonly position?: Position;
   readonly shown: boolean;
-  readonly labelHide?: React.ReactNode;
+  readonly labelHide?: string;
   readonly suppressed?: boolean;
   readonly title?: Common.Translation;
   readonly width?: string;

--- a/packages/orbit-components/src/Modal/ModalCloseButton/types.d.ts
+++ b/packages/orbit-components/src/Modal/ModalCloseButton/types.d.ts
@@ -6,5 +6,5 @@ import type * as Common from "../../common/types";
 
 export interface Props extends Common.Globals {
   readonly onClick?: Common.Event<React.SyntheticEvent<HTMLButtonElement | HTMLAnchorElement>>;
-  readonly title?: React.ReactNode;
+  readonly title?: string;
 }

--- a/packages/orbit-components/src/Modal/README.md
+++ b/packages/orbit-components/src/Modal/README.md
@@ -38,7 +38,7 @@ Table below contains all types of the props available in the Modal component.
 | autoFocus           | `boolean`                  | `true`     | The autofocus attribute of the Modal, see [this docs](https://www.w3schools.com/tags/att_autofocus.asp).                                                                                             |
 | disableAnimation    | `boolean`                  | `false`    | Defines whether the Modal performs the slide in animation on mobile. If you want to improve your [CLS](https://web.dev/cls/) score, you might want to set this to `true`.                            |
 | mobileHeader        | `boolean`                  | `true`     | If `false` the ModalHeader will not have MobileHeader and CloseContainer                                                                                                                             |
-| labelClose          | `React.Node`               | `Close`    | The label for the close button.                                                                                                                                                                      |
+| labelClose          | `string`                   | `Close`    | The label for the close button.                                                                                                                                                                      |
 
 ### Modal enum
 

--- a/packages/orbit-components/src/Modal/index.js.flow
+++ b/packages/orbit-components/src/Modal/index.js.flow
@@ -40,7 +40,7 @@ export type Props = {|
   +hasCloseButton?: boolean,
   +mobileHeader?: boolean,
   +disableAnimation?: boolean,
-  +labelClose?: React.Node,
+  +labelClose?: string,
   ...Globals,
 |};
 

--- a/packages/orbit-components/src/Modal/types.d.ts
+++ b/packages/orbit-components/src/Modal/types.d.ts
@@ -23,7 +23,7 @@ export interface Props extends Common.Globals {
   readonly preventOverlayClose?: boolean;
   readonly hasCloseButton?: boolean;
   readonly disableAnimation?: boolean;
-  readonly labelClose?: React.ReactNode;
+  readonly labelClose?: string;
 }
 
 export type Instance = {

--- a/packages/orbit-components/src/NavigationBar/README.md
+++ b/packages/orbit-components/src/NavigationBar/README.md
@@ -33,4 +33,4 @@ Table below contains all types of the props available in the NavigationBar compo
 | onHide       | `() => void \| Promise` |                          | Function for handling event when the NavigationBar disappears.                                        |
 | onShow       | `() => void \| Promise` |                          | Function for handling event when the NavigationBar appears.                                           |
 | hideOnScroll | `boolean`               | `true`                   | Turn on or off hiding navigation bar on scroll                                                        |
-| openTitle    | `React.Node`            | `"Open navigation menu"` | Property for passing translation string to open Button                                                |
+| openTitle    | `string`                | `"Open navigation menu"` | Property for passing translation string to open Button                                                |

--- a/packages/orbit-components/src/NavigationBar/index.js.flow
+++ b/packages/orbit-components/src/NavigationBar/index.js.flow
@@ -8,7 +8,7 @@ export type Props = {|
   +onShow?: () => void | Promise<any>,
   +onHide?: () => void | Promise<any>,
   +hideOnScroll?: boolean,
-  +openTitle?: React.Node,
+  +openTitle?: string,
   +children: React.Node,
   ...Globals,
 |};

--- a/packages/orbit-components/src/NavigationBar/types.d.ts
+++ b/packages/orbit-components/src/NavigationBar/types.d.ts
@@ -9,6 +9,6 @@ export interface Props extends Common.Globals {
   readonly onShow?: Common.Callback;
   readonly onHide?: Common.Callback;
   readonly children: React.ReactNode;
-  readonly openTitle?: React.ReactNode;
+  readonly openTitle?: string;
   readonly hideOnScroll?: boolean;
 }

--- a/packages/orbit-components/src/Pagination/README.md
+++ b/packages/orbit-components/src/Pagination/README.md
@@ -20,8 +20,8 @@ Table below contains all types of the props available in the Pagination componen
 | :--------------- | :--------------- | :--------- | :----------------------------------------------------------------------------------------- |
 | dataTest         | `string`         |            | Optional prop for testing purposes.                                                        |
 | hideLabels       | `boolean`        | `true`     | If `false`, the Previous and Next labels will be visible.                                  |
-| labelPrev        | `React.Node`     |            | The text label for the previous page call to action.                                       |
-| labelNext        | `React.Node`     |            | The text label for the next page call to action.                                           |
+| labelPrev        | `string`         |            | The text label for the previous page call to action.                                       |
+| labelNext        | `string`         |            | The text label for the next page call to action.                                           |
 | labelProgress    | `React.Node`     |            | The text label for progress indicator.                                                     |
 | **onPageChange** | `number => void` |            | Function for handling onPageChange event. [See Functional specs](#functional-specs)        |
 | **pageCount**    | `number`         |            | The page count to render into separated buttons. [See Functional specs](#functional-specs) |

--- a/packages/orbit-components/src/Pagination/index.js.flow
+++ b/packages/orbit-components/src/Pagination/index.js.flow
@@ -17,9 +17,9 @@ export type Props = {|
   ...PageCount,
   ...SelectedPage,
   hideLabels?: boolean,
-  prevLabel: React.Node,
-  nextLabel: React.Node,
-  progressLabel: React.Node,
+  labelPrev: string,
+  labelNext: string,
+  labelProgress: React.Node,
   size?: Sizes,
 |};
 

--- a/packages/orbit-components/src/Pagination/types.d.ts
+++ b/packages/orbit-components/src/Pagination/types.d.ts
@@ -1,15 +1,15 @@
 // Type definitions for @kiwicom/orbit-components
 // Project: http://github.com/kiwicom/orbit
 
-import type React from "react";
+import type * as React from "react";
 
 import type * as Common from "../common/types";
 
 export type OnPageChange = (page: number) => void;
 export interface Props extends Common.Globals {
   readonly onPageChange: OnPageChange;
-  readonly labelPrev: React.ReactNode;
-  readonly labelNext: React.ReactNode;
+  readonly labelPrev: string;
+  readonly labelNext: string;
   readonly labelProgress: React.ReactNode;
   readonly pageCount: number;
   readonly selectedPage?: number;

--- a/packages/orbit-components/src/Stepper/types.d.ts
+++ b/packages/orbit-components/src/Stepper/types.d.ts
@@ -5,7 +5,6 @@ import type * as React from "react";
 
 import type * as Common from "../common/types";
 
-type Title = string | ((param?: any) => string);
 // InputEvent
 export type Event = Common.Event<React.SyntheticEvent<HTMLInputElement>>;
 
@@ -17,8 +16,8 @@ export interface SharedProps extends Common.Globals {
   readonly maxValue?: number;
   readonly minValue?: number;
   // Deviation from other stepper properties
-  readonly titleIncrement?: Title;
-  readonly titleDecrement?: Title;
+  readonly titleIncrement?: string;
+  readonly titleDecrement?: string;
   // Deviation from common event format onChange
   readonly onFocus?: Event;
   readonly onBlur?: Event;

--- a/packages/orbit-components/src/Tooltip/README.md
+++ b/packages/orbit-components/src/Tooltip/README.md
@@ -36,7 +36,7 @@ Table below contains all types of the props available in the Tooltip component.
 | offset               | `[number, number]`                  | `[0, 5]` | Set offset `[vertical, horizontal]` for Tooltip                                                                                                  |
 | tabIndex             | `string \| number`                  | `"0"`    | Specifies the tab order of an element                                                                                                            |
 | onShow               | `() => void \| () => Promise<void>` |          | Callback when Tooltip is shown                                                                                                                   |
-| labelClose           | `React.Node`                        | `Close`  | Label for close button.                                                                                                                          |
+| labelClose           | `string`                            | `Close`  | Label for close button.                                                                                                                          |
 
 ## enum
 

--- a/packages/orbit-components/src/Tooltip/index.js.flow
+++ b/packages/orbit-components/src/Tooltip/index.js.flow
@@ -20,7 +20,7 @@ export type Props = {|
   +size?: Sizes,
   +onShow?: () => void | Promise<void>,
   +enabled?: boolean,
-  +labelClose?: React.Node,
+  +labelClose?: string,
   +renderInPortal?: boolean,
   +stopPropagation?: boolean,
   +tabIndex?: string | number,

--- a/packages/orbit-components/src/Tooltip/types.d.ts
+++ b/packages/orbit-components/src/Tooltip/types.d.ts
@@ -16,7 +16,7 @@ export interface Props extends Common.Globals, Popper {
   readonly stopPropagation?: boolean;
   readonly enabled?: boolean;
   readonly onShow?: Common.Callback;
-  readonly labelClose?: React.ReactNode;
+  readonly labelClose?: string;
   readonly placement?: Placement;
   readonly tabIndex?: string | number;
   readonly removeUnderlinedText?: boolean;

--- a/packages/orbit-components/src/Wizard/README.md
+++ b/packages/orbit-components/src/Wizard/README.md
@@ -31,7 +31,7 @@ Then use `Wizard` as the container for multiple `WizardStep`s:
 | lockScrolling    | `boolean`                                                 | `true`    | Whether to prevent scrolling of the rest of the page while Modal is open. This is on by default to provide a better user experience. |
 | `direction`      | `row \| column`                                           | `row`     | Allows to use `column` direction on desktop                                                                                          |
 | `dataTest`       | `string`                                                  |           | Optional prop for testing purposes.                                                                                                  |
-| `labelClose`     | `React.Node`                                              | `"Close"` | Property for passing translation string to close Button title                                                                        |
+| `labelClose`     | `string`                                                  | `"Close"` | Property for passing translation string to close Button title                                                                        |
 | `labelProgress`  | `React.Node`                                              |           | Property for passing translation string to progress text                                                                             |
 
 ## WizardStep props

--- a/packages/orbit-components/src/Wizard/index.js.flow
+++ b/packages/orbit-components/src/Wizard/index.js.flow
@@ -11,7 +11,7 @@ export type Props = {|
   +lockScrolling?: boolean,
   +completedSteps: number,
   +activeStep: number,
-  +labelClose?: React.Node,
+  +labelClose?: string,
   +labelProgress?: React.Node,
   +onChangeStep?: (stepIndex: number) => void | Promise<any>,
   +children: React.ChildrenArray<React.Element<WizardStepComponent>>,

--- a/packages/orbit-components/src/Wizard/types.d.ts
+++ b/packages/orbit-components/src/Wizard/types.d.ts
@@ -7,7 +7,7 @@ export interface Props extends Common.Globals {
   readonly direction?: "row" | "column";
   readonly completedSteps: number;
   readonly activeStep: number;
-  readonly labelClose?: React.ReactNode;
+  readonly labelClose?: string;
   readonly labelProgress?: React.ReactNode;
   readonly lockScrolling?: boolean;
   readonly onChangeStep?: (stepIndex: number) => void | Promise<any>;

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.js.flow
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.js.flow
@@ -33,7 +33,7 @@ export type ButtonCommonProps = {|
   +rel?: string,
   +role?: string,
   +submit?: boolean,
-  +title?: React.Node,
+  +title?: string,
   +contentAlign?: string,
   +contentWidth?: string,
   +tabIndex?: string | number,

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/types.d.ts
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/types.d.ts
@@ -47,7 +47,7 @@ export interface ButtonCommonProps extends Common.Globals, Common.SpaceAfter {
   readonly submit?: boolean;
   readonly contentAlign?: string | null;
   readonly contentWidth?: string | null;
-  readonly title?: React.ReactNode;
+  readonly title?: string;
   readonly tabIndex?: string | number;
   readonly width?: string;
 }


### PR DESCRIPTION
[Follow this discussion](https://skypicker.slack.com/archives/C9B1H0ACW/p1682599720016899) 

Changed where it's necessary, when it's being used as attribute it should be a string only