### PR TITLE
chore(themer): remove ramda and other deps

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -29,7 +29,7 @@ function fetchComponentDirs() {
     ],
   });
 
-  const whiteListedDirs = ["tokens", "docs", "hooks", "eslint-plugin", "babel-plugin"];
+  const whiteListedDirs = ["tokens", "docs", "hooks", "eslint-plugin", "babel-plugin", "themer"];
 
   return dirs.reduce(filterOut, whiteListedDirs);
 }

--- a/packages/orbit-themer/.eslintrc.cjs
+++ b/packages/orbit-themer/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: "../../.eslintrc.js",
+  rules: {
+    "import/no-extraneous-dependencies": "off",
+    "no-restricted-syntax": "off",
+  },
+};

--- a/packages/orbit-themer/package.json
+++ b/packages/orbit-themer/package.json
@@ -13,23 +13,26 @@
   },
   "author": "Kiwi.com",
   "license": "MIT",
+  "peerDependencies": {
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0",
+    "styled-components": "^5"
+  },
   "dependencies": {
-    "@kiwicom/orbit-components": "*",
-    "@kiwicom/orbit-design-tokens": "*",
-    "@types/react": "^17.0.26",
-    "copy-to-clipboard": "^3.3.1",
     "deep-object-diff": "^1.1.9",
     "object-hash": "^3.0.0",
-    "prism-react-renderer": "^1.3.5",
-    "ramda": "^0.28.0",
     "react": "^17.0.2",
     "react-color": "^2.19.3",
-    "react-dom": "^17.0.2",
-    "react-hot-loader": "^4.13.0",
-    "styled-components": "^5.3.5"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@kiwicom/babel-plugin-orbit-components": "^3.5.2",
-    "babel-loader": "^8.2.5"
+    "babel-loader": "^8.2.5",
+    "@kiwicom/orbit-components": "*",
+    "@kiwicom/orbit-design-tokens": "*",
+    "styled-components": "^5.3.5",
+    "prism-react-renderer": "^1.3.5",
+    "copy-to-clipboard": "^3.3.1",
+    "@types/react": "^17.0.26"
   }
 }

--- a/packages/orbit-themer/src/App.tsx
+++ b/packages/orbit-themer/src/App.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import assocPath from "ramda/src/assocPath";
-import { hot } from "react-hot-loader";
 import styled, { createGlobalStyle } from "styled-components";
 import { getTokens, OrbitProvider } from "@kiwicom/orbit-components";
 
+import { assocPath } from "./helpers";
 import Components from "./Components";
 import Tabs from "./Tabs";
 import ColorContext from "./ColorContext";
@@ -87,4 +86,4 @@ const App = () => {
   );
 };
 
-export default hot(module)(App);
+export default App;

--- a/packages/orbit-themer/src/Tabs/Color.tsx
+++ b/packages/orbit-themer/src/Tabs/Color.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { SketchPicker } from "react-color";
 import styled from "styled-components";
-import path from "ramda/src/path";
 import AlertCircle from "@kiwicom/orbit-components/lib/icons/AlertCircle";
 import { Tooltip } from "@kiwicom/orbit-components/";
 
+import { get } from "../helpers";
 import ColorContext from "../ColorContext";
 import { DEFAULT_COLORS } from "../consts";
 
@@ -55,12 +55,12 @@ const StyledAdjustedColor = styled.div`
 
 const Color = ({ name, extra, objectKey }: { name: string; extra?: string; objectKey: string }) => {
   const [openedColorPicker, setOpenedColorPicker] = React.useState(false);
-  const defaultColor = path(objectKey.split("."), DEFAULT_COLORS);
+  const defaultColor = get(objectKey, DEFAULT_COLORS);
 
   return (
     <ColorContext.Consumer>
       {({ setColor, colors }) => {
-        const color = path(objectKey.split("."), colors);
+        const color = get(objectKey, colors);
         const isAdjustedColor = color !== defaultColor;
 
         return (

--- a/packages/orbit-themer/src/Tabs/ColorTab.tsx
+++ b/packages/orbit-themer/src/Tabs/ColorTab.tsx
@@ -1,7 +1,5 @@
 import styled, { css } from "styled-components";
 import React from "react";
-import equals from "ramda/src/equals";
-import path from "ramda/src/path";
 import ChevronDown from "@kiwicom/orbit-components/lib/icons/ChevronDown";
 import ChevronForward from "@kiwicom/orbit-components/lib/icons/ChevronForward";
 import InformationCircle from "@kiwicom/orbit-components/lib/icons/InformationCircle";
@@ -9,6 +7,7 @@ import { defaultTheme, Badge, Heading } from "@kiwicom/orbit-components";
 
 import { DEFAULT_COLORS } from "../consts";
 import ColorContext from "../ColorContext";
+import { isDeepEqual, get } from "../helpers";
 
 const StyledColorTab = styled.div`
   font-size: 14px;
@@ -65,11 +64,11 @@ const StyledAdjusted = styled.div`
   transform: translateY(-50%);
 `;
 
-const hasAdjustedSomeColor = (colorPath, currentColors) => {
-  const currentColorObject = path(colorPath.split("."), currentColors);
-  const defaultColorObject = path(colorPath.split("."), DEFAULT_COLORS);
+const hasAdjustedSomeColor = (colorPath: string, currentColors: Record<string, any>) => {
+  const currentColorObject = get(colorPath, currentColors);
+  const defaultColorObject = get(colorPath, DEFAULT_COLORS);
 
-  return !equals(currentColorObject, defaultColorObject);
+  return !isDeepEqual(currentColorObject, defaultColorObject);
 };
 
 const ColorTab = ({ title, children, colorPath }) => {

--- a/packages/orbit-themer/src/helpers.ts
+++ b/packages/orbit-themer/src/helpers.ts
@@ -1,0 +1,42 @@
+const isObject = (object: Record<string, any>) => {
+  return object != null && typeof object === "object";
+};
+
+export function assocPath(path: string[], value: any, obj: Record<string, any>) {
+  if (path.length === 0) return value;
+
+  const [key, ...rest] = path;
+  const newObj = Array.isArray(obj) ? [...obj] : { ...obj };
+  newObj[key] = assocPath(rest, value, newObj[key] || {});
+
+  return newObj;
+}
+
+export function isDeepEqual(object1: Record<string, any>, object2: Record<string, any>) {
+  const objKeys1 = Object.keys(object1);
+  const objKeys2 = Object.keys(object2);
+
+  if (objKeys1.length !== objKeys2.length) return false;
+
+  for (const key of objKeys1) {
+    const value1 = object1[key];
+    const value2 = object2[key];
+
+    const isObjects = isObject(value1) && isObject(value2);
+
+    if ((isObjects && !isDeepEqual(value1, value2)) || (!isObjects && value1 !== value2)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function get(path: string, obj: Record<string, any>, defaultValue = undefined) {
+  const travel = (regexp: RegExp) =>
+    String.prototype.split
+      .call(path, regexp)
+      .filter(Boolean)
+      .reduce((res, key) => (res !== null && res !== undefined ? res[key] : res), obj);
+  const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/);
+  return result === undefined || result === obj ? defaultValue : result;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15204,7 +15204,7 @@ global-prefix@^3.0.0:
     kind-of "^6.0.2"
     which "^1.3.1"
 
-global@^4.3.0, global@^4.3.2, global@^4.4.0:
+global@^4.3.2, global@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
   integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
@@ -18661,7 +18661,7 @@ loader-utils@^1.2.3, loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@^2.0.0, loader-utils@^2.0.3, loader-utils@^2.0.4:
+loader-utils@^2.0.0, loader-utils@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
   integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
@@ -23229,20 +23229,6 @@ react-helmet@^6.1.0:
     prop-types "^15.7.2"
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
-
-react-hot-loader@^4.13.0:
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.13.1.tgz#979fd7598e27338b3faffae6ed01c65374dace5e"
-  integrity sha512-ZlqCfVRqDJmMXTulUGic4lN7Ic1SXgHAFw7y/Jb7t25GBgTR0fYAJ8uY4mrpxjRyWGWmqw77qJQGnYbzCvBU7g==
-  dependencies:
-    fast-levenshtein "^2.0.6"
-    global "^4.3.0"
-    hoist-non-react-statics "^3.3.0"
-    loader-utils "^2.0.3"
-    prop-types "^15.6.1"
-    react-lifecycles-compat "^3.0.4"
-    shallowequal "^1.1.0"
-    source-map "^0.7.3"
 
 react-hot-toast@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
wanted to clean up a bit this old project, after we included that to orbit.kiwi. There was used ramda, we already use lodash in our docs, so there is no need to have an additional library in the bundle like that. Replaced the ramda functions with smaller analogs. 