### PR TITLE
chore: exclude RenderInRtl from build

### DIFF
--- a/packages/orbit-components/config/build/buildIcons.mts
+++ b/packages/orbit-components/config/build/buildIcons.mts
@@ -7,12 +7,9 @@ import jsxPlugin from "@svgr/plugin-jsx";
 import prettierPlugin from "@svgr/plugin-prettier";
 import filedirname from "filedirname";
 
-// @ts-expect-error FIXME: currently ts has some issue with importing mts ext
-import { getProperty, getHTMLComments } from "../checkIcons.mts";
-// @ts-expect-error FIXME: currently ts has some issue with importing mts ext
-import { NAMES as ILLUSTRATION_NAMES } from "../../src/Illustration/consts.mts";
-// @ts-expect-error FIXME: currently ts has some issue with importing mts ext
-import { NAMES as AIRPORT_ILLUSTRATION_NAMES } from "../../src/AirportIllustration/consts.mts";
+import { Attr, getProperty, getHTMLComments } from "../checkIcons.mjs";
+import { NAMES as ILLUSTRATION_NAMES } from "../../src/Illustration/consts.mjs";
+import { NAMES as AIRPORT_ILLUSTRATION_NAMES } from "../../src/AirportIllustration/consts.mjs";
 
 const randomId = () => Math.random().toString(36).substring(2, 9);
 

--- a/packages/orbit-components/config/build/buildSize.mts
+++ b/packages/orbit-components/config/build/buildSize.mts
@@ -1,8 +1,7 @@
 import { fs, $ } from "zx";
 import dedent from "dedent";
 
-// @ts-expect-error FIXME: currently ts has some issue with importing mts ext
-import { logStep } from "./helpers.mts";
+import { logStep } from "./helpers.mjs";
 
 export default async function buildSize() {
   await fs.outputFile(

--- a/packages/orbit-components/config/build/compileSource.mts
+++ b/packages/orbit-components/config/build/compileSource.mts
@@ -2,8 +2,7 @@ import { path, fs, globby, chalk, $ } from "zx";
 import babel from "@babel/core";
 import ora from "ora";
 
-// @ts-expect-error FIXME: currently ts has some issue with importing mts ext
-import { COMPILE_IGNORE_PATTERNS } from "./consts.mts";
+import { COMPILE_IGNORE_PATTERNS } from "./consts.mjs";
 
 type ModuleItem = ["cjs" | "esm", string, babel.TransformOptions | undefined | null];
 

--- a/packages/orbit-components/config/build/consts.mts
+++ b/packages/orbit-components/config/build/consts.mts
@@ -10,9 +10,12 @@ export const OUTPUT_PATTERNS = [
 ];
 
 export const COMPILE_IGNORE_PATTERNS = [
+  "**/RenderInRtl.tsx",
   "**/*.d.ts",
   "**/*.stories.*",
   "**/*.test.*",
   "**/__tests__/**/*",
   "**/__typetests__/**/*",
 ];
+
+export const DECLARATIONS_IGNORE_PATTERN = ["**/RenderInRtl.{tsx,d.ts}"];

--- a/packages/orbit-components/config/build/generateDeclarations.mts
+++ b/packages/orbit-components/config/build/generateDeclarations.mts
@@ -3,6 +3,8 @@ import flowgen, { beautify } from "flowgen";
 import filedirname from "filedirname";
 import dedent from "dedent";
 
+import { DECLARATIONS_IGNORE_PATTERN } from "./consts.mjs";
+
 const [, __dirname] = filedirname();
 
 export default async function generateTypeDeclarations() {
@@ -19,7 +21,11 @@ export default async function generateTypeDeclarations() {
   await $`tsc --p tsconfig-build.json --rootDir src --outDir es --declaration --emitDeclarationOnly --moduleResolution node`;
 
   console.log(chalk.greenBright.bold("Generating flow declarations..."));
-  const tsDeclarations = await globby("{lib,es}/*.d.ts");
+
+  const tsDeclarations = await globby("{lib,es}/*.d.ts", {
+    ignore: DECLARATIONS_IGNORE_PATTERN,
+  });
+
   await Promise.all(
     tsDeclarations.map(async declaration => {
       const flowDeclPath = declaration.replace(".d.ts", ".js.flow");

--- a/packages/orbit-components/config/build/index.mts
+++ b/packages/orbit-components/config/build/index.mts
@@ -1,15 +1,10 @@
 import { $, argv, chalk } from "zx";
 
-// @ts-expect-error FIXME: currently ts has some issue with importing mts ext
-import compileSource from "./compileSource.mts";
-// @ts-expect-error FIXME: currently ts has some issue with importing mts ext
-import { logStep } from "./helpers.mts";
-// @ts-expect-error FIXME: currently ts has some issue with importing mts ext
-import { OUTPUT_PATTERNS } from "./consts.mts";
-// @ts-expect-error FIXME: currently ts has some issue with importing mts ext
-import generateTypeDeclarations from "./generateDeclarations.mts";
-// @ts-expect-error FIXME: currently ts has some issue with importing mts ext
-import buildSize from "./buildSize.mts";
+import compileSource from "./compileSource.mjs";
+import { logStep } from "./helpers.mjs";
+import { OUTPUT_PATTERNS } from "./consts.mjs";
+import generateTypeDeclarations from "./generateDeclarations.mjs";
+import buildSize from "./buildSize.mjs";
 
 (async () => {
   logStep("Cleanup");

--- a/packages/orbit-components/config/checkIcons.mts
+++ b/packages/orbit-components/config/checkIcons.mts
@@ -37,7 +37,11 @@ export function getHTMLComments(content: string) {
   return null;
 }
 
-export function getProperty(attributes: Attr[], name: string, defaultValue: null | string = null) {
+export function getProperty(
+  attributes: NamedNodeMap,
+  name: string,
+  defaultValue: null | string = null,
+) {
   for (let i = attributes.length - 1; i >= 0; i -= 1) {
     if (attributes[i].name === name) {
       return attributes[i].value;

--- a/packages/orbit-components/config/checkIconsCli.mts
+++ b/packages/orbit-components/config/checkIconsCli.mts
@@ -1,10 +1,10 @@
-// @ts-expect-error TODO
-import checkIcons from "./checkIcons.mts";
+import checkIcons from "./checkIcons.mjs";
 
 /*
  Paths are provided as arguments as for example in lint staged,
  and formatted to blob pattern strings e.g. '({pattern1, pattern2})
 */
+
 const paths = process.argv.slice(2);
 const formatPaths = pattern => (pattern.length > 1 ? `{${pattern.join(",")}}` : pattern[0]);
 

--- a/packages/orbit-components/config/createSVGFont.mts
+++ b/packages/orbit-components/config/createSVGFont.mts
@@ -7,6 +7,13 @@ import filedirname from "filedirname";
 const [, __dirname] = filedirname();
 const ORBIT_ICONS_DIR = path.join(__dirname, "../orbit-icons-font");
 
+interface IconType extends fs.ReadStream {
+  metadata: {
+    unicode: string[];
+    name: string;
+  };
+}
+
 const createSVG = () =>
   new Promise((resolve, reject) => {
     if (!fs.existsSync(ORBIT_ICONS_DIR)) {
@@ -35,9 +42,11 @@ const createSVG = () =>
     Object.keys(iconList).forEach(iconName => {
       const iconPath =
         iconList[iconName].iconFont === "false" ? "../src/icons/svg/mobile/" : "../src/icons/svg/";
-      const icon = fs.createReadStream(path.join(__dirname, iconPath, `${iconName}.svg`));
 
-      // @ts-expect-error TODO
+      const icon = fs.createReadStream(
+        path.join(__dirname, iconPath, `${iconName}.svg`),
+      ) as IconType;
+
       icon.metadata = {
         unicode: [String.fromCharCode(Number(`0x${iconList[iconName].character}`))],
         name: iconName,

--- a/packages/orbit-components/config/typeFiles.mts
+++ b/packages/orbit-components/config/typeFiles.mts
@@ -1,14 +1,10 @@
 import { path, fs } from "zx";
 import filedirname from "filedirname";
 
-// @ts-expect-error TODO
-import { NAMES as ILLUSTRATION_NAMES } from "../src/Illustration/consts.mts";
-// @ts-expect-error TODO
-import { NAMES as AIRPORT_ILLUSTRATION_NAMES } from "../src/AirportIllustration/consts.mts";
-// @ts-expect-error TODO
-import { NAME_OPTIONS as SERVICE_LOGOS_NAMES } from "../src/ServiceLogo/consts.mts";
-// @ts-expect-error TODO
-import { NAME_OPTIONS as FEATURE_ICONS_NAMES } from "../src/FeatureIcon/consts.mts";
+import { NAMES as ILLUSTRATION_NAMES } from "../src/Illustration/consts.mjs";
+import { NAMES as AIRPORT_ILLUSTRATION_NAMES } from "../src/AirportIllustration/consts.mjs";
+import { NAME_OPTIONS as SERVICE_LOGOS_NAMES } from "../src/ServiceLogo/consts.mjs";
+import { NAME_OPTIONS as FEATURE_ICONS_NAMES } from "../src/FeatureIcon/consts.mjs";
 
 const [, __dirname] = filedirname();
 

--- a/packages/orbit-components/tsconfig-build.json
+++ b/packages/orbit-components/tsconfig-build.json
@@ -10,5 +10,11 @@
     "emitDeclarationOnly": true
   },
   "include": ["src/**/*", "typings/**/*.d.ts"],
-  "exclude": ["**/*.test.*", "**/__tests__/**/*", "**/__typetests__/**/*", "**/*.stories.*"]
+  "exclude": [
+    "**/*.test.*",
+    "**/__tests__/**/*",
+    "**/__typetests__/**/*",
+    "**/*.stories.*",
+    "**/RenderInRtl.tsx"
+  ]
 }


### PR DESCRIPTION
![image](https://github.com/kiwicom/orbit/assets/14054752/24cdd641-8dad-4e75-9f4f-96731e1942ea)

This is caused by internal component (rtl/RenderInRtl) that we use inside stories, no need for that to be in the bundle 
Also removed the ts suppressions inside build files 

