### PR TITLE
Adjust TextLink + Alert styles

### DIFF
--- a/packages/orbit-components/src/Alert/Alert.stories.tsx
+++ b/packages/orbit-components/src/Alert/Alert.stories.tsx
@@ -13,6 +13,7 @@ import Text from "../Text";
 import Stack from "../Stack";
 import Heading from "../Heading";
 import CountryFlag from "../CountryFlag";
+import TextLink from "../TextLink";
 
 import Alert, { AlertButton } from ".";
 
@@ -155,6 +156,26 @@ export const InlineActions = () => {
 };
 
 InlineActions.story = {
+  parameters: {
+    info: "You can try all possible configurations of this component. However, check Orbit.Kiwi for more detailed design guidelines.",
+  },
+};
+
+export const WithTextLink = () => {
+  const type = select("Type", Object.values(TYPE_OPTIONS), "info");
+
+  return (
+    <Alert type={type}>
+      <p>
+        <TextLink type="primary">This is</TextLink> a primary textlink.
+        <br />
+        <TextLink type="secondary">This is</TextLink> a secondary textlink.
+      </p>
+    </Alert>
+  );
+};
+
+WithTextLink.story = {
   parameters: {
     info: "You can try all possible configurations of this component. However, check Orbit.Kiwi for more detailed design guidelines.",
   },

--- a/packages/orbit-components/src/Alert/index.tsx
+++ b/packages/orbit-components/src/Alert/index.tsx
@@ -204,15 +204,19 @@ StyledTitle.defaultProps = {
 };
 
 const StyledContent = styled.div<{ inlineActions?: boolean; $type: Type; $noUnderline: boolean }>`
-  ${({ inlineActions, theme }) => css`
+  ${({ inlineActions, theme, $type }) => css`
     display: flex;
     align-items: center;
     min-height: 20px;
     width: ${!inlineActions && "100%"};
 
     & a:not([class]),
-    & .orbit-text-link {
-      ${getLinkStyle};
+    & .orbit-text-link:not(.orbit-text-link--secondary) {
+      ${getLinkStyle({ theme, $type, includeBase: true })};
+    }
+
+    & .orbit-text-link.orbit-text-link--secondary {
+      ${getLinkStyle({ theme, $type, includeBase: false })};
     }
 
     & .orbit-list-item,

--- a/packages/orbit-components/src/TextLink/deprecated/index.ts
+++ b/packages/orbit-components/src/TextLink/deprecated/index.ts
@@ -82,24 +82,37 @@ const resolveUnderline = ({
 /**
  * @deprecated kept until Alert is refactored to TW
  */
-export const getLinkStyle = ({ theme, $type }: { theme: Theme; $type: Props["type"] }) => css`
-  &,
-  &:link,
-  &:visited {
-    color: ${getColor} ${$type === TYPE_OPTIONS.SECONDARY && `!important`};
-    text-decoration: ${resolveUnderline} ${$type === TYPE_OPTIONS.SECONDARY && `!important`};
-    font-weight: ${theme.orbit.fontWeightLinks} ${$type === TYPE_OPTIONS.SECONDARY && `!important`};
-  }
+export const getLinkStyle = ({
+  theme,
+  $type,
+  includeBase = true,
+}: {
+  theme: Theme;
+  $type: Props["type"];
+  includeBase?: boolean;
+}) => {
+  const baseStyles = css`
+    &,
+    &:link,
+    &:visited {
+      color: ${getColor} ${$type === TYPE_OPTIONS.SECONDARY && `!important`};
+      text-decoration: ${resolveUnderline} ${$type === TYPE_OPTIONS.SECONDARY && `!important`};
+      font-weight: ${theme.orbit.fontWeightLinks}
+        ${$type === TYPE_OPTIONS.SECONDARY && `!important`};
+    }
+  `;
+  return css`
+    ${includeBase && baseStyles};
+    &:hover {
+      outline: none;
+      text-decoration: none;
+      color: ${getHoverColor};
+    }
 
-  &:hover {
-    outline: none;
-    text-decoration: none;
-    color: ${getHoverColor};
-  }
-
-  &:active {
-    outline: none;
-    text-decoration: none;
-    color: ${getActiveColor};
-  }
-`;
+    &:active {
+      outline: none;
+      text-decoration: none;
+      color: ${getActiveColor};
+    }
+  `;
+};

--- a/packages/orbit-components/src/TextLink/index.tsx
+++ b/packages/orbit-components/src/TextLink/index.tsx
@@ -70,6 +70,7 @@ const TextLink = ({
       download={download}
       className={cx(
         "orbit-text-link font-base duration-fast inline-flex cursor-pointer items-center font-medium transition-colors delay-0 ease-in-out hover:no-underline hover:outline-none active:no-underline active:outline-none",
+        type === "secondary" && "orbit-text-link--secondary",
         standAlone && "h-button-normal",
         typeClasses[type],
         size != null && sizeClasses[size],


### PR DESCRIPTION
A TextLink inside an Alert should have different styles, based on its own type and also the Alert's type. With TW migration that logic was lost. This gets it back.
 Storybook: https://orbit-mainframev-adjust-textlink-alert-styles.surge.sh