### PR TITLE
fix(InputSelect): clearing the input now clears the selected option

### DIFF
--- a/packages/orbit-components/src/InputSelect/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/InputSelect/__tests__/index.test.tsx
@@ -152,7 +152,7 @@ describe("InputSelect", () => {
 
     expect(input).toHaveValue(jetLiOption.title);
 
-    // Simulate closing to assert the selected value is the default
+    // Simulate closing to assert the selected value is the same
     fireEvent.keyDown(input, { key: "Escape" });
     expect(onClose).toHaveBeenCalledWith(jetLiOption);
 
@@ -162,6 +162,32 @@ describe("InputSelect", () => {
     expect(onClose).toHaveBeenLastCalledWith(jetLiOption);
     expect(onOptionSelect).not.toHaveBeenCalled();
     expect(screen.getByRole("textbox")).toHaveValue(jetLiOption.title);
+  });
+
+  it("clears the selected value when the input is cleared", () => {
+    const onClose = jest.fn();
+    const onOptionSelect = jest.fn();
+
+    render(
+      <InputSelect
+        id={id}
+        label={label}
+        options={options}
+        name={name}
+        defaultSelected={jetLiOption}
+        onClose={onClose}
+        onOptionSelect={onOptionSelect}
+      />,
+    );
+
+    userEvent.tab();
+
+    const input = screen.getByRole("combobox");
+
+    userEvent.clear(input);
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledWith(null);
+    expect(onOptionSelect).toHaveBeenCalledWith(null);
   });
 
   it("can have prevSelected defined", () => {

--- a/packages/orbit-components/src/InputSelect/index.tsx
+++ b/packages/orbit-components/src/InputSelect/index.tsx
@@ -103,14 +103,17 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
 
     const handleClose = (selection?: Option | null) => {
       if (!selection) {
-        if (inputValue !== selectedOption?.title) {
+        if (inputValue === "") {
+          if (onOptionSelect) onOptionSelect(null);
+          setSelectedOption(null);
+        } else if (inputValue !== selectedOption?.title) {
           setInputValue(selectedOption?.title || "");
-          setResults(groupedOptions);
-          setActiveIdx(0);
         }
+        setResults(groupedOptions);
+        setActiveIdx(0);
       }
 
-      if (onClose && isOpened) onClose(selection || selectedOption);
+      if (onClose && isOpened) onClose(selection || (inputValue === "" ? null : selectedOption));
       setIsOpened(false);
     };
 


### PR DESCRIPTION
This feature was missing from the previous batch of fixes/features introduced.

InputSelect now clears any selected option if the text field is cleared.