### PR TITLE
fix(ModalFooter): wrap elements in StyledChild only when multiple

### DIFF
--- a/packages/orbit-components/src/Modal/ModalFooter/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Modal/ModalFooter/__tests__/index.test.tsx
@@ -20,6 +20,16 @@ describe("ModalFooter", () => {
     });
   });
 
+  it("should not have StyledChild wrapper on single children", () => {
+    render(
+      <ModalFooter dataTest="footer">
+        <Button type="secondary">Cancel</Button>
+      </ModalFooter>,
+    );
+
+    expect(screen.findByTestId("footer-el-wrapper")).toMatchObject({});
+  });
+
   it("should render buttons with space-between", () => {
     render(
       <ModalFooter dataTest="footer">
@@ -31,5 +41,7 @@ describe("ModalFooter", () => {
     expect(screen.getByTestId("footer")).toHaveStyleRule("justify-content", "space-between", {
       media: getBreakpointWidth("largeMobile", theme),
     });
+
+    expect(screen.getAllByTestId("footer-el-wrapper")).toHaveLength(2);
   });
 });

--- a/packages/orbit-components/src/Modal/ModalFooter/index.tsx
+++ b/packages/orbit-components/src/Modal/ModalFooter/index.tsx
@@ -16,7 +16,7 @@ const StyledChild = styled.div<{ flex?: Props["flex"] }>`
     flex: ${flex};
     box-sizing: border-box;
     padding: ${rtlSpacing(`0 ${theme.orbit.spaceXSmall} 0 0`)};
-  `}
+  `};
 `;
 
 StyledChild.defaultProps = {
@@ -65,6 +65,8 @@ const getChildFlex = (flex: Props["flex"], key: number) =>
   Array.isArray(flex) && flex.length !== 1 ? flex[key] || flex[0] : flex;
 
 const wrappedChildren = (children: React.ReactNode, flex: Props["flex"]) => {
+  if (!Array.isArray(children)) return children;
+
   return React.Children.map(children, (child, key) => {
     if (!React.isValidElement(child)) return null;
     return (

--- a/packages/orbit-components/src/Modal/ModalFooter/index.tsx
+++ b/packages/orbit-components/src/Modal/ModalFooter/index.tsx
@@ -70,7 +70,7 @@ const wrappedChildren = (children: React.ReactNode, flex: Props["flex"]) => {
   return React.Children.map(children, (child, key) => {
     if (!React.isValidElement(child)) return null;
     return (
-      <StyledChild flex={getChildFlex(flex, key)}>
+      <StyledChild flex={getChildFlex(flex, key)} data-test="footer-el-wrapper">
         {React.cloneElement(child, {
           // @ts-expect-error React.cloneElement  issue
           ref: child.ref


### PR DESCRIPTION
Getting back accidentally removed condition for checking if children element is array or not. 

[Slack request](https://skypicker.slack.com/archives/C9B1H0ACW/p1686053579542679)