### PR TITLE
Stack: Fix classes not applied in viewports

### DIFF
--- a/packages/orbit-components/src/Stack/index.tsx
+++ b/packages/orbit-components/src/Stack/index.tsx
@@ -139,18 +139,14 @@ const Stack = (props: Props) => {
 
     return cx(
       typeof spaceAfter !== "undefined" && getSpaceAfterClasses(spaceAfter, viewport),
-      flex || inline
-        ? [
-            getDisplayClasses(inline ? "inline-flex" : "flex", viewport),
-            typeof align !== "undefined" && getAlignItemsClasses(align, viewport),
-            typeof align !== "undefined" && getAlignContentClasses(align, viewport),
-            typeof wrap !== "undefined" && getWrapClasses(wrap, viewport),
-            typeof grow !== "undefined" && getGrowClasses(grow, viewport),
-            typeof shrink !== "undefined" && getShrinkClasses(shrink, viewport),
-            typeof justify !== "undefined" && getJustifyClasses(justify, viewport),
-            getDirectionClasses(direction, viewport),
-          ]
-        : "block",
+      typeof align !== "undefined" && getAlignItemsClasses(align, viewport),
+      typeof align !== "undefined" && getAlignContentClasses(align, viewport),
+      typeof wrap !== "undefined" && getWrapClasses(wrap, viewport),
+      typeof grow !== "undefined" && getGrowClasses(grow, viewport),
+      typeof shrink !== "undefined" && getShrinkClasses(shrink, viewport),
+      typeof justify !== "undefined" && getJustifyClasses(justify, viewport),
+      getDirectionClasses(direction, viewport),
+      flex || inline ? getDisplayClasses(inline ? "inline-flex" : "flex", viewport) : "block",
       getSpacingClasses(spacing, viewport, direction, legacy),
       inline === false && "w-full",
     );


### PR DESCRIPTION
On #4071 we started to verify a condition on viewport properties that should not be required. The condition is now only required for the classes that it actually affects.

Commit is labeled as a chore as this is a fix to an unreleased bug.
 Storybook: https://orbit-mainframev-fix-stack-viewports.surge.sh