### PR TITLE
fix(Text): default value for align is now start

### DIFF
--- a/packages/orbit-components/src/Text/Text.stories.tsx
+++ b/packages/orbit-components/src/Text/Text.stories.tsx
@@ -139,11 +139,15 @@ Playground.story = {
   },
 };
 
-export const Rtl = () => (
-  <RenderInRtl>
-    <Text align="left">Lorem ipsum dolor sit amet</Text>
-  </RenderInRtl>
-);
+export const Rtl = () => {
+  const align = select("Align", Object.values(ALIGN_OPTIONS), ALIGN_OPTIONS.START);
+
+  return (
+    <RenderInRtl>
+      <Text align={align}>Lorem ipsum dolor sit amet</Text>
+    </RenderInRtl>
+  );
+};
 
 Rtl.story = {
   name: "RTL",

--- a/packages/orbit-components/src/Text/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Text/__tests__/index.test.tsx
@@ -61,7 +61,7 @@ describe("Text", () => {
       "font-family": theme.orbit.fontFamily,
       "font-size": theme.orbit.fontSizeTextNormal,
       "line-height": theme.orbit.lineHeightTextNormal,
-      "text-align": "left",
+      "text-align": "start",
     });
   });
 

--- a/packages/orbit-components/src/Text/index.tsx
+++ b/packages/orbit-components/src/Text/index.tsx
@@ -26,7 +26,7 @@ const Text = ({
   type = TYPE_OPTIONS.PRIMARY,
   size = SIZE_OPTIONS.NORMAL,
   weight = WEIGHT_OPTIONS.NORMAL,
-  align = ALIGN_OPTIONS.LEFT,
+  align = ALIGN_OPTIONS.START,
   margin,
   as: Component = ELEMENT_OPTIONS.P,
   uppercase,


### PR DESCRIPTION
With Tailwind, default value can't be `left`, but should be `start`, so that it is correctly aligned in RTL.
 Storybook: https://orbit-mainframev-fix-text-alignment-default.surge.sh