### PR TITLE
Make OrbitProvider#useId optional with React 18

### DIFF
--- a/packages/orbit-components/src/OrbitProvider/README.md
+++ b/packages/orbit-components/src/OrbitProvider/README.md
@@ -18,8 +18,8 @@ After adding import please wrap your application into `OrbitProvider` and you ca
 
 Table below contains all types of the props available in the OrbitProvider component.
 
-| Name         | Type         | Default | Description                                                                                                                           |
-| :----------- | :----------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------ |
-| **children** | `React.Node` |         | Your app                                                                                                                              |
-| theme        | `[Object]`   |         | See [`theming`](https://github.com/kiwicom/orbit/blob/master/.github/theming.md)                                                      |
-| useId        | `[Object]`   |         | If using React 18 or above, use `React.useId`. If not, use `useRandomId` from [`react-uid`](https://www.npmjs.com/package/react-uid). |
+| Name         | Type           | Default                                   | Description                                                                                                                           |
+| :----------- | :------------- | :---------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| **children** | `React.Node`   |                                           | Your app                                                                                                                              |
+| theme        | `[Object]`     |                                           | See [`theming`](https://github.com/kiwicom/orbit/blob/master/.github/theming.md)                                                      |
+| useId        | `() => string` | `React.useId` (`undefined` for React ≤17) | If using React 18 or above, use `React.useId`. If not, use `useRandomId` from [`react-uid`](https://www.npmjs.com/package/react-uid). |

--- a/packages/orbit-components/src/OrbitProvider/index.tsx
+++ b/packages/orbit-components/src/OrbitProvider/index.tsx
@@ -21,7 +21,7 @@ import type { Props } from "./types";
  * ```
  *
  */
-const OrbitProvider = ({ theme, children, useId }: Props) => {
+const OrbitProvider = ({ theme, children, useId = React.useId }: Props) => {
   return (
     <RandomIdProvider useId={useId}>
       <StyledThemeProvider theme={theme}>

--- a/packages/orbit-components/src/OrbitProvider/types.d.ts
+++ b/packages/orbit-components/src/OrbitProvider/types.d.ts
@@ -5,8 +5,21 @@ import type * as React from "react";
 
 import type { Theme } from "../defaultTheme";
 
-export interface Props {
+type UseId = () => string;
+
+interface RequiredUseId {
+  readonly useId: UseId;
+}
+
+interface OptionalUseId {
+  readonly useId?: UseId;
+}
+
+type IsReact18 = typeof React extends { useId: UseId } ? true : false;
+
+type WithUseId = IsReact18 extends true ? OptionalUseId : RequiredUseId;
+
+export type Props = WithUseId & {
   readonly theme: Theme;
   readonly children: React.ReactNode;
-  readonly useId: () => string;
-}
+};


### PR DESCRIPTION
The useId attribute of OrbitProvider is expected to be passed the value `React.useId` if used with React 18. This is a breaking change in Orbit 9.

This MR:

0. adds `React.useId` as a default value for the attribute. With React 17 and lower, `React.useId` evaluates to undefined, which is the current default value, so for users of React ≤17, nothing is changed.
1. Adds types that make the attribute optional with React 18, but required for React ≤17.

With this change, consumers of Orbit do not need to update their OrbitProviders when updating to Orbit 9 if they use React 18.

And we will be able to use Orbit without waiting for [Overlord support](https://gitlab.skypicker.com/frontend/core/-/blob/master/packages/overlord/src/components/OverlordProvider.tsx) for the attribute.
 Storybook: https://orbit-mainframev-jozef-react-18-useId.surge.sh