### PR TITLE
docs: remove persistence of code in playground

### DIFF
--- a/docs/src/components/ReactExample/Example.tsx
+++ b/docs/src/components/ReactExample/Example.tsx
@@ -179,7 +179,6 @@ const Example = ({
           restoreLocalStorage();
           setPlaygroundOpened(false);
           setOpenEditor(true);
-          updateLocalStorage(defaultCode);
         }}
         knobs={exampleKnobs.length > 0}
         variants={exampleVariants}

--- a/docs/src/hooks/useSandbox.ts
+++ b/docs/src/hooks/useSandbox.ts
@@ -1,18 +1,9 @@
 import React from "react";
 
-import { load, save } from "../utils/storage";
+import { save } from "../utils/storage";
 
 const useSandbox = (exampleId: string, initialCode: string) => {
-  const [code, setCode] = React.useState(() => {
-    try {
-      const storedCode = load(exampleId);
-      return storedCode || initialCode;
-    } catch (err) {
-      console.error(err);
-      return initialCode;
-    }
-  });
-
+  const [code, setCode] = React.useState(initialCode);
   const [origin, setOrigin] = React.useState("");
 
   React.useEffect(() => {
@@ -23,6 +14,10 @@ const useSandbox = (exampleId: string, initialCode: string) => {
         setCode(e.newValue);
       }
     });
+
+    return () => {
+      window.removeEventListener("storage", () => {});
+    };
   }, [exampleId]);
 
   const updateLocalStorage = (newCode: string) => {


### PR DESCRIPTION
Removes persistence of code between editor and iframes. It's saving only during usage, on initial usage always default code is used.


 Storybook: https://orbit-mainframev-docs-change-key-of-docs.surge.sh