### PR TITLE
fix(Select): fixed spacing between prefix and customValueText

### DIFF
--- a/packages/orbit-components/src/Select/index.tsx
+++ b/packages/orbit-components/src/Select/index.tsx
@@ -244,10 +244,8 @@ SelectSuffix.defaultProps = {
   theme: defaultTheme,
 };
 
-const StyledCustomValue = styled(({ _prefix, theme, _filled, _disabled, ...props }) => (
-  <div {...props} />
-))`
-  ${({ theme, _filled, disabled, prefix }) => css`
+const StyledCustomValue = styled(({ _theme, _filled, _disabled, ...props }) => <div {...props} />)`
+  ${({ theme, _filled, disabled }) => css`
     color: ${(disabled && theme.orbit.paletteInkLight) ||
     (_filled ? theme.orbit.colorTextInput : theme.orbit.colorPlaceholderInput)};
 
@@ -257,7 +255,7 @@ const StyledCustomValue = styled(({ _prefix, theme, _filled, _disabled, ...props
     position: absolute;
     height: 100%;
     top: 0;
-    ${left}: ${prefix ? "48px" : theme.orbit.spaceSmall};
+    ${left}: ${theme.orbit.spaceSmall};
     bottom: 0;
     pointer-events: none;
   `}
@@ -370,7 +368,7 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
         )}
         <StyledSelectWrapper>
           {customValueText && (
-            <StyledCustomValue disabled={disabled} _filled={filled} prefix={prefix}>
+            <StyledCustomValue disabled={disabled} _filled={filled}>
               {customValueText}
             </StyledCustomValue>
           )}

--- a/packages/orbit-components/src/Select/types.d.ts
+++ b/packages/orbit-components/src/Select/types.d.ts
@@ -11,7 +11,7 @@ type Event = Common.Event<React.SyntheticEvent<HTMLSelectElement>>;
 interface Option {
   readonly key?: string;
   readonly value: string | number;
-  readonly label?: React.ReactNode;
+  readonly label?: string;
   readonly disabled?: boolean;
 }
 

--- a/packages/orbit-components/src/SkipNavigation/index.tsx
+++ b/packages/orbit-components/src/SkipNavigation/index.tsx
@@ -49,7 +49,7 @@ const SkipNavigation = ({
 }: Props) => {
   const [links, setLinks] = React.useState<HTMLAnchorElement[]>([]);
   const [mappedLinks, setMappedLinks] = React.useState<MappedOptions[]>([]);
-  const [innerPages, setPages] = React.useState<{ value: number; label?: React.ReactNode }[]>([]);
+  const [innerPages, setPages] = React.useState<{ value: number; label?: string }[]>([]);
   const [show, setShow] = React.useState(false);
 
   const handleLinksClick = (ev: React.SyntheticEvent<HTMLSelectElement>) => {

--- a/packages/orbit-components/src/SkipNavigation/types.d.ts
+++ b/packages/orbit-components/src/SkipNavigation/types.d.ts
@@ -12,14 +12,14 @@ interface Action {
 export interface Props {
   readonly actions?: Action[];
   readonly feedbackUrl?: string;
-  readonly firstSectionLabel?: React.ReactNode;
-  readonly firstActionLabel?: React.ReactNode;
-  readonly feedbackLabel?: React.ReactNode;
+  readonly firstSectionLabel?: string;
+  readonly firstActionLabel?: string;
+  readonly feedbackLabel?: string;
 }
 
 export interface MappedOptions {
   readonly key?: string;
   readonly value: string | number;
-  readonly label?: React.ReactNode;
+  readonly label?: string;
   readonly disabled?: boolean;
 }


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/CAMS40F7B/p1685526457132239).

During the inlineLabel and size refactoring of Select, this bug was introduced. The condition for prefix is no longer needed because of the way the customValueText is rendered

[ORBIT-2767](https://kiwicom.atlassian.net/browse/ORBIT-2767)