### PR TITLE
fix: use ForwardRefRenderFunction instead of deprecated RefForwarding…

### DIFF
--- a/packages/orbit-components/src/common/types.d.ts
+++ b/packages/orbit-components/src/common/types.d.ts
@@ -17,7 +17,7 @@ export type Event<T> = (event: T) => void | Promise<void>;
 export type Component =
   | string
   | React.ComponentType<any>
-  | React.RefForwardingComponent<HTMLElement, any>;
+  | React.ForwardRefRenderFunction<HTMLElement, any>;
 export type Size = "small" | "normal" | "large" | "extraLarge";
 export type InputSize = "small" | "normal";
 


### PR DESCRIPTION
…Component

In particular, that type was removed in React 18 and blocks adoption otherwise.

```
   // From @types/react for React 17.0
  [...]
    /**
     * @deprecated Use ForwardRefRenderFunction. forwardRef doesn't accept a
     *             "real" component.
     */
    interface RefForwardingComponent <T, P = {}> extends ForwardRefRenderFunction<T, P> {}
```

