### PR TITLE
chore: allow InputField to accept tabIndex=0

### DIFF
--- a/packages/orbit-components/src/InputField/index.tsx
+++ b/packages/orbit-components/src/InputField/index.tsx
@@ -439,7 +439,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
           maxLength={maxLength}
           error={insideInputGroup ? undefined : error}
           ref={ref}
-          tabIndex={tabIndex ? Number(tabIndex) : undefined}
+          tabIndex={tabIndex !== undefined ? Number(tabIndex) : undefined}
           list={list}
           aria-labelledby={!label ? inputId : undefined}
           aria-describedby={shown ? `${inputId}-feedback` : undefined}


### PR DESCRIPTION
This was introduced in #3851. The commit can be a chore because the bug was actually never released, so no need to mention it on the changelog 🙂 