### PR TITLE
chore: split general checks into multiple jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,5 @@
 name: Test
 
-#TODO remove the all branches condition later
 on:
   push:
     branches:
@@ -17,7 +16,7 @@ env: # Set environment variables for every job and step in this workflow
   STREAMLINE_FAMILIES: ${{ secrets.STREAMLINE_FAMILIES }}
 
 jobs:
-  general:
+  types:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -39,13 +38,51 @@ jobs:
       - name: Type checks
         run: yarn check:types && yarn flow check
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Node
+        uses: ./.github/actions/node
+
+      - name: Build
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        run: |
+          yarn tokens build
+          yarn tailwind-preset build
+          yarn components build
+          yarn tracking build
+          yarn themer build
+
       - name: Lint
         run: |
           yarn eslint:ci
           yarn prettier:test
           yarn check:css
 
-      - name: Test
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Node
+        uses: ./.github/actions/node
+
+      - name: Build
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        run: |
+          yarn tokens build
+          yarn tailwind-preset build
+          yarn components build
+          yarn tracking build
+          yarn themer build
+
+      - name: Unit tests
         env:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
         run: |


### PR DESCRIPTION
General job was executing 3 types os checks. They all now have their own job each.

Also removed the TODO as we _should_ run the pipeline for every PR. We can just have less restrict required checks on non-master PRs, but that can be configured somewhere else 

After this is approved and before is merged, I will change the required checks on the branch rules to reflect the new jobs.

**Time changes** (compared with [the latest run](https://github.com/kiwicom/orbit/actions/runs/6237496256)):
| Scenario | Test workflow time (excluding Cypress and Docs) | Jobs duration |
|---|---|---|
| This branch | 8m 50s | Types (4m 37s), Lint (8m 50s), Unit (8m 5s) |
| Before | 15m 59s | General (15m 59s) |

Not only we can detect failures earlier (if a test fails, we don't have to wait for types and lint to run to see it failing), the time to execute also decreases drastically.

Storybook: https://orbit-mainframev-split-pipelines-jobs.surge.sh