### PR TITLE
fix(HorizontalScroll): arrows now only display if it's overflowing

### DIFF
--- a/packages/orbit-components/src/HorizontalScroll/index.tsx
+++ b/packages/orbit-components/src/HorizontalScroll/index.tsx
@@ -242,7 +242,7 @@ const HorizontalScroll = React.forwardRef<HTMLDivElement, Props>(
             <StyledButton
               tabIndex={0}
               type="button"
-              isHidden={reachedStart}
+              isHidden={reachedStart || !isOverflowing}
               onClick={() => handleClick("left")}
             >
               <ChevronBackward customColor={arrowColor} />
@@ -250,7 +250,7 @@ const HorizontalScroll = React.forwardRef<HTMLDivElement, Props>(
             <StyledButton
               tabIndex={0}
               type="button"
-              isHidden={reachedEnd}
+              isHidden={reachedEnd || !isOverflowing}
               onClick={() => handleClick("right")}
             >
               <ChevronForward customColor={arrowColor} />


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/CAMS40F7B/p1686735217397959)