### PR TITLE
feat/Add prefix to InputSelect Option

### DIFF
--- a/packages/orbit-components/src/InputSelect/InputSelect.stories.tsx
+++ b/packages/orbit-components/src/InputSelect/InputSelect.stories.tsx
@@ -3,6 +3,8 @@ import { css } from "styled-components";
 import { object, text, boolean } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 
+import CountryFlag from "../CountryFlag";
+
 import InputSelect from ".";
 
 export default {
@@ -15,28 +17,34 @@ export const Grouped = () => {
       title: "Euro",
       value: "EUR",
       group: "Popular",
+      prefix: <CountryFlag code="eu" />,
     },
     {
       title: "US Dollar",
       value: "USD",
       group: "Popular",
+      prefix: <CountryFlag code="us" />,
     },
     {
       title: "Pound Sterling",
       value: "GBP",
       group: "Popular",
+      prefix: <CountryFlag code="gb" />,
     },
     {
       title: "Australian Dollar",
       value: "AUD",
+      prefix: <CountryFlag code="au" />,
     },
     {
       title: "Brazilian Real",
       value: "BRL",
+      prefix: <CountryFlag code="br" />,
     },
     {
       title: "Czech Koruna",
       value: "CZK",
+      prefix: <CountryFlag code="cz" />,
     },
   ];
 

--- a/packages/orbit-components/src/InputSelect/InputSelect.styled.ts
+++ b/packages/orbit-components/src/InputSelect/InputSelect.styled.ts
@@ -64,6 +64,7 @@ export const StyledDropdown = styled.ul<{
     box-sizing: border-box;
     width: 100%;
     background: ${theme.orbit.paletteWhite};
+    z-index: 3;
 
     ${mq.largeMobile(css`
       position: absolute;

--- a/packages/orbit-components/src/InputSelect/InputSelectOption/index.tsx
+++ b/packages/orbit-components/src/InputSelect/InputSelectOption/index.tsx
@@ -24,11 +24,12 @@ type InputSelectOptionProps = {
   isSelected: boolean;
   title: Option["title"];
   description: Option["description"];
+  prefix: Option["prefix"];
   onClick: (ev: React.SyntheticEvent) => void;
 };
 
 const InputSelectOption = React.forwardRef<HTMLDivElement, InputSelectOptionProps>(
-  ({ active, id, onClick, isSelected, title, description }, ref) => {
+  ({ active, id, onClick, isSelected, title, description, prefix }, ref) => {
     return (
       <StyledListChoiceWrapper $active={active}>
         <ListChoice
@@ -41,6 +42,7 @@ const InputSelectOption = React.forwardRef<HTMLDivElement, InputSelectOptionProp
           role="option"
           title={title}
           description={description}
+          icon={prefix}
         />
       </StyledListChoiceWrapper>
     );

--- a/packages/orbit-components/src/InputSelect/README.md
+++ b/packages/orbit-components/src/InputSelect/README.md
@@ -106,3 +106,4 @@ The table below contains all types of props available for the object in the `Opt
 | **value**   | `string   \| number` | **Required.** The value of the Option. Should be unique in each option on the array of options passed to `InputSelect`. |
 | description | `string`             | The description of the Option.                                                                                          |
 | group       | `string`             | The group of the Option.                                                                                                |
+| prefix      | `React.Node`         | A prefix to the title. Can be an icon, flag, etc.                                                                       |

--- a/packages/orbit-components/src/InputSelect/index.js.flow
+++ b/packages/orbit-components/src/InputSelect/index.js.flow
@@ -11,6 +11,7 @@ type Option = {|
   +title: string,
   +value: string | number,
   +description?: string,
+  +prefix?: React.Node,
 |};
 
 export type Props = {|

--- a/packages/orbit-components/src/InputSelect/index.tsx
+++ b/packages/orbit-components/src/InputSelect/index.tsx
@@ -221,7 +221,7 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
     const renderOptions = () => {
       if (results.groups.length === 0) {
         return results.all.map((option, idx) => {
-          const { title, description, value: optValue } = option;
+          const { title, description, prefix, value: optValue } = option;
           const optionId = randomId(title);
           const isSelected = optValue === selectedOption?.value;
           const optionRef = React.createRef() as React.RefObject<HTMLDivElement>;
@@ -236,6 +236,7 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
               ref={optionRef}
               title={title}
               description={description}
+              prefix={prefix}
               onClick={ev => {
                 ev.preventDefault();
                 if (onOptionSelect) onOptionSelect(option);
@@ -272,7 +273,7 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
                   const optionRef = React.createRef() as React.RefObject<HTMLDivElement>;
                   refs[optionIdx] = optionRef;
 
-                  const { title, description, value: optValue } = option;
+                  const { title, description, prefix, value: optValue } = option;
                   const optionId = randomId(title);
                   const isSelected = optValue === selectedOption?.value;
 
@@ -285,6 +286,7 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
                       ref={optionRef}
                       title={title}
                       description={description}
+                      prefix={prefix}
                       onClick={ev => {
                         ev.preventDefault();
                         if (onOptionSelect) onOptionSelect(option);
@@ -304,7 +306,7 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
             <Text type="secondary">{showAllLabel}</Text>
           </Box>
           {results.all.map(option => {
-            const { title, description, value: optValue, group } = option;
+            const { title, description, prefix, value: optValue, group } = option;
             if (group && !showAll) return null;
             idx += 1;
             const optionRef = React.createRef() as React.RefObject<HTMLDivElement>;
@@ -323,6 +325,7 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
                 ref={optionRef}
                 title={title}
                 description={description}
+                prefix={prefix}
                 onClick={ev => {
                   ev.preventDefault();
                   if (onOptionSelect) onOptionSelect(option);

--- a/packages/orbit-components/src/InputSelect/types.d.ts
+++ b/packages/orbit-components/src/InputSelect/types.d.ts
@@ -10,6 +10,7 @@ export interface Option {
   readonly title: string;
   readonly value: string | number;
   readonly description?: string;
+  readonly prefix?: React.ReactNode;
 }
 
 // InputEvent

--- a/packages/orbit-components/src/ListChoice/index.tsx
+++ b/packages/orbit-components/src/ListChoice/index.tsx
@@ -13,6 +13,7 @@ import type { Props } from "./types";
 const StyledListChoiceIcon = styled.div`
   ${({ theme }) => css`
     display: flex;
+    align-items: center;
     align-self: flex-start;
     flex: 0 0 auto;
     margin-${right}: ${theme.orbit.spaceXSmall};


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/CAMS40F7B/p1687446287291309).

The Option of InputSelect now supports a prefix. Added a missing `z-index` property to the Dropdown. And center aligned the icon of the ListChoice, since it can now receive other things from the InputSelect (flags were misaligned, for instance)