### PR TITLE
fix(Wizard): title now renders correctly even without labelProgress

### DIFF
--- a/packages/orbit-components/src/Wizard/index.tsx
+++ b/packages/orbit-components/src/Wizard/index.tsx
@@ -99,7 +99,7 @@ const Wizard = ({
           }}
         >
           <Stack as="span" inline>
-            <b>{labelProgress}</b>
+            {typeof labelProgress !== "undefined" && <b>{labelProgress}</b>}
             <span
               css={css`
                 font-weight: normal;


### PR DESCRIPTION
If `labelProgress` is not defined, the `<b>` spacing was still being rendered, causing the title to be misaligned.

Before:
<img width="306" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/89dd6395-559c-452b-a46e-7731e1b4c12e">

After:
<img width="306" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/c944ff80-58dc-4b1a-8dd9-e2a0f01ec1ea">

 Storybook: https://orbit-mainframev-fix-wizard-label-render.surge.sh