### PR TITLE
fix(TextLink): allow secondary type inside Alert

### DIFF
--- a/packages/orbit-components/src/TextLink/index.tsx
+++ b/packages/orbit-components/src/TextLink/index.tsx
@@ -118,13 +118,16 @@ const resolveUnderline = ({
 };
 
 // Common styles for TextLink and "a" in Text
-export const getLinkStyle = ({ theme }: { theme: Theme; $type: Props["type"] }) => css`
+export const getLinkStyle = ({ theme, $type }: { theme: Theme; $type: Props["type"] }) => css`
   &,
   &:link,
   &:visited {
-    color: ${getColor};
-    text-decoration: ${resolveUnderline};
-    font-weight: ${theme.orbit.fontWeightLinks};
+    &:not(:hover) {
+      color: ${getColor} ${$type === TYPE_OPTIONS.SECONDARY && `!important`};
+      text-decoration: ${resolveUnderline} ${$type === TYPE_OPTIONS.SECONDARY && `!important`};
+      font-weight: ${theme.orbit.fontWeightLinks}
+        ${$type === TYPE_OPTIONS.SECONDARY && `!important`};
+    }
   }
 
   &:hover {


### PR DESCRIPTION
Type secondary should have predominance over Alert type.

[ORBIT-2837](https://kiwicom.atlassian.net/browse/ORBIT-2837)

**Before:**
<img width="246" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/6ccee886-57c2-4fb7-a392-19c86672e688">

**Now:**
<img width="246" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/5bb057ad-44a6-4590-81da-054521eff4df">

```jsx
<Alert>
  <TextLink type="secondary">blue</TextLink>
</Alert>
```
