### PR TITLE
ButtonMobileStore: migrate to Tailwind

### DIFF
--- a/docs/src/data/tailwind-migration-status.yaml
+++ b/docs/src/data/tailwind-migration-status.yaml
@@ -13,7 +13,7 @@ OrbitButton: true
 Button: true
 ButtonGroup: true
 ButtonLink: true
-ButtonMobileStore: false
+ButtonMobileStore: true
 ButtonPrimitive: true
 CallOutBanner: false
 Card: true

--- a/packages/orbit-components/src/ButtonMobileStore/ButtonMobileStore.stories.tsx
+++ b/packages/orbit-components/src/ButtonMobileStore/ButtonMobileStore.stories.tsx
@@ -42,20 +42,27 @@ Default.story = {
 };
 
 export const VisualTest = () => {
+  const languages = Object.values(LANGUAGE);
   return (
-    <div className="space-x-xs flex">
-      <ButtonMobileStore
-        onClick={action("clicked")}
-        href="#"
-        type="appStore"
-        alt="Download on the App Store"
-      />
-      <ButtonMobileStore
-        onClick={action("clicked")}
-        href="#"
-        type="googlePlay"
-        alt="Download on the Google Play"
-      />
+    <div className="space-x-xs">
+      {languages.map(lang => (
+        <React.Fragment key={lang}>
+          <ButtonMobileStore
+            onClick={action("clicked")}
+            lang={lang}
+            href="#"
+            type="appStore"
+            alt="Download on the App Store"
+          />
+          <ButtonMobileStore
+            onClick={action("clicked")}
+            lang={lang}
+            href="#"
+            type="googlePlay"
+            alt="Download on the Google Play"
+          />
+        </React.Fragment>
+      ))}
     </div>
   );
 };

--- a/packages/orbit-components/src/ButtonMobileStore/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/ButtonMobileStore/__tests__/index.test.tsx
@@ -17,6 +17,7 @@ describe("ButtonMobileStore", () => {
     const link = screen.getByRole("link");
     expect(link).toHaveAttribute("href", "#");
     expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
     expect(link).toHaveAttribute("target", "_blank");
     await user.click(link);
     expect(onClick).toHaveBeenCalled();

--- a/packages/orbit-components/src/ButtonMobileStore/consts.ts
+++ b/packages/orbit-components/src/ButtonMobileStore/consts.ts
@@ -27,5 +27,3 @@ export enum LANGUAGE {
   TR = "TR",
   ZH = "ZH",
 }
-
-export const HEIGHT = "40px";

--- a/packages/orbit-components/src/ButtonMobileStore/index.tsx
+++ b/packages/orbit-components/src/ButtonMobileStore/index.tsx
@@ -1,20 +1,9 @@
 "use client";
 
 import * as React from "react";
-import styled from "styled-components";
 
-import defaultTheme from "../defaultTheme";
-import { HEIGHT, TYPE_OPTIONS, LANGUAGE } from "./consts";
+import { TYPE_OPTIONS, LANGUAGE } from "./consts";
 import type { Props, Type } from "./types";
-
-const StyledButtonMobileStore = styled.a`
-  display: inline-block;
-  height: ${HEIGHT};
-`;
-
-StyledButtonMobileStore.defaultProps = {
-  theme: defaultTheme,
-};
 
 const getSrc = (type: Type, lang: string) => {
   if (type === "appStore")
@@ -41,16 +30,17 @@ const ButtonMobileStore = ({
   };
 
   return (
-    <StyledButtonMobileStore
+    <a
+      className="inline-block h-[40px]"
       href={href}
       target="_blank"
-      rel="noopener"
+      rel="noopener noreferrer"
       onClick={onClickHandler}
       data-test={dataTest}
       id={id}
     >
-      <img srcSet={getSrc(type, lang)} height={HEIGHT} alt={alt} />
-    </StyledButtonMobileStore>
+      <img srcSet={getSrc(type, lang)} height="40px" alt={alt} />
+    </a>
   );
 };
 


### PR DESCRIPTION
FEPLT-1717

# This Pull Request meets the following criteria:

### For tailwind migrations:

- [x] Visual regression test suite has been added and run before the migration. **— This PR updates it to be more complete**
- [x] `tailwind-migration-status.yaml` file has been updated with the migrated component(s).
- [ ] Visual regression test suite has been run after the PR approval and no visual changes were identified. **— will be executed and accepted after approve, to include the new version**

The updated visual tests were not executed prior to the migration because the component migration is extremely simple.
 Storybook: https://orbit-mainframev-tw-button-mobile-store.surge.sh