### PR TITLE
fix(ItinerarySegmentDetail): fix overflowing content issue

### DIFF
--- a/packages/orbit-components/src/Itinerary/Itinerary.stories.tsx
+++ b/packages/orbit-components/src/Itinerary/Itinerary.stories.tsx
@@ -182,7 +182,7 @@ const content = [
 
 export const Segment = () => {
   return (
-    <Stack spacing="large">
+    <div className="space-y-xl">
       <Itinerary>
         <ItinerarySegment>
           <ItinerarySegmentStop
@@ -240,7 +240,7 @@ export const Segment = () => {
           />
         </ItinerarySegment>
       </Itinerary>
-    </Stack>
+    </div>
   );
 };
 

--- a/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentDetail/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentDetail/index.tsx
@@ -21,7 +21,9 @@ import { usePart } from "../context";
 import { useWidth } from "../../context";
 import AirplaneDown from "../../../icons/AirplaneDown";
 import type { Props } from "./types";
+import type { SpaceAfterSizes } from "../../../common/types";
 import ItineraryIcon from "../ItineraryIcon";
+import getSpacingToken from "../../../common/getSpacingToken";
 
 const StyledWrapper = styled.div`
   width: 100%;
@@ -79,7 +81,7 @@ const StyledExpandableContent = styled.div<{ $offset: number }>`
     padding: 0 ${theme.orbit.spaceSmall};
     position: relative;
     z-index: 1;
-    margin-${left}: ${parseInt(theme.orbit.spaceXSmall, 10) + $offset}px;
+    ${left}: ${parseInt(theme.orbit.spaceXSmall, 10) + $offset}px;
   `}
 `;
 
@@ -127,6 +129,20 @@ const StyledIcon = styled.div<{ isFirst?: boolean; isLast?: boolean }>`
     }
   `}
 `;
+
+const StyledItemWrapper = styled.div<{ $offset: number; spaceAfter: SpaceAfterSizes }>`
+  ${({ theme, $offset }) => css`
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    width: calc(100% - ${parseInt(theme.orbit.spaceXSmall, 10) + $offset}px);
+    margin-bottom: ${getSpacingToken};
+  `};
+`;
+
+StyledItemWrapper.defaultProps = {
+  theme: themeDefault,
+};
 
 StyledIcon.defaultProps = {
   theme: themeDefault,
@@ -199,9 +215,8 @@ const ItinerarySegmentDetail = ({
                         {title}
                       </TemporaryText>
                     </StyledHeadingOffset>
-                    <Stack
-                      direction="column"
-                      spacing="none"
+                    <StyledItemWrapper
+                      $offset={calculatedWidth}
                       spaceAfter={idx === content.length - 1 ? "none" : "medium"}
                     >
                       {items.map(({ icon: itemIcon, name, value }, id) => {
@@ -222,7 +237,7 @@ const ItinerarySegmentDetail = ({
                           </Stack>
                         );
                       })}
-                    </Stack>
+                    </StyledItemWrapper>
                   </React.Fragment>
                 );
               })}


### PR DESCRIPTION
[Reported in Slack](https://skypicker.slack.com/archives/C7T7QG7M5/p1695212720944469)

I tested that on Booking directly by applying the calc logic
 Storybook: https://orbit-mainframev-fix-itinerary-details.surge.sh