### PR TITLE
fix(Slider): range Slider was not updating correctly

### DIFF
--- a/packages/orbit-components/src/Slider/Slider.stories.tsx
+++ b/packages/orbit-components/src/Slider/Slider.stories.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { array, text, number, boolean } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 
+import type { Value } from "./types";
 import RenderInRtl from "../utils/rtl/RenderInRtl";
 
 import Slider from ".";
@@ -74,18 +75,24 @@ SliderWithHistogram.story = {
 
 export const RangeSlider = () => {
   const label = text("label", "Depart from Prague");
-  const valueDescription = text("valueDescription", "01:00 PM – 11:59 PM");
-  const defaultValue = array("defaultValue", ["1", "5"]);
+  const defaultValue = array("defaultValue", ["1", "5"]).map(v => parseInt(v, 10));
   const minValue = number("minValue", 1);
   const maxValue = number("maxValue", 24);
   const step = number("step", 1);
+
+  const [times, setTimes] = React.useState<Value>(defaultValue);
+  const valueDescription = `${times[0]}:00 - ${times[1]}:00`;
+
   return (
     <Slider
       onChangeAfter={action("onChangeAfter")}
-      onChange={action("onChange")}
+      onChange={v => {
+        setTimes(v);
+        action("onChange")(v);
+      }}
       label={label}
       valueDescription={valueDescription}
-      defaultValue={defaultValue.map(v => parseInt(v, 10))}
+      defaultValue={defaultValue}
       minValue={minValue}
       maxValue={maxValue}
       step={step}
@@ -101,8 +108,7 @@ RangeSlider.story = {
 
 export const RangeSliderWithHistogram = () => {
   const label = text("label", "Depart from Prague");
-  const valueDescription = text("valueDescription", "01:00 PM – 11:59 PM");
-  const defaultValue = array("defaultValue", ["0", "24"]);
+  const defaultValue = array("defaultValue", ["0", "24"]).map(v => parseInt(v, 10));
   const minValue = number("minValue", 0);
   const maxValue = number("maxValue", 48);
   const step = number("step", 2);
@@ -114,14 +120,19 @@ export const RangeSliderWithHistogram = () => {
     ].map(v => v.toString()),
   );
   const histogramDescription = text("histogramDescription", "20 of 133 flights");
+  const [times, setTimes] = React.useState<Value>(defaultValue);
+  const valueDescription = `${times[0]}:00 - ${times[1]}:00`;
   return (
     <div style={{ backgroundColor: "#f1f5f7", padding: "24px" }}>
       <Slider
-        onChange={action("onChange")}
+        onChange={v => {
+          setTimes(v);
+          action("onChange")(v);
+        }}
         label={label}
         valueDescription={valueDescription}
         histogramDescription={histogramDescription}
-        defaultValue={defaultValue.map(v => parseInt(v, 10))}
+        defaultValue={defaultValue}
         histogramData={histogramData.map(v => parseInt(v, 10))}
         minValue={minValue}
         maxValue={maxValue}

--- a/packages/orbit-components/src/Slider/index.tsx
+++ b/packages/orbit-components/src/Slider/index.tsx
@@ -25,6 +25,7 @@ import {
   injectCallbackAndSetState,
   moveValueByExtraStep,
   calculateValueFromPosition,
+  isNotEqual,
 } from "./utils";
 
 const StyledSlider = styled.div`
@@ -102,6 +103,7 @@ const PureSlider = ({
   const bar = React.useRef<HTMLDivElement>(null);
   const [value, setValue] = React.useState(defaultValue);
   const valueRef = React.useRef(value);
+  const defaultRef = React.useRef(defaultValue);
   const handleIndex = React.useRef<number | null>(null);
   const [focused, setFocused] = React.useState(false);
   const { rtl } = theme;
@@ -116,7 +118,10 @@ const PureSlider = ({
       ? defaultValue.map(item => Number(item))
       : Number(defaultValue);
 
-    updateValue(newValue);
+    if (isNotEqual(defaultValue, defaultRef.current)) {
+      defaultRef.current = newValue;
+      updateValue(newValue);
+    }
   }, [defaultValue]);
 
   const handleKeyDown = (event: KeyboardEvent) => {

--- a/packages/orbit-components/src/Slider/index.tsx
+++ b/packages/orbit-components/src/Slider/index.tsx
@@ -131,7 +131,6 @@ const PureSlider = ({
       pauseEvent(event);
       if (onChange) {
         injectCallbackAndSetState(
-          value,
           updateValue,
           onChange,
           moveValueByExtraStep(value, maxValue, minValue, step, handleIndex.current, step),
@@ -142,7 +141,6 @@ const PureSlider = ({
       pauseEvent(event);
       if (onChange) {
         injectCallbackAndSetState(
-          value,
           updateValue,
           onChange,
           moveValueByExtraStep(value, maxValue, minValue, step, handleIndex.current, -step),
@@ -154,7 +152,6 @@ const PureSlider = ({
       pauseEvent(event);
       if (onChange) {
         injectCallbackAndSetState(
-          value,
           updateValue,
           onChange,
           moveValueByExtraStep(value, maxValue, minValue, step, handleIndex.current, switchStep),
@@ -166,7 +163,6 @@ const PureSlider = ({
       pauseEvent(event);
       if (onChange) {
         injectCallbackAndSetState(
-          value,
           updateValue,
           onChange,
           moveValueByExtraStep(value, maxValue, minValue, step, handleIndex.current, switchStep),
@@ -177,7 +173,6 @@ const PureSlider = ({
       pauseEvent(event);
       if (onChange) {
         injectCallbackAndSetState(
-          value,
           updateValue,
           onChange,
           moveValueByExtraStep(value, maxValue, minValue, step, handleIndex.current, 0, minValue),
@@ -188,7 +183,6 @@ const PureSlider = ({
       pauseEvent(event);
       if (onChange) {
         injectCallbackAndSetState(
-          value,
           updateValue,
           onChange,
           moveValueByExtraStep(value, maxValue, minValue, step, handleIndex.current, 0, maxValue),
@@ -202,7 +196,7 @@ const PureSlider = ({
     window.removeEventListener("keydown", handleKeyDown);
     window.removeEventListener("focusout", handleBlur);
     if (onChangeAfter) {
-      injectCallbackAndSetState(value, updateValue, onChangeAfter, value, true);
+      injectCallbackAndSetState(updateValue, onChangeAfter, value);
     }
   };
 
@@ -213,7 +207,7 @@ const PureSlider = ({
     window.addEventListener("keydown", handleKeyDown);
     window.addEventListener("focusout", handleBlur);
     if (onChangeBefore) {
-      injectCallbackAndSetState(value, updateValue, onChangeBefore, value, true);
+      injectCallbackAndSetState(updateValue, onChangeBefore, value);
     }
   };
 
@@ -253,18 +247,14 @@ const PureSlider = ({
           alignValue(maxValue, minValue, step, newValue),
           index || 0,
         );
-        if (onChangeBefore)
-          injectCallbackAndSetState(value, updateValue, onChangeBefore, value, true);
-        if (onChange) injectCallbackAndSetState(value, updateValue, onChange, replacedValue);
-        if (onChangeAfter)
-          injectCallbackAndSetState(value, updateValue, onChangeAfter, replacedValue);
+        if (onChangeBefore) injectCallbackAndSetState(updateValue, onChangeBefore, value);
+        if (onChange) injectCallbackAndSetState(updateValue, onChange, replacedValue);
+        if (onChangeAfter) injectCallbackAndSetState(updateValue, onChangeAfter, replacedValue);
       } else {
         const alignedValue = alignValue(maxValue, minValue, step, newValue);
-        if (onChangeBefore)
-          injectCallbackAndSetState(value, updateValue, onChangeBefore, value, true);
-        if (onChange) injectCallbackAndSetState(value, updateValue, onChange, alignedValue);
-        if (onChangeAfter)
-          injectCallbackAndSetState(value, updateValue, onChangeAfter, alignedValue);
+        if (onChangeBefore) injectCallbackAndSetState(updateValue, onChangeBefore, value);
+        if (onChange) injectCallbackAndSetState(updateValue, onChange, alignedValue);
+        if (onChangeAfter) injectCallbackAndSetState(updateValue, onChangeAfter, alignedValue);
       }
     }
   };
@@ -282,7 +272,7 @@ const PureSlider = ({
       pageX: event.pageX,
     });
     pauseEvent(event);
-    injectCallbackAndSetState(value, updateValue, onChange, handleMove(newValue));
+    injectCallbackAndSetState(updateValue, onChange, handleMove(newValue));
   };
 
   const handleMouseUp = () => {
@@ -291,7 +281,7 @@ const PureSlider = ({
     window.removeEventListener("mousemove", handleMouseMove);
     window.removeEventListener("mouseup", handleMouseUp);
     if (onChangeAfter) {
-      injectCallbackAndSetState(value, updateValue, onChangeAfter, valueRef.current, true);
+      injectCallbackAndSetState(updateValue, onChangeAfter, valueRef.current);
     }
   };
 
@@ -304,7 +294,7 @@ const PureSlider = ({
       window.addEventListener("mouseup", handleMouseUp);
       pauseEvent(event);
       if (onChangeBefore) {
-        injectCallbackAndSetState(value, updateValue, onChangeBefore, value, true);
+        injectCallbackAndSetState(updateValue, onChangeBefore, value);
       }
     }
   };
@@ -323,7 +313,7 @@ const PureSlider = ({
       pageX: event.touches[0]?.pageX || 0,
     });
     pauseEvent(event);
-    injectCallbackAndSetState(value, updateValue, onChange, handleMove(newValue));
+    injectCallbackAndSetState(updateValue, onChange, handleMove(newValue));
   };
 
   const handleTouchEnd = () => {
@@ -331,7 +321,7 @@ const PureSlider = ({
     window.removeEventListener("touchmove", handleOnTouchMove);
     window.removeEventListener("touchend", handleTouchEnd);
     if (onChangeAfter) {
-      injectCallbackAndSetState(value, updateValue, onChangeAfter, valueRef.current, true);
+      injectCallbackAndSetState(updateValue, onChangeAfter, valueRef.current);
     }
   };
 
@@ -345,7 +335,7 @@ const PureSlider = ({
       window.addEventListener("touchend", handleTouchEnd);
       stopPropagation(event);
       if (onChangeBefore) {
-        injectCallbackAndSetState(value, updateValue, onChangeBefore, value, true);
+        injectCallbackAndSetState(updateValue, onChangeBefore, value);
       }
     }
   };

--- a/packages/orbit-components/src/Slider/utils/index.ts
+++ b/packages/orbit-components/src/Slider/utils/index.ts
@@ -84,19 +84,15 @@ export const alignValue = (
 };
 
 export const injectCallbackAndSetState = (
-  value: Value,
   setValue: (value: Value) => void,
   callback: SliderCallback | undefined,
   newValue: Value | null,
-  forced?: boolean,
 ): void => {
   if (newValue != null) {
-    if (isNotEqual(newValue, value) || forced) {
-      if (callback) {
-        callback(sortArray(newValue));
-      }
-      setValue(newValue);
+    if (callback) {
+      callback(sortArray(newValue));
     }
+    setValue(newValue);
   }
 };
 


### PR DESCRIPTION
defaultValue comparison was not being made correctly. Therefore, it was triggering a state update all the time, overcoming the actual value update from the user's interaction.

**Update:** During inspection with Search, another bug was noticed, that was actually present even before this branch was created. So it was impossible to slide over the currently selected value. This was fixed by removing the verifications of new values, which, from my understanding, were legacy to the older implementation without hooks. But review is appreciated 🙏 

Reported [here](https://skypicker.slack.com/archives/CAMS40F7B/p1687859299240369).