### PR TITLE
feat: abstract away react-uid and remove it from deps

### DIFF
--- a/docs/src/__examples__/Theme/default.tsx
+++ b/docs/src/__examples__/Theme/default.tsx
@@ -25,7 +25,7 @@ export default {
     return (
       <Stack>
         <Button type="primary">Primary Button</Button>
-        <OrbitProvider theme={{ orbit: customTokens }}>
+        <OrbitProvider useId={React.useId} theme={{ orbit: customTokens }}>
           <Button type="primary">Primary Button (themed)</Button>
         </OrbitProvider>
       </Stack>

--- a/docs/src/components/__tests__/TableOfContents.test.tsx
+++ b/docs/src/components/__tests__/TableOfContents.test.tsx
@@ -31,7 +31,7 @@ afterAll(() => {
 describe(TableOfContents.name, () => {
   it("should generate table of contents from headings", async () => {
     render(
-      <OrbitProvider theme={defaultTheme}>
+      <OrbitProvider useId={React.useId} theme={defaultTheme}>
         <TableOfContentsProvider>
           <main>
             <H2>General guidelines</H2>

--- a/docs/src/documentation/02-foundation/10-typography/02-circular-pro.mdx
+++ b/docs/src/documentation/02-foundation/10-typography/02-circular-pro.mdx
@@ -38,6 +38,7 @@ It's actually not much harder, just a few more steps .
 #### 2. Change theme object
 
 ```jsx
+import React from "react"
 import getTokens from "@kiwicom/orbit-components/lib/getTokens"
 import OrbitProvider from "@kiwicom/orbit-components/lib/OrbitProvider"
 const customTokens = getTokens({
@@ -47,7 +48,7 @@ const customTokens = getTokens({
   }
 })
 
-<OrbitProvider theme={{orbit: customTokens}}>
+<OrbitProvider useId={React.useId} theme={{orbit: customTokens}}>
   <App />
 </OrbitProvider>
 ```

--- a/docs/src/documentation/05-development/03-hooks/useclickoutside.mdx
+++ b/docs/src/documentation/05-development/03-hooks/useclickoutside.mdx
@@ -1,0 +1,10 @@
+---
+title: useClickOutside
+description: How to install and use Orbit's useClickOutside hook
+redirect_from:
+  - /utilities/useClickOutside/
+---
+
+import UseClickOutsideReadMe from "@kiwicom/orbit-components/src/hooks/useClickOutside/README.md";
+
+<UseClickOutsideReadMe />

--- a/docs/src/documentation/05-development/04-migration-guides/v9.mdx
+++ b/docs/src/documentation/05-development/04-migration-guides/v9.mdx
@@ -62,3 +62,46 @@ Orbit v9 introduces a new prop on `OrbitProvider` called `useId`.
   ```
 
 One more note: the underlying implementation for how ids are generated is slightly different now. In particular, Orbit's `useRandomIdSeed` no longer relies on `react-uid`'s `useUIDSeed`.
+
+## Deprecations
+
+### ClickOutside
+
+The ClickOutside component is now deprecated and its usage should be replaced by the `useClickOutside` hook, already available in Orbit and documented [here](/utilities/useClickOutside/).
+
+**Before:**
+
+```jsx
+<ClickOutside onClickOuside={...}>
+  <div>
+    Some content
+  </div>
+</ClickOutside>
+```
+
+**Now:**
+
+```jsx
+useClickOutside(ref, ev => ...);
+
+<div ref={ref}>
+  Some content
+</div>
+```
+
+### Flow types
+
+Flow types are being deprecated in favor of TypeScript types. The Flow types definitions will be removed in a future version of Orbit.
+
+### Removed previously deprecated components
+
+The following deprecated components were removed in this version:
+
+- FormFeedback
+- InputField
+- InputFile
+- InputGroup
+- Select
+- Textarea
+
+Notice that for most of them there are already replacements available in Orbit, with the same name. The removed components were only the deprecated versions.

--- a/docs/src/documentation/05-development/04-migration-guides/v9.mdx
+++ b/docs/src/documentation/05-development/04-migration-guides/v9.mdx
@@ -1,0 +1,64 @@
+---
+title: V9
+description: How to migrate to Orbit 9.0.0
+redirect_from:
+  - /migration-guides/v9/
+---
+
+# Orbit Migration Guide v9
+
+This migration guide focuses on the process of migrating from Orbit v8.1.2 to v9.0, as some breaking changes were introduced.
+With this guide we aim to walkthrough all the breaking changes and how they can be addressed, allowing the migration to be smoother and effortless.
+
+This version of Orbit is **still** compatible with React 17 and doesn't make use of new features only available in React 18.
+
+That being said, because v9 now recommends using React 18, some changes are required to allow for this transition.
+
+## Breaking changes
+
+### `react-uid` vs React.useId
+
+React 18 introduces this new hook to generate stable random ids called `useId`, while Orbit used to rely on `react-uid` for that purpose.
+
+`react-uid` is not compatible with React 18 (especially when Strict or Concurrent modes are enabled) and as a result was removed from Orbit's dependencies.
+
+The need to generate random ids is still present, however.
+
+Orbit v9 introduces a new prop on `OrbitProvider` called `useId`.
+
+- **React 18**: if you are using React 18, please pass in `React.useId`, e.g.
+
+  ```tsx
+  import * as React from "react";
+
+  export const Root = (props: Props) => {
+    return (
+      <OrbitProvider theme={theme} useId={React.useId}>
+        {children}
+      </OrbitProvider>
+    );
+  };
+  ```
+
+- **React 17**: if you are using React 17, you will need to:
+
+  - install `react-uid` in your dependencies (`yarn add react-uid`)
+  - pass `react-uid`'s `useRandomId` export in the `useId` prop, as well as mounting two providers (`UIDReset` and `UIDFork`), like so
+
+  ```tsx
+  import { useRandomId, UIDReset, UIDFork } from "react-uid";
+
+  export const Root = (props: Props) => {
+    return (
+      <UIDReset>
+        <UIDFork>
+          <OrbitProvider theme={theme} useId={useRandomId}>
+            {children}
+          </OrbitProvider>
+        </UIDFork>
+      </UIDReset>
+    );
+  };
+  ```
+
+One more note: the underlying implementation for how ids are generated is slightly different now. In particular, Orbit's `useRandomIdSeed` no longer relies on `react-uid`'s `useUIDSeed`.

--- a/docs/src/pages/examples/{Example.id}.tsx
+++ b/docs/src/pages/examples/{Example.id}.tsx
@@ -31,7 +31,7 @@ const PureSandbox = ({ data }) => {
   const modules = getModules(scope);
 
   return (
-    <OrbitProvider theme={defaultTheme}>
+    <OrbitProvider useId={React.useId} theme={defaultTheme}>
       <LiveProvider
         code={code || example}
         scope={{ ...modules, styled, Icons, css }}

--- a/docs/src/pages/playground-full.tsx
+++ b/docs/src/pages/playground-full.tsx
@@ -28,7 +28,7 @@ const PlaygroundIframe = () => {
   const { code } = useSandbox("playground", "() => <Button>Hello world!</Button>");
 
   return (
-    <OrbitProvider theme={defaultTheme}>
+    <OrbitProvider useId={React.useId} theme={defaultTheme}>
       <Orbit>
         {orbit => {
           const { Icons, ...components } = orbit;

--- a/docs/wrapWithProviders.tsx
+++ b/docs/wrapWithProviders.tsx
@@ -8,7 +8,7 @@ import { KeyboardContextProvider } from "./src/services/KeyboardProvider";
 
 export const wrapWithProviders = ({ element }) => {
   return (
-    <OrbitProvider theme={theme}>
+    <OrbitProvider useId={React.useId} theme={theme}>
       <KeyboardContextProvider>
         <DevModeProvider>
           <TableOfContentsProvider>{element}</TableOfContentsProvider>

--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -80,8 +80,7 @@
     "@popperjs/core": "^2.9.2",
     "clsx": "^2.0.0",
     "react-hot-toast": "^2.4.0",
-    "react-popper": "^2.3.0",
-    "react-uid": "^2.3.2"
+    "react-popper": "^2.3.0"
   },
   "devDependencies": {
     "@babel/helper-get-function-arity": "^7.16.7",

--- a/packages/orbit-components/src/OrbitProvider/RandomId/Provider.tsx
+++ b/packages/orbit-components/src/OrbitProvider/RandomId/Provider.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+const RandomIdContext = React.createContext<() => string>(() => {
+  throw new Error(
+    "Orbit RandomIdProvider: useId is undefined; please provide React.useId or `react-uid`'s useUID.",
+  );
+});
+
+const RandomIdProvider = ({
+  children,
+  useId,
+}: {
+  children: React.ReactNode;
+  useId: () => string;
+}) => {
+  return <RandomIdContext.Provider value={useId}>{children}</RandomIdContext.Provider>;
+};
+
+export const useRandomId = () => React.useContext(RandomIdContext);
+
+export default RandomIdProvider;

--- a/packages/orbit-components/src/OrbitProvider/ThemeProvider.stories.tsx
+++ b/packages/orbit-components/src/OrbitProvider/ThemeProvider.stories.tsx
@@ -26,7 +26,10 @@ export function OwnTheme() {
   });
   const customTheme = object("customTheme", { black: "#000" });
   return (
-    <OrbitProvider theme={{ orbit: { ...getTokens(orbitTheme), ...customTheme } }}>
+    <OrbitProvider
+      theme={{ orbit: { ...getTokens(orbitTheme), ...customTheme } }}
+      useId={React.useId}
+    >
       <Button onClick={action("onClick")}>Hello World!</Button>
     </OrbitProvider>
   );

--- a/packages/orbit-components/src/OrbitProvider/index.tsx
+++ b/packages/orbit-components/src/OrbitProvider/index.tsx
@@ -2,20 +2,32 @@
 
 import * as React from "react";
 import { ThemeProvider as StyledThemeProvider } from "styled-components";
-import { UIDReset, UIDFork } from "react-uid";
 
 import QueryContextProvider from "./QueryContext/Provider";
+import RandomIdProvider from "./RandomId/Provider";
 import type { Props } from "./types";
 
-const OrbitProvider = ({ theme, children }: Props) => {
-  return (
+/**
+ *
+ * Use OrbitProvider with useId prop as follows to still use `react-uid`:
+ * ```jsx
     <UIDReset>
       <UIDFork>
-        <StyledThemeProvider theme={theme}>
-          <QueryContextProvider>{React.Children.only(children)}</QueryContextProvider>
-        </StyledThemeProvider>
+        <OrbitProvider theme={theme} useId={useUID}>
+          {children}
+        </OrbitProvider>
       </UIDFork>
     </UIDReset>
+ * ```
+ *
+ */
+const OrbitProvider = ({ theme, children, useId }: Props) => {
+  return (
+    <RandomIdProvider useId={useId}>
+      <StyledThemeProvider theme={theme}>
+        <QueryContextProvider>{React.Children.only(children)}</QueryContextProvider>
+      </StyledThemeProvider>
+    </RandomIdProvider>
   );
 };
 

--- a/packages/orbit-components/src/OrbitProvider/types.d.ts
+++ b/packages/orbit-components/src/OrbitProvider/types.d.ts
@@ -8,4 +8,5 @@ import type { Theme } from "../defaultTheme";
 export interface Props {
   readonly theme: Theme;
   readonly children: React.ReactNode;
+  readonly useId: () => string;
 }

--- a/packages/orbit-components/src/hooks/useClickOutside/README.md
+++ b/packages/orbit-components/src/hooks/useClickOutside/README.md
@@ -1,0 +1,26 @@
+# useClickOutside
+
+The `useClickOutside` executes a certain action whenever there is a click outside of a given component.
+
+To implement the `useClickOutside` hook in your component, add the import:
+
+```jsx
+import useClickOutside from "@kiwicom/orbit-components/lib/hooks/useClickOutside";
+```
+
+Then you can use it in your functional component:
+
+```tsx
+const App = () => {
+  const elementRef = React.useRef<HTMLDivElement | null>(null);
+  const handleClickOutside = ev => console.log(`The following event was detected: ${ev}`);
+
+  useClickOutside(elementRef, handleClickOutside);
+
+  return (
+    <div ref={elementRef}>
+      <span>Any click outside the parent div will trigger a log of the event.</span>
+    </div>
+  );
+};
+```

--- a/packages/orbit-components/src/hooks/useLockScrolling/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/hooks/useLockScrolling/__tests__/index.test.tsx
@@ -94,7 +94,7 @@ describe("useLockScrolling", () => {
     expect(document.body).toHaveStyle({ overflow: "hidden" });
 
     rerender(
-      <OrbitProvider theme={{ ...defaultTheme, lockScrolling: false }}>
+      <OrbitProvider theme={{ ...defaultTheme, lockScrolling: false }} useId={React.useId}>
         <>
           <LockFoo>
             <LockBar lock={false} />
@@ -107,7 +107,10 @@ describe("useLockScrolling", () => {
     expect(document.body).not.toHaveStyle({ overflow: "hidden" });
 
     rerender(
-      <OrbitProvider theme={{ ...defaultTheme, lockScrolling: true, lockScrollingBarGap: true }}>
+      <OrbitProvider
+        theme={{ ...defaultTheme, lockScrolling: true, lockScrollingBarGap: true }}
+        useId={React.useId}
+      >
         <LockBaz switchRefs />
       </OrbitProvider>,
     );

--- a/packages/orbit-components/src/hooks/useMediaQuery/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/hooks/useMediaQuery/__tests__/index.test.tsx
@@ -39,7 +39,7 @@ describe("useMediaQuery", () => {
 
     function App() {
       return (
-        <OrbitProvider theme={theme}>
+        <OrbitProvider theme={theme} useId={React.useId}>
           <MediaQuery
             onChange={query => {
               result = query;
@@ -117,6 +117,7 @@ describe("useMediaQuery", () => {
             widthBreakpointMediumMobile,
           },
         }}
+        useId={React.useId}
       >
         <MediaQuery
           onChange={query => {
@@ -176,7 +177,7 @@ describe("useMediaQuery", () => {
       const matchMedia = new MatchMediaMock();
 
       const { rerender } = render(
-        <OrbitProvider theme={theme}>
+        <OrbitProvider theme={theme} useId={React.useId}>
           <UpdateCounter />
         </OrbitProvider>,
       );
@@ -185,7 +186,7 @@ describe("useMediaQuery", () => {
 
       rerender(
         // change theme object reference to trigger re-render
-        <OrbitProvider theme={{ ...theme }}>
+        <OrbitProvider theme={{ ...theme }} useId={React.useId}>
           <UpdateCounter />
         </OrbitProvider>,
       );
@@ -198,7 +199,7 @@ describe("useMediaQuery", () => {
       });
 
       rerender(
-        <OrbitProvider theme={{ ...theme }}>
+        <OrbitProvider theme={{ ...theme }} useId={React.useId}>
           <UpdateCounter />
         </OrbitProvider>,
       );
@@ -215,6 +216,7 @@ describe("useMediaQuery", () => {
               widthBreakpointMediumMobile: theme.orbit.widthBreakpointMediumMobile + 1,
             },
           }}
+          useId={React.useId}
         >
           <UpdateCounter />
         </OrbitProvider>,

--- a/packages/orbit-components/src/hooks/useRandomId/README.md
+++ b/packages/orbit-components/src/hooks/useRandomId/README.md
@@ -1,5 +1,6 @@
 #useRandomId
 
+**If you are using version 18 (or above) of React, you should use the native React.useId hook instead of this one.**
 The `useRandomId` generates unique random id.
 
 In order to use the hook, you can simply import it like:

--- a/packages/orbit-components/src/hooks/useRandomId/README.md
+++ b/packages/orbit-components/src/hooks/useRandomId/README.md
@@ -1,4 +1,4 @@
-#useRandomId
+# useRandomId
 
 **If you are using version 18 (or above) of React, you should use the native React.useId hook instead of this one.**
 The `useRandomId` generates unique random id.

--- a/packages/orbit-components/src/hooks/useRandomId/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/hooks/useRandomId/__tests__/index.test.tsx
@@ -32,7 +32,7 @@ describe("useRandomId", () => {
     const container = document.createElement("div");
 
     container.innerHTML = renderToString(
-      <OrbitProvider theme={{ ...theme }}>
+      <OrbitProvider theme={{ ...theme }} useId={React.useId}>
         <Component />
       </OrbitProvider>,
     );
@@ -40,7 +40,7 @@ describe("useRandomId", () => {
     document.body?.appendChild(container);
 
     const { container: clientContainer } = render(
-      <OrbitProvider theme={{ ...theme }}>
+      <OrbitProvider theme={{ ...theme }} useId={React.useId}>
         <Component />
       </OrbitProvider>,
       { container, hydrate: true },

--- a/packages/orbit-components/src/hooks/useRandomId/index.ts
+++ b/packages/orbit-components/src/hooks/useRandomId/index.ts
@@ -1,14 +1,17 @@
-import { useUIDSeed, useUID } from "react-uid";
+import { useRandomId as useRandomIdContext } from "../../OrbitProvider/RandomId/Provider";
 
 type UseRandomIdSeed = () => (id: string) => string;
 type UseRandomId = () => string;
 
-export const useRandomIdSeed: UseRandomIdSeed = () => {
-  return useUIDSeed();
+export const useRandomId: UseRandomId = () => {
+  const useId = useRandomIdContext();
+  return useId();
 };
 
-const useRandomId: UseRandomId = () => {
-  return useUID();
+export const useRandomIdSeed: UseRandomIdSeed = () => {
+  const useId = useRandomIdContext();
+  const prefix = useId();
+  return (seed: string) => `${prefix}-${seed}`;
 };
 
 export default useRandomId;

--- a/packages/orbit-components/src/utils/rtl/RenderInRtl.tsx
+++ b/packages/orbit-components/src/utils/rtl/RenderInRtl.tsx
@@ -8,8 +8,6 @@ interface Props {
 }
 
 class RenderInRtl extends React.PureComponent<Props> {
-  html: null | HTMLHtmlElement = document.querySelector("html");
-
   componentDidMount() {
     if (this.html) {
       this.html.setAttribute("dir", "rtl");
@@ -22,9 +20,11 @@ class RenderInRtl extends React.PureComponent<Props> {
     }
   }
 
+  html: null | HTMLHtmlElement = document.querySelector("html");
+
   render() {
     return (
-      <OrbitProvider theme={{ orbit: defaultTokens, rtl: true }}>
+      <OrbitProvider theme={{ orbit: defaultTokens, rtl: true }} useId={React.useId}>
         {this.props.children}
       </OrbitProvider>
     );

--- a/packages/orbit-themer/src/App.tsx
+++ b/packages/orbit-themer/src/App.tsx
@@ -56,6 +56,7 @@ const App = () => {
       <ColorContext.Provider value={value}>
         <>
           <OrbitProvider
+            useId={React.useId}
             theme={{
               orbit: getTokens({
                 fontFamily: {
@@ -67,6 +68,7 @@ const App = () => {
             <Tabs />
           </OrbitProvider>
           <OrbitProvider
+            useId={React.useId}
             theme={{
               orbit: getTokens({
                 palette: colors,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2774,20 +2774,6 @@
   resolved "https://registry.npmjs.org/@kiwicom/browserslist-config/-/browserslist-config-4.0.0.tgz"
   integrity sha512-CkBXOf5noNBSh8nOQl6/qMBEz1GwYQpIxDTyImqJDwSiXgY/lWHgW9TQT8n9akhFMd4uB9tAFsWFPk8EhzogfA==
 
-"@kiwicom/orbit-design-tokens@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@kiwicom/orbit-design-tokens/-/orbit-design-tokens-5.0.0.tgz#b1677adbf2436544664bc966c781e33134a61880"
-  integrity sha512-jWA00BJpHMEV+RmcClrLWoBOaPN0fu+UwIeUYSP8ktL50hIQyBXzhOPNCwSW5Plf96A/VTPla2Pnebe4l/6byw==
-  dependencies:
-    color2k "^2.0.2"
-
-"@kiwicom/orbit-tailwind-preset@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@kiwicom/orbit-tailwind-preset/-/orbit-tailwind-preset-1.0.0.tgz#d10c41460eafc84b5eb691853223b0cd5ee01141"
-  integrity sha512-hBBHV3uxsHTvaueXEMQqoEjSYfcegaBhquOZ1vjmjoFfIJdla3Lh8InZO0DqMwWrSsI9VvD0sH7jAjUsvCDpzw==
-  dependencies:
-    "@kiwicom/orbit-design-tokens" "^5.0.0"
-
 "@lerna/add@5.2.0":
   version "5.2.0"
   resolved "https://registry.npmjs.org/@lerna/add/-/add-5.2.0.tgz"
@@ -22531,13 +22517,6 @@ react-transition-group@^4.3.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-
-react-uid@^2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/react-uid/-/react-uid-2.3.3.tgz"
-  integrity sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==
-  dependencies:
-    tslib "^2.0.0"
 
 react-window@^1.8.6:
   version "1.8.9"


### PR DESCRIPTION
This is to allow for React 17/18 compatibility, with additional steps required for React 17 compat.

BREAKING CHANGE: Message to be amended

---

This is a proposal to use dependency injection and allow for React 17 compat while updating Orbit to React 18 primitives like useId.

 Storybook: https://orbit-mainframev-rcsl-abstract-react-uid.surge.sh