### PR TITLE
Fix Tailwind config and OrbitProvider children

### DIFF
--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -15,7 +15,7 @@
     "cy:run": "start-server-and-test cy:dev http-get://localhost:3000 'cypress run'",
     "cy:open": "start-server-and-test cy:dev http-get://localhost:3000 'cypress open'",
     "build": "ts-node --esm config/build/index.mts",
-    "tailwind": "npx tailwindcss -i ./src/tailwind.css -o ./lib/tailwind.css",
+    "tailwind": "cross-env NODE_ENV=test npx tailwindcss -i ./src/tailwind.css -o ./lib/tailwind.css",
     "prepublishOnly": "yarn build",
     "size:build": "yarn build --size",
     "size": "size-limit",

--- a/packages/orbit-components/src/OrbitProvider/index.tsx
+++ b/packages/orbit-components/src/OrbitProvider/index.tsx
@@ -25,7 +25,7 @@ const OrbitProvider = ({ theme, children, useId }: Props) => {
   return (
     <RandomIdProvider useId={useId}>
       <StyledThemeProvider theme={theme}>
-        <QueryContextProvider>{React.Children.only(children)}</QueryContextProvider>
+        <QueryContextProvider>{children}</QueryContextProvider>
       </StyledThemeProvider>
     </RandomIdProvider>
   );

--- a/packages/orbit-components/tailwind.config.ts
+++ b/packages/orbit-components/tailwind.config.ts
@@ -6,7 +6,7 @@ export default {
   content: ["./src/**/*.{ts,tsx}"],
   presets: [
     orbitPreset({
-      disabledPreflight: false,
+      disablePreflight: false,
     }),
   ],
 } satisfies Config;

--- a/packages/orbit-components/tailwind.config.ts
+++ b/packages/orbit-components/tailwind.config.ts
@@ -6,7 +6,7 @@ export default {
   content: ["./src/**/*.{ts,tsx}"],
   presets: [
     orbitPreset({
-      disablePreflight: false,
+      disablePreflight: process.env.NODE_ENV === "test",
     }),
   ],
 } satisfies Config;


### PR DESCRIPTION
This PR addresses three things:
- The typo in the tailwind.config.ts inside `orbit-components`
- ~The brokens examples caused by #3979 because OrbitProvider expects a single child~ This was replaced by allowing OrbitProvider to receive multiple children
- The tailwind config does not include pre-flight for testing 

With this, there are possible future work:
- Type checks should run for the tailwind.config files as well
- ~The type of prop `children` on `OrbitProvider` should ensure it only gets a single child.~
 Storybook: https://orbit-mainframev-fix-tw-config-and-docs.surge.sh