### PR TITLE
ci: fix changelog script to sort tags by creation date

### DIFF
--- a/scripts/post-changelog.mjs
+++ b/scripts/post-changelog.mjs
@@ -99,7 +99,7 @@ async function configureSlackToken() {
 async function publishChangelog(package_) {
   try {
     await simpleGit().fetch(["origin", "master", "--tags"]);
-    const tags = await simpleGit().tags();
+    const tags = await simpleGit().tags({ "--sort": "-taggerdate" });
     const diff = await getDiff(tags.latest ?? "", changelogPath(package_));
     const files = gitDiffParser.parse(diff);
     if (files.length === 0) {


### PR DESCRIPTION
By default they were sorted by semver

Closes [FEPLT-1761](https://kiwicom.atlassian.net/browse/FEPLT-1761)
 Storybook: https://orbit-mainframev-marco-fix-changelog-most-recent-tag.surge.sh