### PR TITLE
V9 migration guide + useClickOutside docs

### DIFF
--- a/docs/src/documentation/05-development/03-hooks/useclickoutside.mdx
+++ b/docs/src/documentation/05-development/03-hooks/useclickoutside.mdx
@@ -1,0 +1,10 @@
+---
+title: useClickOutside
+description: How to install and use Orbit's useClickOutside hook
+redirect_from:
+  - /utilities/useClickOutside/
+---
+
+import UseClickOutsideReadMe from "@kiwicom/orbit-components/src/hooks/useClickOutside/README.md";
+
+<UseClickOutsideReadMe />

--- a/docs/src/documentation/05-development/04-migration-guides/v9.mdx
+++ b/docs/src/documentation/05-development/04-migration-guides/v9.mdx
@@ -62,3 +62,46 @@ Orbit v9 introduces a new prop on `OrbitProvider` called `useId`.
   ```
 
 One more note: the underlying implementation for how ids are generated is slightly different now. In particular, Orbit's `useRandomIdSeed` no longer relies on `react-uid`'s `useUIDSeed`.
+
+## Deprecations
+
+### ClickOutside
+
+The ClickOutside component is now deprecated and its usage should be replaced by the `useClickOutside` hook, already available in Orbit and documented [here](/utilities/useClickOutside/).
+
+**Before:**
+
+```jsx
+<ClickOutside onClickOuside={...}>
+  <div>
+    Some content
+  </div>
+</ClickOutside>
+```
+
+**Now:**
+
+```jsx
+useClickOutside(ref, ev => ...);
+
+<div ref={ref}>
+  Some content
+</div>
+```
+
+### Flow types
+
+Flow types are being deprecated in favor of TypeScript types. The Flow types definitions will be removed in a future version of Orbit.
+
+### Removed previously deprecated components
+
+The following deprecated components were removed in this version:
+
+- FormFeedback
+- InputField
+- InputFile
+- InputGroup
+- Select
+- Textarea
+
+Notice that for most of them there are already replacements available in Orbit, with the same name. The removed components were only the deprecated versions.

--- a/packages/orbit-components/src/hooks/useClickOutside/README.md
+++ b/packages/orbit-components/src/hooks/useClickOutside/README.md
@@ -1,0 +1,26 @@
+# useClickOutside
+
+The `useClickOutside` executes a certain action whenever there is a click outside of a given component.
+
+To implement the `useClickOutside` hook in your component, add the import:
+
+```jsx
+import useClickOutside from "@kiwicom/orbit-components/lib/hooks/useClickOutside";
+```
+
+Then you can use it in your functional component:
+
+```tsx
+const App = () => {
+  const elementRef = React.useRef<HTMLDivElement | null>(null);
+  const handleClickOutside = ev => console.log(`The following event was detected: ${ev}`);
+
+  useClickOutside(elementRef, handleClickOutside);
+
+  return (
+    <div ref={elementRef}>
+      <span>Any click outside the parent div will trigger a log of the event.</span>
+    </div>
+  );
+};
+```

--- a/packages/orbit-components/src/hooks/useRandomId/README.md
+++ b/packages/orbit-components/src/hooks/useRandomId/README.md
@@ -1,4 +1,4 @@
-#useRandomId
+# useRandomId
 
 The `useRandomId` generates unique random id.
 


### PR DESCRIPTION
Adds documentation for `useClickOutside` hook and completes the v9 migration guide.

This PR is opened against the branch that started the v9 migration guide. Base branch will change after #3950 is merged.
 Storybook: https://orbit-mainframev-v9-migration-guide.surge.sh