### PR TITLE
fix(Itinerary): correct cursor is now applied to ItinerarySegmentBanner

### DIFF
--- a/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentBanner/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentBanner/index.tsx
@@ -8,8 +8,8 @@ import { StyledWrapper as StyledBadgeListWrapper } from "../../ItineraryBadgeLis
 import type { Props } from "./types";
 import { left } from "../../../utils/rtl";
 
-const StyledBannerWrapper = styled.div`
-  ${({ theme }) => css`
+const StyledBannerWrapper = styled.div<{ $actionable?: boolean }>`
+  ${({ theme, $actionable }) => css`
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -17,6 +17,7 @@ const StyledBannerWrapper = styled.div`
     overflow: hidden;
     box-sizing: border-box;
     padding: 0 ${theme.orbit.spaceMedium};
+    cursor: ${$actionable ? "pointer" : "default"};
 
     ${StyledBadgeListWrapper} {
       margin-${left}: 0 !important;
@@ -40,6 +41,7 @@ StyledBannerWrapper.defaultProps = {
 const ItinerarySegmentBanner = ({ onClick, children }: Props) => {
   return (
     <StyledBannerWrapper
+      $actionable={!!onClick}
       onClick={ev => {
         ev.stopPropagation();
         if (onClick) onClick(ev);


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/CAMS40F7B/p1686830163608249). Instead of inheriting the `cursor` property from the `ItinerarySegment`, the `ItinerarySegmentBanner` now applies the correct cursor based on whether or not they have an `onClick` defined.