### PR TITLE
FEPLT-1777: chore(tailwind): make setup instructions more robust

### DIFF
--- a/packages/orbit-tailwind-preset/README.md
+++ b/packages/orbit-tailwind-preset/README.md
@@ -23,12 +23,17 @@ The `orbitComponentsPreset` function accepts an optional object with one propert
 In your `tailwind.config.js` file (or equivalent), add the following:
 
 ```js
+const path = require("node:path");
 const orbitComponentsPreset = require("@kiwicom/orbit-tailwind-preset");
+// the following ensures the correct path is found (especially within monorepos)
+const orbitComponentsPath = require
+  .resolve("@kiwicom/orbit-components")
+  .replace("/lib/index.js", "");
 
 module.exports = {
   content: [
     // ...
-    "./node_modules/@kiwicom/orbit-components/**/*.js",
+    path.join(orbitComponentsPath, "**", "*.js"),
   ],
   presets: [
     orbitComponentsPreset({
@@ -38,7 +43,7 @@ module.exports = {
 };
 ```
 
-The `content` property is required for Tailwind to [know which files to scan for classes](https://tailwindcss.com/docs/content-configuration). It should include the path to all your source files that use Tailwind classes. The path to the `@kiwicom/orbit-components` package is required for the component-specific classes to be scanned and built into the final CSS.
+The `content` property is required for Tailwind to [know which files to scan for classes](https://tailwindcss.com/docs/content-configuration). It should include the path to all your source files that use Tailwind classes. The path to the `@kiwicom/orbit-components` package is required for the component-specific classes to be scanned and built into the final CSS. (The `require.resolve` ensures it works inside of monorepos too).
 
 The `presets` property is required for Tailwind to [know which presets to use](https://tailwindcss.com/docs/presets). It should include the `orbitComponentsPreset` function, which returns the Orbit Tailwind preset.
 


### PR DESCRIPTION
The code snippet for the tailwind.config.js file is expanded to account for monorepo setups where the Orbit components node module might be hoisted elsewhere.

Relates to [FEPLT-1777](https://kiwicom.atlassian.net/browse/FEPLT-1777)

# This Pull Request meets the following criteria:

- [ ] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components has both `.flow` and `d.ts` files and are exported in `index.js.flow` and `index.d.ts`

 Storybook: https://orbit-mainframev-rcsl-expand-orbit-preset-docs.surge.sh

[FEPLT-1777]: https://kiwicom.atlassian.net/browse/FEPLT-1777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ