### PR TITLE
Fix ServiceLogo height token

### DIFF
--- a/packages/orbit-components/src/ServiceLogo/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/ServiceLogo/__tests__/index.test.tsx
@@ -1,22 +1,18 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
 
-import defaultTheme from "../../defaultTheme";
 import { NAME_OPTIONS, SIZE_OPTIONS, baseURL } from "../consts";
 import ServiceLogo from "..";
 
 const name = NAME_OPTIONS.AIRHELP;
-const size = SIZE_OPTIONS.LARGE;
-
-const SIZE = defaultTheme.orbit.heightServiceLogoLarge;
 
 describe(`ServiceLogo`, () => {
   it("should have expected DOM output", () => {
-    const IMAGE_PATH = `${baseURL}/logos/0x${parseInt(SIZE, 10)}/${name}.png`;
-    const IMAGE_PATH_RETINA = `${baseURL}/logos/0x${parseInt(SIZE, 10) * 2}/${name}.png`;
+    const IMAGE_PATH = `${baseURL}/logos/0x24/${name}.png`;
+    const IMAGE_PATH_RETINA = `${baseURL}/logos/0x48/${name}.png`;
     const dataTest = "test";
 
-    render(<ServiceLogo dataTest={dataTest} name={name} size={size} />);
+    render(<ServiceLogo dataTest={dataTest} name={name} />);
 
     expect(screen.getByRole("img")).toHaveAttribute("src", IMAGE_PATH);
     expect(screen.getByRole("img")).toHaveAttribute("srcSet", `${IMAGE_PATH_RETINA} 2x`);
@@ -25,10 +21,30 @@ describe(`ServiceLogo`, () => {
   });
 
   it("should be grayscale", () => {
-    render(<ServiceLogo name={name} size={size} grayScale />);
+    render(<ServiceLogo name={name} grayScale />);
 
-    const IMAGE_PATH = `${baseURL}/logos-grayscale/0x${parseInt(SIZE, 10)}/${name}.png`;
-    const IMAGE_PATH_RETINA = `${baseURL}/logos-grayscale/0x${parseInt(SIZE, 10) * 2}/${name}.png`;
+    const IMAGE_PATH = `${baseURL}/logos-grayscale/0x24/${name}.png`;
+    const IMAGE_PATH_RETINA = `${baseURL}/logos-grayscale/0x48/${name}.png`;
+
+    expect(screen.getByRole("img")).toHaveAttribute("src", IMAGE_PATH);
+    expect(screen.getByRole("img")).toHaveAttribute("srcSet", `${IMAGE_PATH_RETINA} 2x`);
+  });
+
+  it("should be small", () => {
+    render(<ServiceLogo name={name} size={SIZE_OPTIONS.SMALL} />);
+
+    const IMAGE_PATH = `${baseURL}/logos/0x12/${name}.png`;
+    const IMAGE_PATH_RETINA = `${baseURL}/logos/0x24/${name}.png`;
+
+    expect(screen.getByRole("img")).toHaveAttribute("src", IMAGE_PATH);
+    expect(screen.getByRole("img")).toHaveAttribute("srcSet", `${IMAGE_PATH_RETINA} 2x`);
+  });
+
+  it("should be large", () => {
+    render(<ServiceLogo name={name} size={SIZE_OPTIONS.LARGE} />);
+
+    const IMAGE_PATH = `${baseURL}/logos/0x48/${name}.png`;
+    const IMAGE_PATH_RETINA = `${baseURL}/logos/0x96/${name}.png`;
 
     expect(screen.getByRole("img")).toHaveAttribute("src", IMAGE_PATH);
     expect(screen.getByRole("img")).toHaveAttribute("srcSet", `${IMAGE_PATH_RETINA} 2x`);

--- a/packages/orbit-design-tokens/output/docs-tokens.json
+++ b/packages/orbit-design-tokens/output/docs-tokens.json
@@ -11650,7 +11650,7 @@
     },
     "javascript": {
       "name": "heightServiceLogoMedium",
-      "value": "20px"
+      "value": "24px"
     },
     "foundation": {
       "name": "heightServiceLogoMedium",
@@ -11658,7 +11658,7 @@
     },
     "scss": {
       "name": "heightServiceLogoMedium",
-      "value": "20px"
+      "value": "24px"
     }
   },
   "heightServiceLogoLarge": {

--- a/packages/orbit-design-tokens/output/tokens.css
+++ b/packages/orbit-design-tokens/output/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 03 Aug 2023 12:05:46 GMT
+ * Generated on Tue, 08 Aug 2023 07:33:23 GMT
  */
 
 :root {
@@ -507,7 +507,7 @@
   --height-stopover-arrow: 7;
   --height-country-flag: auto;
   --height-service-logo-small: 12;
-  --height-service-logo-medium: 20;
+  --height-service-logo-medium: 24;
   --height-service-logo-large: 48;
   --height-separator: 1;
   --height-input-group-separator-small: 16;

--- a/packages/orbit-design-tokens/output/tokens.less
+++ b/packages/orbit-design-tokens/output/tokens.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 03 Aug 2023 12:05:46 GMT
+// Generated on Tue, 08 Aug 2023 07:33:23 GMT
 
 @padding-alert: 16;
 @padding-alert-with-icon: 12;
@@ -505,7 +505,7 @@
 @height-stopover-arrow: 7;
 @height-country-flag: auto;
 @height-service-logo-small: 12;
-@height-service-logo-medium: 20;
+@height-service-logo-medium: 24;
 @height-service-logo-large: 48;
 @height-separator: 1;
 @height-input-group-separator-small: 16;

--- a/packages/orbit-design-tokens/output/tokens.scss
+++ b/packages/orbit-design-tokens/output/tokens.scss
@@ -512,7 +512,7 @@ $height-radio-button: 20px;
 $height-stopover-arrow: 7px;
 $height-country-flag: auto;
 $height-service-logo-small: 12px;
-$height-service-logo-medium: 20px;
+$height-service-logo-medium: 24px;
 $height-service-logo-large: 48px;
 $height-separator: 1px;
 $height-input-group-separator-small: 16px;

--- a/packages/orbit-design-tokens/output/tokens.styl
+++ b/packages/orbit-design-tokens/output/tokens.styl
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 03 Aug 2023 12:05:46 GMT
+// Generated on Tue, 08 Aug 2023 07:33:23 GMT
 
 $padding-alert= 16;
 $padding-alert-with-icon= 12;
@@ -505,7 +505,7 @@ $height-radio-button= 20;
 $height-stopover-arrow= 7;
 $height-country-flag= auto;
 $height-service-logo-small= 12;
-$height-service-logo-medium= 20;
+$height-service-logo-medium= 24;
 $height-service-logo-large= 48;
 $height-separator= 1;
 $height-input-group-separator-small= 16;

--- a/packages/orbit-design-tokens/output/tokens.xml
+++ b/packages/orbit-design-tokens/output/tokens.xml
@@ -2013,7 +2013,7 @@
   </token>
   <token>
     <name>heightServiceLogoMedium</name>
-    <value>20</value>
+    <value>24</value>
   </token>
   <token>
     <name>heightServiceLogoLarge</name>

--- a/packages/orbit-design-tokens/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/orbit-design-tokens/src/__tests__/__snapshots__/index.test.ts.snap
@@ -566,7 +566,7 @@ Object {
   "heightRadioButton": "20px",
   "heightSeparator": "1px",
   "heightServiceLogoLarge": "48px",
-  "heightServiceLogoMedium": "20px",
+  "heightServiceLogoMedium": "24px",
   "heightServiceLogoSmall": "12px",
   "heightStopoverArrow": "7px",
   "iconCriticalForeground": "#D21C1C",

--- a/packages/orbit-design-tokens/src/dictionary/definitions/component/icon/icon-size.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/component/icon/icon-size.json
@@ -154,7 +154,7 @@
         },
         "medium": {
           "type": "size",
-          "value": 20,
+          "value": 24,
           "deprecated": true,
           "deprecated-replace": "{component.icon.medium.size}",
           "deprecated-version": "6.0.0"

--- a/packages/orbit-design-tokens/src/js/createTokens.ts
+++ b/packages/orbit-design-tokens/src/js/createTokens.ts
@@ -1341,7 +1341,7 @@ const createTokens: CreateTokens = foundation => ({
   heightStopoverArrow: "7px",
   heightCountryFlag: "auto",
   heightServiceLogoSmall: "12px",
-  heightServiceLogoMedium: "20px",
+  heightServiceLogoMedium: "24px",
   heightServiceLogoLarge: "48px",
   heightSeparator: "1px",
   heightInputGroupSeparatorSmall: foundation.size.small,


### PR DESCRIPTION
The token `heightServiceLogoMedium` changed from 24px to 20px during the Styled Dictionary / Tailwind migration, unexpectedly.
The token is being used to get the src from images.kiwi and the test is only asserting that the src URL contains the correct country code, it does not assert the width, that is also part of the URL. So it silently broke.

This PR improves the test and fixes the token value.