### PR TITLE
test: remove act wrappers for user event actions

### DIFF
--- a/.github/contribution/testing-conventions.md
+++ b/.github/contribution/testing-conventions.md
@@ -16,7 +16,7 @@ import Button from "../";
 describe("Button", () => {
   const user = userEvent.setup();
 
-  it("should be accessible", () => {
+  it("should be accessible", async () => {
     render(<Button>Click me</Button>);
     expect(screen.getByRole("button", { name: "Click me" })).toBeInTheDocument();
   });
@@ -24,7 +24,7 @@ describe("Button", () => {
     const onClick = jest.fn();
     render(<Button onClick={onClick}>Click me</Button>);
 
-    act(() => user.click(screen.getByRole("button", { name: "Click me" })));
+    await user.click(screen.getByRole("button", { name: "Click me" }));
     expect(onClick).toHaveBeenCalled();
   });
   describe("when disabled", () => {
@@ -36,7 +36,7 @@ describe("Button", () => {
         </Button>,
       );
 
-      act(() => user.click(screen.getByRole("button", { name: "Click me" })));
+      await user.click(screen.getByRole("button", { name: "Click me" }));
       expect(onClick).not.toHaveBeenCalled();
     });
   });
@@ -58,7 +58,7 @@ import userEvent from "@testing-library/user-event";
 
 import Button from "../";
 
-describe("Button", () => {
+describe("Button", async () => {
   const user = userEvent.setup();
 
   it("default", () => {
@@ -70,7 +70,7 @@ describe("Button", () => {
     );
 
     const button = screen.getByRole("button");
-    act(() => user.click(button));
+    await user.click(button);
     expect(button).toHaveTextContent("Click me"); // you can just repeat it
     expect(onClick).toHaveBeenCalled();
   });

--- a/docs/src/components/ComponentStructure/__tests__/index.test.tsx
+++ b/docs/src/components/ComponentStructure/__tests__/index.test.tsx
@@ -57,7 +57,7 @@ describe("ComponentStructure", () => {
       />,
     );
 
-    await act(() => user.click(screen.getByRole("tab", { name: "iOS" })));
+    await user.click(screen.getByRole("tab", { name: "iOS" }));
     screen.getByText(/iOSOne/);
   });
 
@@ -75,7 +75,7 @@ describe("ComponentStructure", () => {
     const tabIOS = screen.getByRole("tab", { name: "iOS" });
     const tabAndroid = screen.getByRole("tab", { name: "Android" });
 
-    await act(() => user.tab());
+    await user.tab();
     expect(tabWeb).toHaveFocus();
 
     await act(async () => {

--- a/packages/orbit-components/src/Card/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Card/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import Card, { CardSection } from "..";
 import Button from "../../Button";
 
@@ -103,7 +103,7 @@ describe("Card", () => {
       );
       const content = document.querySelector("[aria-hidden]");
       expect(content).toHaveAttribute("aria-hidden", "true");
-      await act(() => user.click(screen.getByText("kek")));
+      await user.click(screen.getByText("kek"));
       expect(content).toHaveAttribute("aria-hidden", "false");
     });
   });

--- a/packages/orbit-components/src/Collapse/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Collapse/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import Collapse from "..";
 
 const toggleButtons = [
@@ -39,25 +39,29 @@ describe("Collapse", () => {
       </Collapse>,
     );
     const toggleButton = screen.getAllByRole("button", { name: "Collapse" })[buttonIndex];
-    await act(() => user.click(toggleButton));
+    await user.click(toggleButton);
     expect(onClick).toHaveBeenCalled();
   });
 
   describe("uncontrolled", () => {
-    it.each(toggleButtons)("should expand/collapse when clicking on %s", async buttonIndex => {
-      render(
-        <Collapse label="Collapse">
-          <article>children</article>
-        </Collapse>,
-      );
-      const toggleButton = screen.getAllByRole("button", { name: "Collapse" })[buttonIndex];
-      // with ByRole we can test whether the content is visible because of aria-hidden
-      expect(screen.queryByRole("article")).not.toBeInTheDocument();
-      await act(() => user.click(toggleButton));
-      expect(screen.getByRole("article")).toBeInTheDocument();
-      await act(() => user.click(toggleButton));
-      expect(screen.queryByRole("article")).not.toBeInTheDocument();
-    });
+    it.each(toggleButtons)(
+      "should expand/collapse when clicking on %s",
+      async buttonIndex => {
+        render(
+          <Collapse label="Collapse">
+            <article>children</article>
+          </Collapse>,
+        );
+        const toggleButton = screen.getAllByRole("button", { name: "Collapse" })[buttonIndex];
+        // with ByRole we can test whether the content is visible because of aria-hidden
+        expect(screen.queryByRole("article")).not.toBeInTheDocument();
+        await user.click(toggleButton);
+        expect(screen.getByRole("article")).toBeInTheDocument();
+        await user.click(toggleButton);
+        expect(screen.queryByRole("article")).not.toBeInTheDocument();
+      },
+      10000,
+    );
   });
 
   describe("controlled", () => {

--- a/packages/orbit-components/src/ErrorFormTooltip/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/ErrorFormTooltip/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import ErrorFormTooltip from "..";
 
 describe("ErrorFormTooltip", () => {
@@ -15,7 +15,7 @@ describe("ErrorFormTooltip", () => {
 
     expect(screen.getByTestId("test")).toBeInTheDocument();
     expect(screen.getByText("error")).toBeInTheDocument();
-    await act(() => user.click(container));
+    await user.click(container);
     expect(onShown).toHaveBeenCalled();
   });
 
@@ -26,7 +26,7 @@ describe("ErrorFormTooltip", () => {
     expect(screen.getByTestId("test")).toBeInTheDocument();
     expect(screen.getByText("help")).toBeInTheDocument();
 
-    await act(() => user.click(screen.getByLabelText("close")));
+    await user.click(screen.getByLabelText("close"));
     expect(onShown).toHaveBeenCalled();
   });
 });

--- a/packages/orbit-components/src/InputField/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/InputField/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import InputField from "..";
 import ButtonLink from "../../ButtonLink";
 import TextLink from "../../TextLink";
@@ -64,7 +64,7 @@ describe("InputField", () => {
     expect(screen.getByTestId("test")).toBeInTheDocument();
     expect(screen.getByTestId("prefix")).toBeInTheDocument();
     expect(screen.getByTestId("suffix")).toBeInTheDocument();
-    await act(() => user.tab());
+    await user.tab();
     expect(screen.getByTestId("help")).toBeInTheDocument();
     expect(container.firstChild).toHaveStyle({ marginBottom: defaultTheme.orbit.spaceSmall });
   });
@@ -142,7 +142,7 @@ describe("InputField", () => {
       expect(input).toHaveAttribute("data-state", "error");
       expect(input).toBeInvalid();
 
-      await act(() => user.tab());
+      await user.tab();
       expect(screen.queryByTestId("help")).not.toBeInTheDocument();
       expect(screen.getByTestId("error")).toBeInTheDocument();
     });
@@ -158,9 +158,9 @@ describe("InputField", () => {
       );
 
       expect(screen.queryByText("First")).not.toBeInTheDocument();
-      await act(() => user.tab());
+      await user.tab();
       expect(screen.getByText("First")).toBeVisible();
-      await act(() => user.tab());
+      await user.tab();
       expect(screen.queryByText("First")).not.toBeInTheDocument();
       expect(screen.getByText("Second")).toBeVisible();
     });
@@ -168,13 +168,13 @@ describe("InputField", () => {
     it("should close tooltip when tabbing away from its content", async () => {
       render(<InputField error={<a href="/">Second</a>} />);
 
-      await act(() => user.tab());
+      await user.tab();
       expect(screen.getByText("Second")).toBeVisible();
 
       screen.getByRole("link").focus();
       expect(screen.getByRole("link")).toHaveFocus();
 
-      await act(() => user.tab());
+      await user.tab();
       expect(screen.queryByText("Second")).not.toBeInTheDocument();
     });
   });

--- a/packages/orbit-components/src/InputFile/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/InputFile/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent, { PointerEventsCheckLevel } from "@testing-library/user-event";
 
-import { render, screen, act } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import InputFile from "..";
 import SPACINGS_AFTER from "../../common/getSpacingToken/consts";
 
@@ -92,12 +92,12 @@ describe("InputFile", () => {
       />,
     );
 
-    await act(() => user.tab());
+    await user.tab();
     expect(onFocus).toHaveBeenCalled();
 
     expect(screen.getByText("chuck norris counted to infinity twice")).toBeInTheDocument();
 
-    await act(() => user.tab());
+    await user.tab();
     expect(onBlur).toHaveBeenCalled();
   });
 });

--- a/packages/orbit-components/src/InputGroup/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/InputGroup/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import InputGroup from "..";
 import InputField from "../../InputField";
 import defaultTheme from "../../defaultTheme";
@@ -40,7 +40,7 @@ describe("InputGroup", () => {
       </InputGroup>,
     );
 
-    await act(() => user.tab());
+    await user.tab();
     expect(screen.getByText("help message")).toBeInTheDocument();
   });
   it("should render error message", async () => {
@@ -50,7 +50,7 @@ describe("InputGroup", () => {
       </InputGroup>,
     );
 
-    await act(() => user.tab());
+    await user.tab();
     expect(screen.getByText("error message")).toBeInTheDocument();
   });
 
@@ -64,10 +64,10 @@ describe("InputGroup", () => {
       </InputGroup>,
     );
     const input = screen.getByRole("textbox");
-    await act(() => user.type(input, "text"));
+    await user.type(input, "text");
     expect(onChange).toHaveBeenCalled();
     expect(onFocus).toHaveBeenCalled();
-    await act(() => user.tab());
+    await user.tab();
     expect(onBlur).toHaveBeenCalled();
   });
   it("should be able to disable children", () => {

--- a/packages/orbit-components/src/InputSelect/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/InputSelect/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, fireEvent, act } from "../../test-utils";
+import { render, screen, fireEvent } from "../../test-utils";
 import InputSelect from "..";
 
 const jetLiOption = {
@@ -63,7 +63,7 @@ describe("InputSelect", () => {
       />,
     );
 
-    await act(() => user.tab());
+    await user.tab();
 
     const input = screen.getByRole("combobox");
     const dropdown = screen.getByRole("listbox");
@@ -87,15 +87,15 @@ describe("InputSelect", () => {
     expect(input).toHaveAttribute("id", id);
 
     // clear current value
-    await act(() => user.clear(input));
+    await user.clear(input);
 
     // test empty message
-    await act(() => user.type(input, "Arnold"));
+    await user.type(input, "Arnold");
     expect(screen.getByText(emptyMessage)).toBeInTheDocument();
 
     // test dropdown result filtering
-    await act(() => user.clear(input));
-    await act(() => user.type(input, "J"));
+    await user.clear(input);
+    await user.type(input, "J");
     expect(onChange).toHaveBeenCalled();
 
     expect(screen.getAllByRole("option")).toHaveLength(2);
@@ -108,7 +108,7 @@ describe("InputSelect", () => {
     expect(onKeyDown).toHaveBeenCalled();
 
     // should select by click
-    await act(() => user.click(screen.getByText("Jet Li")));
+    await user.click(screen.getByText("Jet Li"));
 
     expect(onOptionSelect).toHaveBeenCalledWith(jetLiOption);
 
@@ -125,8 +125,8 @@ describe("InputSelect", () => {
     expect(onClose).toHaveBeenCalledWith(jetLiOption);
 
     // test clear of the input by button and reset of filtered options
-    await act(() => user.tab());
-    await act(() => user.click(screen.getByLabelText("Clear")));
+    await user.tab();
+    await user.click(screen.getByLabelText("Clear"));
     expect(onOptionSelect).toBeCalledWith(null);
     expect(screen.getByRole("textbox")).toHaveValue("");
     expect(screen.getAllByRole("option")).toHaveLength(totalOptions);
@@ -148,7 +148,7 @@ describe("InputSelect", () => {
       />,
     );
 
-    await act(() => user.tab());
+    await user.tab();
 
     const input = screen.getByRole("combobox");
 
@@ -159,7 +159,7 @@ describe("InputSelect", () => {
     expect(onClose).toHaveBeenCalledWith(jetLiOption);
 
     // Simulate changing the input without selecting anything to assert the previous selected option remains selected
-    await act(() => user.type(input, "Random unexisting option"));
+    await user.type(input, "Random unexisting option");
     fireEvent.keyDown(input, { key: "Escape" });
     expect(onClose).toHaveBeenLastCalledWith(jetLiOption);
     expect(onOptionSelect).not.toHaveBeenCalled();
@@ -182,11 +182,11 @@ describe("InputSelect", () => {
       />,
     );
 
-    await act(() => user.tab());
+    await user.tab();
 
     const input = screen.getByRole("combobox");
 
-    user.clear(input);
+    await user.clear(input);
     fireEvent.keyDown(input, { key: "Escape" });
     expect(onClose).toHaveBeenCalledWith(null);
     expect(onOptionSelect).toHaveBeenCalledWith(null);
@@ -206,7 +206,7 @@ describe("InputSelect", () => {
       />,
     );
 
-    await act(() => user.tab());
+    await user.tab();
 
     expect(screen.queryByText("Previously selected")).not.toBeInTheDocument();
     expect(screen.queryByText(prevSelectedLabel)).toBeInTheDocument();
@@ -217,7 +217,7 @@ describe("InputSelect", () => {
     it("should not render repeated options", async () => {
       const showAllLabel = "Those without a group";
       render(<InputSelect options={options} showAll={false} showAllLabel={showAllLabel} />);
-      await act(() => user.tab());
+      await user.tab();
 
       // after focus dropdown should have all options grouped and then show only the ones without a group
       expect(screen.getAllByRole("option")).toHaveLength(2 + 1 + 1); // (2 asian, 1 american, 1 ungrouped)

--- a/packages/orbit-components/src/Popover/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Popover/__tests__/index.test.tsx
@@ -38,11 +38,11 @@ describe("Popover", () => {
     );
 
     const openButton = screen.getByRole("button", { name: "Open" });
-    await act(() => user.click(openButton));
+    await user.click(openButton);
     expect(onOpen).toHaveBeenCalled();
     expect(screen.getByTestId(dataTest)).toBeInTheDocument();
     const closeButton = screen.getByRole("button", { name: "Close" });
-    await act(() => user.click(closeButton));
+    await user.click(closeButton);
     expect(onClose).toHaveBeenCalled();
   });
 
@@ -100,10 +100,10 @@ describe("Popover", () => {
         <Button>Open popover</Button>
       </Popover>,
     );
-    await act(() => user.click(screen.getByRole("button")));
+    await user.click(screen.getByRole("button"));
     const overlay = (await screen.findByTestId("popover")).previousElementSibling;
     expect(overlay).toBeInTheDocument();
-    if (overlay) await act(() => user.click(overlay));
+    if (overlay) await user.click(overlay);
     expect(screen.queryByTestId("popover")).not.toBeInTheDocument();
   });
 });

--- a/packages/orbit-components/src/SegmentedSwitch/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/SegmentedSwitch/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import SegmentedSwitch from "..";
 
 describe("SegmentedSwitch", () => {
@@ -29,10 +29,10 @@ describe("SegmentedSwitch", () => {
     expect(screen.getByText(label)).toBeInTheDocument();
     expect(screen.getByTestId(dataTest)).toBeInTheDocument();
 
-    await act(() => user.tab());
+    await user.tab();
     expect(onFocus).toHaveBeenCalled();
 
-    await act(() => user.click(screen.getByLabelText("Female")));
+    await user.click(screen.getByLabelText("Female"));
     expect(screen.getByDisplayValue("Female")).toBeInTheDocument();
     expect(onChange).toHaveBeenCalled();
   });
@@ -53,7 +53,7 @@ describe("SegmentedSwitch", () => {
       />,
     );
 
-    await act(() => user.hover(screen.getByText(label)));
+    await user.hover(screen.getByText(label));
     expect(screen.getByText(error)).toBeInTheDocument();
     expect(screen.getByLabelText("Female")).toBeDisabled();
   });
@@ -73,7 +73,7 @@ describe("SegmentedSwitch", () => {
       />,
     );
 
-    await act(() => user.hover(screen.getByText("Gender")));
+    await user.hover(screen.getByText("Gender"));
     expect(screen.getByText(help)).toBeInTheDocument();
   });
 });

--- a/packages/orbit-components/src/Select/__tests__/Select.test.tsx
+++ b/packages/orbit-components/src/Select/__tests__/Select.test.tsx
@@ -95,7 +95,7 @@ describe("Select", () => {
     );
     const select = screen.getByTestId("error-select");
 
-    await act(() => user.tab());
+    await user.tab();
     expect(screen.getByText("error")).toBeInTheDocument();
     expect(select).toBeInvalid();
     expect(select).toHaveAccessibleDescription("error");
@@ -113,7 +113,7 @@ describe("Select", () => {
     );
     const select = screen.getByTestId("help-select");
 
-    await act(() => user.tab());
+    await user.tab();
     expect(screen.getByText("help")).toBeInTheDocument();
     expect(select).toHaveAccessibleDescription("help");
     await act(async () => {});

--- a/packages/orbit-components/src/SkipNavigation/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/SkipNavigation/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import SkipNavigation from "..";
 
 describe("SkipNavigation", () => {
@@ -39,7 +39,7 @@ describe("SkipNavigation", () => {
     );
 
     expect(container).toHaveStyle({ clip: "rect(0 0 0 0)" });
-    await act(() => user.tab());
+    await user.tab();
     expect(container).toHaveStyle({ clip: "" });
   });
 });

--- a/packages/orbit-components/src/Slider/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Slider/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, fireEvent, act } from "../../test-utils";
+import { render, screen, fireEvent } from "../../test-utils";
 import Slider from "..";
 
 const MOUSE_MOVE_STEP = 10;
@@ -74,9 +74,9 @@ describe("Slider", () => {
     expect(slider).toHaveAttribute("aria-valuenow", defaultValue.toString());
     expect(slider).toHaveAttribute("aria-valuetext", ariaValueText.toString());
 
-    await act(() => user.tab());
+    await user.tab();
     expect(onChangeBefore).toHaveBeenCalled();
-    await act(() => user.tab());
+    await user.tab();
     expect(onChangeAfter).toHaveBeenCalled();
     expect(onChangeAfter).toHaveBeenCalledWith(2);
 

--- a/packages/orbit-components/src/Tabs/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Tabs/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { act, render, screen } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import Tabs, { TabList, Tab, TabPanels, TabPanel } from "..";
 
 describe("Tabs", () => {
@@ -29,7 +29,7 @@ describe("Tabs", () => {
     expect(screen.getByTestId("panel")).toBeInTheDocument();
     expect(screen.getByTestId("panel1")).toBeInTheDocument();
 
-    await act(() => user.click(screen.getByText("Tab 2")));
+    await user.click(screen.getByText("Tab 2"));
 
     expect(onChange).toHaveBeenCalled();
     expect(screen.getByTestId("first-tab")).toHaveAttribute("aria-selected", "false");
@@ -82,7 +82,7 @@ describe("Tabs", () => {
 
     expect(screen.getByTestId("first-tab")).toHaveAttribute("aria-selected", "true");
     expect(screen.getByText("1")).toBeInTheDocument();
-    await act(() => user.click(screen.getByText("second tab")));
+    await user.click(screen.getByText("second tab"));
     expect(onClick).toHaveBeenCalled();
     expect(onChange).not.toHaveBeenCalled();
     expect(screen.getByTestId("second-tab")).toHaveAttribute("aria-selected", "true");

--- a/packages/orbit-components/src/Textarea/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Textarea/__tests__/index.test.tsx
@@ -42,7 +42,7 @@ describe("Textarea", () => {
     expect(screen.getByDisplayValue("value")).toBeInTheDocument();
     expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument();
 
-    await act(() => user.tab());
+    await user.tab();
     expect(screen.getByText("Something useful.")).toBeInTheDocument();
     expect(textarea).toHaveAttribute("maxlength", maxLength.toString());
     expect(textarea).toHaveAttribute("rows", "4");
@@ -66,7 +66,7 @@ describe("Textarea", () => {
     expect(onFocus).toHaveBeenCalled();
     await user.tab();
     expect(onBlur).toHaveBeenCalled();
-    await act(() => user.type(textarea, "kek"));
+    await user.type(textarea, "kek");
     expect(onChange).toHaveBeenCalled();
   });
 
@@ -74,7 +74,7 @@ describe("Textarea", () => {
     render(<Textarea error="error" size="small" />);
     const textarea = screen.getByRole("textbox");
 
-    await act(() => user.tab());
+    await user.tab();
     expect(screen.getByText("error")).toBeInTheDocument();
     expect(textarea).toHaveStyle({ padding: "8px 12px" });
     expect(textarea).toBeInvalid();

--- a/packages/orbit-components/src/Toast/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Toast/__tests__/index.test.tsx
@@ -40,10 +40,10 @@ describe("Toast", () => {
 
     const toast = screen.getByText("kek");
 
-    await act(() => user.hover(toast));
+    await user.hover(toast);
     expect(onMouseEnter).toHaveBeenCalled();
 
-    await act(() => user.unhover(toast));
+    await user.unhover(toast);
     expect(onMouseLeave).toHaveBeenCalled();
 
     jest.useFakeTimers();
@@ -80,7 +80,7 @@ describe("Toast", () => {
       </>,
     );
 
-    await act(() => user.click(screen.getByRole("button")));
+    await user.click(screen.getByRole("button"));
 
     expect(screen.getByTestId("test")).toHaveStyle({
       top: "30px",

--- a/packages/orbit-components/src/Tooltip/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Tooltip/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import Tooltip from "..";
 
 jest.mock("../../hooks/useMediaQuery", () => {
@@ -26,7 +26,7 @@ describe("Tooltip", () => {
     );
 
     expect(screen.getByText("kek")).toBeInTheDocument();
-    await act(() => user.hover(screen.getByText("kek")));
+    await user.hover(screen.getByText("kek"));
     expect(onShow).toHaveBeenCalled();
   });
 });

--- a/packages/orbit-components/src/Tooltip/__tests__/mobile.test.tsx
+++ b/packages/orbit-components/src/Tooltip/__tests__/mobile.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import Button from "../../Button";
 import Tooltip from "..";
 
@@ -28,9 +28,9 @@ describe("Tooltip mobile", () => {
     );
 
     // Open the tooltip
-    await act(() => user.click(screen.getByText("kek")));
+    await user.click(screen.getByText("kek"));
     // Close the tooltip
-    await act(() => user.click(screen.getByText("Close")));
+    await user.click(screen.getByText("Close"));
 
     expect(onClick).not.toHaveBeenCalled();
   });

--- a/packages/orbit-components/src/Wizard/__tests__/compact.test.tsx
+++ b/packages/orbit-components/src/Wizard/__tests__/compact.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, within, act } from "../../test-utils";
+import { render, screen, within } from "../../test-utils";
 import Wizard, { WizardStep } from "..";
 
 jest.mock("../../hooks/useMediaQuery", () => () => ({ isLargeMobile: false }));
@@ -35,7 +35,7 @@ describe("Wizard", () => {
           <WizardStep title="Overview & payment" />
         </Wizard>,
       );
-      await act(() => user.click(screen.getByRole("button")));
+      await user.click(screen.getByRole("button"));
       const customizeYourTripStep = within(screen.getByRole("dialog")).getByRole("button", {
         name: /Customize your trip/,
       });
@@ -62,11 +62,12 @@ describe("Wizard", () => {
         );
       };
       render(<MyApp />);
-      await act(() => user.click(screen.getByRole("button")));
+      await user.click(screen.getByRole("button"));
       const ticketFareStep = within(screen.getByRole("dialog")).getByRole("button", {
         name: /Ticket fare/,
       });
-      await act(() => user.click(ticketFareStep));
+
+      await user.click(ticketFareStep);
       expect(onClickStep).toHaveBeenCalled();
     });
 
@@ -81,8 +82,8 @@ describe("Wizard", () => {
           <WizardStep title="Overview & payment" onClick={onClick} />
         </Wizard>,
       );
-      await act(() => user.click(screen.getByRole("button")));
-      await act(() => user.click(screen.getByText("Overview & payment")));
+      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByText("Overview & payment"));
       expect(onClick).not.toHaveBeenCalled();
     });
 
@@ -96,9 +97,9 @@ describe("Wizard", () => {
           <WizardStep title="Overview & payment" />
         </Wizard>,
       );
-      await act(() => user.click(screen.getByRole("button")));
-      await act(() => user.click(screen.getByText("Close")));
+      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByText("Close"));
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
+    }, 10000);
   });
 });

--- a/packages/orbit-components/src/Wizard/__tests__/loose.test.tsx
+++ b/packages/orbit-components/src/Wizard/__tests__/loose.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../test-utils";
+import { render, screen } from "../../test-utils";
 import Wizard, { WizardStep } from "..";
 
 jest.mock("../../hooks/useMediaQuery", () => () => ({ isLargeMobile: true }));
@@ -32,7 +32,7 @@ describe("Wizard", () => {
       const customizeYourTripStep = screen.getByRole("button", { name: /Customize your trip/ });
       expect(customizeYourTripStep).toHaveAttribute("aria-current", "step");
       const ticketFareStep = screen.getByRole("button", { name: /Ticket fare/ });
-      await act(() => user.click(ticketFareStep));
+      await user.click(ticketFareStep);
       expect(ticketFareStep).toHaveAttribute("aria-current", "step");
     });
 
@@ -47,7 +47,7 @@ describe("Wizard", () => {
           <WizardStep title="Overview & payment" onClick={onClick} />
         </Wizard>,
       );
-      await act(() => user.click(screen.getByText("Overview & payment")));
+      await user.click(screen.getByText("Overview & payment"));
       expect(onClick).not.toHaveBeenCalled();
     });
   });

--- a/packages/orbit-components/src/hooks/useTransition/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/hooks/useTransition/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, fireEvent, act } from "../../../test-utils";
+import { render, screen, fireEvent } from "../../../test-utils";
 import useTransition from "..";
 
 function App(props: { show: boolean; appear: boolean }) {
@@ -33,12 +33,12 @@ describe("useTransition", () => {
   it("should provide correct API for transitioning", async () => {
     render(<App show={false} appear={false} />);
     expect(screen.queryByText("Test")).not.toBeInTheDocument();
-    await act(() => user.click(screen.getByRole("button")));
+    await user.click(screen.getByRole("button"));
     expect(screen.getByText("Test")).toHaveStyle({ opacity: 1 });
     expect(screen.getByRole("button")).toBeDisabled();
     fireEvent.transitionEnd(screen.getByText("Test"));
     expect(screen.getByRole("button")).not.toBeDisabled();
-    await act(() => user.click(screen.getByRole("button")));
+    await user.click(screen.getByRole("button"));
     expect(screen.getByText("Test")).toHaveStyle({ opacity: 0 });
     fireEvent.transitionEnd(screen.getByText("Test"));
     expect(screen.queryByText("Test")).not.toBeInTheDocument();

--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../../test-utils";
+import { render, screen } from "../../../test-utils";
 import MobileDialog from "..";
 
 let dialogs: HTMLElement;
@@ -28,7 +28,7 @@ describe("MobileDialogPrimitive", () => {
     );
     const children = screen.getByText("children");
     expect(children).toHaveAttribute("tabindex", "1");
-    await act(() => user.click(children));
+    await user.click(children);
     expect(onShown).toHaveBeenCalledTimes(1);
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByTestId("test")).toBeInTheDocument();

--- a/packages/orbit-components/src/primitives/TooltipPrimitive/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/primitives/TooltipPrimitive/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, act } from "../../../test-utils";
+import { render, screen } from "../../../test-utils";
 import Tooltip from "..";
 
 describe("Tooltip", () => {
@@ -37,8 +37,8 @@ describe("Tooltip", () => {
       </div>,
     );
 
-    await act(() => user.hover(screen.getByText("kek")));
-    await act(() => user.click(screen.getByText(content)));
+    await user.hover(screen.getByText("kek"));
+    await user.click(screen.getByText(content));
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
@@ -61,8 +61,8 @@ describe("Tooltip", () => {
       </div>,
     );
 
-    await act(() => user.hover(screen.getByText("kek")));
-    await act(() => user.click(screen.getByText(content)));
+    await user.hover(screen.getByText("kek"));
+    await user.click(screen.getByText(content));
 
     expect(onClick).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
Having an act wrapper for user event actions seems a redundant thing to have, tests are working fine without 

We also started to receive warnings about the wrong usage of the act and [I later found this comment](https://github.com/testing-library/react-testing-library/issues/1061#issuecomment-1419824786)
 Storybook: https://orbit-mainframev-chore-fix-test-suits.surge.sh