### PR TITLE
Fix/select label

### DIFF
--- a/packages/orbit-components/src/Select/Select.stories.tsx
+++ b/packages/orbit-components/src/Select/Select.stories.tsx
@@ -66,6 +66,26 @@ WithCountryFlagPrefix.story = {
   },
 };
 
+export const WithLongLabel = () => {
+  const inlineLabel = boolean("inlineLabel", true);
+  return (
+    <Select
+      label="Select box (with long label)"
+      options={objectOptions}
+      onChange={action("onChange")}
+      inlineLabel={inlineLabel}
+    />
+  );
+};
+
+WithLongLabel.story = {
+  name: "With long label",
+
+  parameters: {
+    info: "Long labels truncate automatically when inline.",
+  },
+};
+
 export const WithPlaceholder = () => {
   const placeholder = text("Placeholder", "Select value from list");
   return (

--- a/packages/orbit-components/src/Select/index.tsx
+++ b/packages/orbit-components/src/Select/index.tsx
@@ -205,6 +205,14 @@ export const SelectContainer = styled.div<{ disabled?: boolean; error?: boolean 
         error ? theme.orbit.borderColorInputErrorHover : theme.orbit.borderColorInputHover
       }`};
     }
+
+    &:focus-within {
+      outline: none;
+
+      ${FakeInput} {
+        ${formElementFocus}
+      }
+    }
   `}
 `;
 

--- a/packages/orbit-components/src/Select/index.tsx
+++ b/packages/orbit-components/src/Select/index.tsx
@@ -44,10 +44,14 @@ const StyledInlineLabel = styled.div<{ hasFeedback?: boolean }>`
     )};
 
     ${FormLabel} {
+      display: inline-block;
       margin-bottom: 0;
       font-size: ${theme.orbit.fontSizeInputNormal};
       line-height: ${theme.orbit.lineHeightTextNormal};
+      text-overflow: ellipsis;
       white-space: nowrap;
+      overflow: hidden;
+      max-width: 20ch;
     }
   `}
 `;


### PR DESCRIPTION
On Select component, a long inline label now truncates automatically. The focus styles were also missing and were fixed.