### PR TITLE
chore: fix test timeout

### DIFF
--- a/packages/orbit-components/src/Drawer/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Drawer/__tests__/index.test.tsx
@@ -7,7 +7,7 @@ import Drawer from "..";
 jest.useFakeTimers();
 
 describe("Drawer", () => {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
 
   it("should have expected DOM output", () => {
     render(

--- a/packages/orbit-components/src/Wizard/__tests__/compact.test.tsx
+++ b/packages/orbit-components/src/Wizard/__tests__/compact.test.tsx
@@ -7,7 +7,7 @@ import Wizard, { WizardStep } from "..";
 jest.mock("../../hooks/useMediaQuery", () => () => ({ isLargeMobile: false }));
 
 describe("Wizard", () => {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
 
   describe("compact", () => {
     it("shows the current position", () => {
@@ -97,7 +97,7 @@ describe("Wizard", () => {
         </Wizard>,
       );
       await act(() => user.click(screen.getByRole("button")));
-      await act(() => user.click(screen.getByRole("button", { name: "Close" })));
+      await act(() => user.click(screen.getByText("Close")));
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
This commit was originally in #3942 because it was thought to be cause by loading Tailwind CSS into the test environment. However, the latest pipeline run failed because of the same problem, so we are including it in master now.
 Storybook: https://orbit-mainframev-fix-test-timeout.surge.sh