### PR TITLE
docs: fix WebStructureImages by renaming them

### DIFF
--- a/docs/src/documentation/03-components/01-action/button/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/01-action/button/01-guidelines.mdx
@@ -6,7 +6,7 @@ redirect_from:
 
 import { Grid } from "@kiwicom/orbit-components";
 
-import WebStructureImage from "../../../../images/component-structure/web/button.svg";
+import ButtonWebImage from "../../../../images/component-structure/web/button.svg";
 import ButtonPrimaryActionDo from "../../../../images/button-primary-action-do.svg";
 import ButtonPrimaryActionDont from "../../../../images/button-primary-action-dont.svg";
 import ButtonShowHierarchyDo from "../../../../images/button-show-hierarchy-do.svg";
@@ -58,7 +58,7 @@ Buttons help users to perform tasks or trigger processes.
 <ComponentStructure
   component="Button"
   web={{
-    Image: WebStructureImage,
+    Image: ButtonWebImage,
     imageWidth: 124,
     parts: [
       {

--- a/docs/src/documentation/03-components/03-information/alert/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/03-information/alert/01-guidelines.mdx
@@ -6,7 +6,7 @@ redirect_from:
 
 import { Grid } from "@kiwicom/orbit-components";
 
-import WebStructureImage from "../../../../images/component-structure/web/alert.svg";
+import AlertWebImage from "../../../../images/component-structure/web/alert.svg";
 import AlertInfoActions from "../../../../images/alert-info-w-actions.svg";
 import AlertUseIconsDo from "../../../../images/alert-use-icons_do.svg";
 import AlertUseIconsDont from "../../../../images/alert-use-icons_dont.svg";
@@ -55,7 +55,7 @@ Alert is used to communicate important information or feedback to the user. It i
   component="Alert"
   vertical
   web={{
-    Image: WebStructureImage,
+    Image: AlertWebImage,
     parts: [
       {
         name: "Title",


### PR DESCRIPTION
The [Component Structure image](https://orbit.kiwi/components/action/button/#component-structure) on the Button docs page was showing the image for the Alert component. This weird behavior happens for an even more weird reason: we were giving the same name to the imported image on both the Alert and Button files. Renaming them to unique names seems to solve the problem.