### PR TITLE
fix(SegmentedSwitch): errorForm tooltip offset

### DIFF
--- a/packages/orbit-components/src/SegmentedSwitch/index.tsx
+++ b/packages/orbit-components/src/SegmentedSwitch/index.tsx
@@ -68,12 +68,11 @@ const SegmentedSwitch = ({
   }, [showTooltip, hasTooltip, setTooltipShown]);
 
   return (
-    <StyledWrapper spaceAfter={spaceAfter} data-test={dataTest} $maxWidth={maxWidth}>
+    <StyledWrapper spaceAfter={spaceAfter} data-test={dataTest} $maxWidth={maxWidth} ref={labelRef}>
       {label && (
         <FormLabel
           help={!!help}
           error={!!error}
-          labelRef={labelRef}
           onMouseEnter={() => setTooltipShownHover(true)}
           onMouseLeave={() => setTooltipShownHover(false)}
         >


### PR DESCRIPTION
I noticed, that SegmentedSwitch has a slight offset to the right side for ErroFormTooltip, I fixed that. 

Check current master and branch storybook to compare