### PR TITLE
fix(eslint-plugin): fix missing dev dependency for postinstall

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -29,7 +29,7 @@ function fetchComponentDirs() {
     ],
   });
 
-  const whiteListedDirs = ["tokens", "docs", "hooks"];
+  const whiteListedDirs = ["tokens", "docs", "hooks", "eslint-plugin", "babel-plugin"];
 
   return dirs.reduce(filterOut, whiteListedDirs);
 }

--- a/packages/eslint-plugin-orbit-components/package.json
+++ b/packages/eslint-plugin-orbit-components/package.json
@@ -36,5 +36,7 @@
   "dependencies": {
     "@babel/types": "=7.12.10"
   },
-  "gitHead": "5e7d8f283e39532de0393f7f42cea2f7d33f6ac7"
+  "devDependencies": {
+    "del": "^7.0.0"
+  }
 }


### PR DESCRIPTION
[Reported in Slack](https://skypicker.slack.com/archives/CAMS40F7B/p1685358081894759). Forgotten, that on post install del dependency should be accessible. 