### PR TITLE
chore: adjust tokens in icon PNG generator script

### DIFF
--- a/packages/orbit-components/config/generatePngIcons.mts
+++ b/packages/orbit-components/config/generatePngIcons.mts
@@ -8,9 +8,9 @@ const DIR = path.join(__dirname, "../orbit-email-icons");
 const sizesToGenerate = [32, 48];
 const colors = [
   ["white", defaultTokens.paletteWhite],
-  ["secondary", defaultTokens.paletteCloudNormal],
-  ["tertiary", defaultTokens.paletteInkLight],
-  ["primary", defaultTokens.paletteInkNormal],
+  ["secondary", defaultTokens.colorIconSecondary],
+  ["tertiary", defaultTokens.colorIconTertiary],
+  ["primary", defaultTokens.colorIconPrimary],
   ["warning", defaultTokens.paletteOrangeNormal],
   ["error", defaultTokens.paletteRedNormal],
   ["success", defaultTokens.paletteGreenNormal],


### PR DESCRIPTION
The script was using outdated and incorrect tokens. It now follows the theme tokens that are expected and documented.

Marked as a chore commit as not relevant to the changelog, because it is an internal script.