### PR TITLE
docs: fix Stack story default alignment

### DIFF
--- a/packages/orbit-components/src/Stack/Stack.stories.tsx
+++ b/packages/orbit-components/src/Stack/Stack.stories.tsx
@@ -105,7 +105,7 @@ export const MediumMobileProperties = () => {
   const grow = boolean("Grow", true);
   const shrink = boolean("Shrink", false);
   const basis = text("Basis", "auto");
-  const align = select("Align", Object.values(ALIGNS), undefined);
+  const align = select("Align", Object.values(ALIGNS), ALIGNS.END);
   const justify = select("Justify", Object.values(JUSTIFY), undefined);
   const spacing = select("Spacing", Object.values(SPACINGS), undefined);
   const spaceAfter = select("spaceAfter", Object.values(SPACINGS_AFTER), undefined);
@@ -146,7 +146,7 @@ export const LargeMobileProperties = () => {
   const grow = boolean("Grow", true);
   const shrink = boolean("Shrink", false);
   const basis = text("Basis", "auto");
-  const align = select("Align", Object.values(ALIGNS), undefined);
+  const align = select("Align", Object.values(ALIGNS), ALIGNS.END);
   const justify = select("Justify", Object.values(JUSTIFY), undefined);
   const spacing = select("Spacing", Object.values(SPACINGS), undefined);
   const spaceAfter = select("spaceAfter", Object.values(SPACINGS_AFTER), undefined);
@@ -187,7 +187,7 @@ export const TabletProperties = () => {
   const grow = boolean("Grow", true);
   const shrink = boolean("Shrink", false);
   const basis = text("Basis", "auto");
-  const align = select("Align", Object.values(ALIGNS), undefined);
+  const align = select("Align", Object.values(ALIGNS), ALIGNS.END);
   const justify = select("Justify", Object.values(JUSTIFY), undefined);
   const spacing = select("Spacing", Object.values(SPACINGS), undefined);
   const spaceAfter = select("spaceAfter", Object.values(SPACINGS_AFTER), undefined);
@@ -202,6 +202,7 @@ export const TabletProperties = () => {
     align,
     justify,
     spacing,
+    spaceAfter,
   };
 
   return (
@@ -227,7 +228,7 @@ export const DesktopProperties = () => {
   const grow = boolean("Grow", true);
   const shrink = boolean("Shrink", false);
   const basis = text("Basis", "auto");
-  const align = select("Align", Object.values(ALIGNS), undefined);
+  const align = select("Align", Object.values(ALIGNS), ALIGNS.END);
   const justify = select("Justify", Object.values(JUSTIFY), undefined);
   const spacing = select("Spacing", Object.values(SPACINGS), undefined);
   const spaceAfter = select("spaceAfter", Object.values(SPACINGS_AFTER), undefined);
@@ -268,7 +269,7 @@ export const LargeDesktopProperties = () => {
   const grow = boolean("Grow", true);
   const shrink = boolean("Shrink", false);
   const basis = text("Basis", "auto");
-  const align = select("Align", Object.values(ALIGNS), undefined);
+  const align = select("Align", Object.values(ALIGNS), ALIGNS.END);
   const justify = select("Justify", Object.values(JUSTIFY), undefined);
   const spacing = select("Spacing", Object.values(SPACINGS), undefined);
   const spaceAfter = select("spaceAfter", Object.values(SPACINGS_AFTER), undefined);


### PR DESCRIPTION
While reviewing some Stack code, I noticed that our docs look… odd. This fixes the alignment in our stories.

**Before:**
<img width="380" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/968b63dc-41c4-45fe-a2c8-9fc0f8065247">

**Now:**
<img width="380" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/0bd83ff7-4cbc-4804-af21-4c59ab637cd6">

 Storybook: https://orbit-mainframev-docs-fix-stack-story-align.surge.sh