### PR TITLE
feat(Illustration): add NoFlightChange illustration

### DIFF
--- a/packages/orbit-components/src/Illustration/README.md
+++ b/packages/orbit-components/src/Illustration/README.md
@@ -77,6 +77,7 @@ The table below contains all types of props available in the Illustration compon
 | `"NetVerify"`                   |
 | `"NoBookings"`                  |
 | `"NoFavoriteFlights"`           |
+| `"NoFlightChange"`              |
 | `"Nomad"`                       |
 | `"NomadNeutral"`                |
 | `"NoNotification"`              |

--- a/packages/orbit-components/src/Illustration/consts.mts
+++ b/packages/orbit-components/src/Illustration/consts.mts
@@ -52,6 +52,7 @@ export const NAMES: Name[] = [
   "NetVerify",
   "NoBookings", // TODO: Get rid off 22.11
   "NoFavoriteFlights",
+  "NoFlightChange",
   "Nomad",
   "NomadNeutral",
   "NoNotification",

--- a/packages/orbit-components/src/Illustration/index.js.flow
+++ b/packages/orbit-components/src/Illustration/index.js.flow
@@ -56,6 +56,7 @@ type Name =
   | "NetVerify"
   | "NoBookings"
   | "NoFavoriteFlights"
+  | "NoFlightChange"
   | "Nomad"
   | "NomadNeutral"
   | "NoNotification"

--- a/packages/orbit-components/src/Illustration/types.d.ts
+++ b/packages/orbit-components/src/Illustration/types.d.ts
@@ -57,6 +57,7 @@ export type Name =
   | "NetVerify"
   | "NoBookings"
   | "NoFavoriteFlights"
+  | "NoFlightChange"
   | "Nomad"
   | "NomadNeutral"
   | "NoNotification"


### PR DESCRIPTION
Adds the NoFlightChange illustration.

Still waiting for deploy and upload on the internal repository.