### PR TITLE
ci: add build step to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,15 @@ jobs:
           git config user.name "mainframev"
           git config user.email "vgenaev@gmail.com"
 
+      - name: Build
+        run: |
+          # we need to build packages in the right order
+          # lerna won't run build due to --ignore-prepublish flag
+          yarn tokens build
+          yarn tailwind-preset build
+          yarn components build
+          yarn workspace @kiwicom/eslint-plugin-orbit-components build
+
       - name: Dry run
         if: ${{ github.event.inputs.dryrun == 'true' }}
         run: |
@@ -46,7 +55,7 @@ jobs:
           echo "access=public" >> ~/.npmrc
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
           echo "//registry.npmjs.org/:always-auth=true" >> ~/.npmrc
-          yarn lerna publish --no-private --conventional-commits --create-release github --yes
+          yarn lerna publish --no-private --conventional-commits --create-release github --ignore-prepublish --yes
           yarn docs changelog
           git add docs/src/data/log.md && git commit -m "docs: update changelog" && git push
           yarn zx scripts/post-changelog.mjs

--- a/packages/orbit-tailwind-preset/package.json
+++ b/packages/orbit-tailwind-preset/package.json
@@ -26,6 +26,7 @@
   ],
   "scripts": {
     "build": "yarn tsup",
+    "prepublishOnly": "yarn build",
     "pretest": "yarn workspace @kiwicom/orbit-design-tokens build && yarn build && yarn tailwindcss -o style.css",
     "test": "jest"
   },


### PR DESCRIPTION
- ensure building packages in the right order
- prevent lerna from running prepublish script

# This Pull Request meets the following criteria:

- [ ] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components has both `.flow` and `d.ts` files and are exported in `index.js.flow` and `index.d.ts`

 Storybook: https://orbit-mainframev-marco-publish-build.surge.sh