### PR TITLE
chore(tracking): extend scope to home and mobile-landing

### DIFF
--- a/packages/orbit-tracking/src/consts.ts
+++ b/packages/orbit-tracking/src/consts.ts
@@ -6,6 +6,8 @@ export const PROJECTS: Record<Scope, string> = {
   booking: "3993",
   frontend: "104",
   search: "1483",
+  home: "5369",
+  "mobile-landing": "3994",
   account: "2127",
   mmb: "2788",
   core: "3371",

--- a/packages/orbit-tracking/src/helpers/projects.ts
+++ b/packages/orbit-tracking/src/helpers/projects.ts
@@ -25,7 +25,7 @@ export const mapProjects = (data: ProjectNode[], folderName: string) =>
       // retrieve name from url, because repository name can be the same twice (balkan has just `Frontend`)
       const name = url.split("/").slice(-1)[0].replace(".git", "");
       return {
-        cmd: `git clone -b master ${ssh} --depth=1 --single-branch ${path.join(
+        cmd: `git clone ${ssh} --depth=1 --single-branch ${path.join(
           folderName,
           `${name}-${projectId}`,
         )}`,

--- a/packages/orbit-tracking/src/interfaces.ts
+++ b/packages/orbit-tracking/src/interfaces.ts
@@ -9,6 +9,8 @@ type AccessLevel =
 
 export type Scope =
   | "booking"
+  | "home"
+  | "mobile-landing"
   | "smart-faq"
   | "search"
   | "frontend"


### PR DESCRIPTION
Extending the scope to include home and mobile-landing. Removed *-b master* as home repository by default is using the main branch. 