### PR TITLE
Fix country flag width token

### DIFF
--- a/packages/orbit-components/src/CountryFlag/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/CountryFlag/__tests__/index.test.tsx
@@ -2,13 +2,15 @@ import React from "react";
 import { render, screen, cleanup } from "@testing-library/react";
 
 import CountryFlag from "..";
+import { baseURL } from "../consts";
 
 describe("CountryFlag", () => {
   it("should have expected DOM output", () => {
     render(<CountryFlag code="anywhere" name="Anywhere" dataTest="test" />);
     const flag = screen.getByRole("img", { name: "Anywhere" });
     expect(flag).toHaveAttribute("src", expect.stringContaining("anywhere"));
-    expect(flag).toHaveAttribute("srcset", expect.stringContaining("anywhere"));
+    expect(flag).toHaveAttribute("src", `${baseURL}/flags/24x0/flag-anywhere.jpg`);
+    expect(flag).toHaveAttribute("srcset", `${baseURL}/flags/48x0/flag-anywhere.jpg 2x`);
     expect(screen.getByTitle("Anywhere")).toBeInTheDocument();
     expect(screen.getByAltText("Anywhere")).toBeInTheDocument();
     expect(screen.getByTestId("test")).toBeInTheDocument();

--- a/packages/orbit-design-tokens/output/docs-tokens.json
+++ b/packages/orbit-design-tokens/output/docs-tokens.json
@@ -10540,7 +10540,7 @@
     },
     "javascript": {
       "name": "widthCountryFlag",
-      "value": "20px"
+      "value": "24px"
     },
     "foundation": {
       "name": "widthCountryFlag",
@@ -10548,7 +10548,7 @@
     },
     "scss": {
       "name": "widthCountryFlag",
-      "value": "20px"
+      "value": "24px"
     }
   },
   "widthModalSmall": {

--- a/packages/orbit-design-tokens/output/tokens.css
+++ b/packages/orbit-design-tokens/output/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 25 Jul 2023 11:18:26 GMT
+ * Generated on Wed, 26 Jul 2023 13:12:51 GMT
  */
 
 :root {
@@ -486,7 +486,7 @@
   --width-checkbox: 20;
   --width-radio-button: 20;
   --width-stopover-arrow: 36;
-  --width-country-flag: 20;
+  --width-country-flag: 24;
   --width-modal-small: 540;
   --width-modal-normal: 740;
   --width-modal-large: 900;

--- a/packages/orbit-design-tokens/output/tokens.less
+++ b/packages/orbit-design-tokens/output/tokens.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 25 Jul 2023 11:18:26 GMT
+// Generated on Wed, 26 Jul 2023 13:12:51 GMT
 
 @padding-alert: 16;
 @padding-alert-with-icon: 12;
@@ -484,7 +484,7 @@
 @width-checkbox: 20;
 @width-radio-button: 20;
 @width-stopover-arrow: 36;
-@width-country-flag: 20;
+@width-country-flag: 24;
 @width-modal-small: 540;
 @width-modal-normal: 740;
 @width-modal-large: 900;

--- a/packages/orbit-design-tokens/output/tokens.scss
+++ b/packages/orbit-design-tokens/output/tokens.scss
@@ -491,7 +491,7 @@ $width-badge-circled: 24px;
 $width-checkbox: 20px;
 $width-radio-button: 20px;
 $width-stopover-arrow: 36px;
-$width-country-flag: 20px;
+$width-country-flag: 24px;
 $width-modal-small: 540px;
 $width-modal-normal: 740px;
 $width-modal-large: 900px;

--- a/packages/orbit-design-tokens/output/tokens.styl
+++ b/packages/orbit-design-tokens/output/tokens.styl
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 25 Jul 2023 11:18:26 GMT
+// Generated on Wed, 26 Jul 2023 13:12:51 GMT
 
 $padding-alert= 16;
 $padding-alert-with-icon= 12;
@@ -484,7 +484,7 @@ $width-badge-circled= 24;
 $width-checkbox= 20;
 $width-radio-button= 20;
 $width-stopover-arrow= 36;
-$width-country-flag= 20;
+$width-country-flag= 24;
 $width-modal-small= 540;
 $width-modal-normal= 740;
 $width-modal-large= 900;

--- a/packages/orbit-design-tokens/output/tokens.xml
+++ b/packages/orbit-design-tokens/output/tokens.xml
@@ -1929,7 +1929,7 @@
   </token>
   <token>
     <name>widthCountryFlag</name>
-    <value>20</value>
+    <value>24</value>
   </token>
   <token>
     <name>widthModalSmall</name>

--- a/packages/orbit-design-tokens/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/orbit-design-tokens/src/__tests__/__snapshots__/index.test.ts.snap
@@ -799,7 +799,7 @@ Object {
   "widthBreakpointTablet": 768,
   "widthCarrierLogo": "32px",
   "widthCheckbox": "20px",
-  "widthCountryFlag": "20px",
+  "widthCountryFlag": "24px",
   "widthIconLarge": "24px",
   "widthIconMedium": "20px",
   "widthIconSmall": "16px",

--- a/packages/orbit-design-tokens/src/dictionary/definitions/component/icon/icon-size.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/component/icon/icon-size.json
@@ -81,9 +81,9 @@
       },
       "country-flag": {
         "type": "size",
-        "value": 20,
+        "value": 24,
         "deprecated": true,
-        "deprecated-replace": "{component.icon.medium.size}",
+        "deprecated-replace": "{component.icon.large.size}",
         "deprecated-version": "1.0.0"
       }
     },

--- a/packages/orbit-design-tokens/src/js/createTokens.ts
+++ b/packages/orbit-design-tokens/src/js/createTokens.ts
@@ -1318,7 +1318,7 @@ const createTokens: CreateTokens = foundation => ({
   widthCheckbox: "20px",
   widthRadioButton: "20px",
   widthStopoverArrow: "36px",
-  widthCountryFlag: "20px",
+  widthCountryFlag: "24px",
   widthModalSmall: "540px",
   widthModalNormal: "740px",
   widthModalLarge: "900px",


### PR DESCRIPTION
The token `widthCountryFlag` changed from 24px to 20px during the Styled Dictionary / Tailwind migration, unexpectedly.
The token is being used to get the src from images.kiwi and the test is only asserting that the src URL contains the correct country code, it does not assert the width, that is also part of the URL. So it silently broke.

This PR improves the test and fixes the token value.

[FEPLT-1627](https://kiwicom.atlassian.net/browse/FEPLT-1627)