### PR TITLE
docs: adjust tailwind classnames tooltip text

### DIFF
--- a/docs/src/components/DesignTokensList/components/DesignTokenName.tsx
+++ b/docs/src/components/DesignTokensList/components/DesignTokenName.tsx
@@ -3,10 +3,10 @@ import { Tooltip } from "@kiwicom/orbit-components";
 
 import useCopyToClipboard from "../../../hooks/useCopyToClipboard";
 
-const DesignTokenName = ({ children }) => {
+const DesignTokenName = ({ children, tooltipText = "Click to copy the name of the token." }) => {
   const [isCopied, copy] = useCopyToClipboard(1000);
   return (
-    <Tooltip content="Click to copy the name of the token." placement="top">
+    <Tooltip content={tooltipText} placement="top">
       <button onClick={() => copy(children)} type="button">
         {isCopied ? "Copied!" : children}
       </button>

--- a/docs/src/components/TailwindClassnames/index.tsx
+++ b/docs/src/components/TailwindClassnames/index.tsx
@@ -13,9 +13,7 @@ import {
 import styled from "styled-components";
 import { merge, upperFirst, transform, omit } from "lodash";
 
-import DesignTokenName from "../DesignTokensList/components/DesignTokenName";
-import DesignTokenValue from "../DesignTokensList/components/DesignTokenValue";
-import DesignTokenIcon from "../DesignTokensList/components/DesignTokenIcon";
+import { DesignTokenName, DesignTokenValue, DesignTokenIcon } from "../DesignTokensList";
 
 const StyledTableWrapper = styled.div`
   table {
@@ -119,7 +117,7 @@ const TailwindClassnames = () => {
                       <TableCell>
                         <Stack flex align="center">
                           <DesignTokenIcon value={String(value)} type={getCategory(group)} />
-                          <DesignTokenName>
+                          <DesignTokenName tooltipText="Click to copy the classname.">
                             {["Screens", "Spacing"].includes(group)
                               ? name
                               : `${tailwindPrefixes[group]}-${name}`}


### PR DESCRIPTION
Small 💅 the tailwind classnames list was mistakenly mentioning tokens, instead of classnames. This PR fixes that.

![image](https://github.com/kiwicom/orbit/assets/6265045/f3ecc6b8-ed49-4dcd-a4fd-eaec66e0c1ac)

 
 Storybook: https://orbit-mainframev-docs-fix-tw-classnames-tooltip-text.surge.sh