### PR TITLE
docs: use correct hook in react@17 example

### DIFF
--- a/docs/src/documentation/05-development/04-migration-guides/v9.mdx
+++ b/docs/src/documentation/05-development/04-migration-guides/v9.mdx
@@ -43,16 +43,16 @@ Orbit v9 introduces a new prop on `OrbitProvider` called `useId`.
 - **React 17**: if you are using React 17, you will need to:
 
   - install `react-uid` in your dependencies (`yarn add react-uid`)
-  - pass `react-uid`'s `useRandomId` export in the `useId` prop, as well as mounting two providers (`UIDReset` and `UIDFork`), like so
+  - pass `react-uid`'s `useUID` export in the `useId` prop, as well as mounting two providers (`UIDReset` and `UIDFork`), like so
 
   ```tsx
-  import { useRandomId, UIDReset, UIDFork } from "react-uid";
+  import { useUID, UIDReset, UIDFork } from "react-uid";
 
   export const Root = (props: Props) => {
     return (
       <UIDReset>
         <UIDFork>
-          <OrbitProvider theme={theme} useId={useRandomId}>
+          <OrbitProvider theme={theme} useId={useUID}>
             {children}
           </OrbitProvider>
         </UIDFork>


### PR DESCRIPTION
This Pull Request aims to fix the migration guide for orbit-components@v9.
In the current docs, it's suggested to use `useRandomId` but this hook is not part of `react-uid` package.

While in the component description, it is correctly stated to use `useUID` instead. 
https://github.com/kiwicom/orbit/blob/015f84a9a74f0b5f05de30f4b747158d1126b249/packages/orbit-components/src/OrbitProvider/index.tsx#L12-L21


# This Pull Request meets the following criteria:

- [ ] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components has both `.flow` and `d.ts` files and are exported in `index.js.flow` and `index.d.ts`
