### PR TITLE
fix(Dialog): hide scroll bar, but keep scrolling behaviour

### DIFF
--- a/packages/orbit-components/src/primitives/MobileDialogPrimitive/components/DialogContent.tsx
+++ b/packages/orbit-components/src/primitives/MobileDialogPrimitive/components/DialogContent.tsx
@@ -44,6 +44,12 @@ const StyledDialogWrapper = styled.div<{ shown?: boolean }>`
   right: ${({ theme }) => theme.orbit.spaceMedium};
   max-height: ${({ theme }) => `calc(100% - ${theme.orbit.spaceXLarge})`};
   overflow-y: scroll;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 
   img {
     max-width: 100%;


### PR DESCRIPTION
[Reported on Slack](https://skypicker.slack.com/archives/C7T7QG7M5/p1696338848003649)
 Storybook: https://orbit-mainframev-fix-tooltip-overflow.surge.sh