### PR TITLE
chore: add jsx react to tsconfig

### DIFF
--- a/packages/orbit-components/tsconfig.json
+++ b/packages/orbit-components/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDirs": ["./src", "./.storybook"],
     "outDir": "lib",
+    "jsx": "react",
     "skipLibCheck": true,
     "noEmit": true,
     "moduleResolution": "node",


### PR DESCRIPTION
Noticed ts warnings inside stories, and added `jsx: react` to tsconfig to remove them, this does not affect the build, so it's safe and just for removing the warning. 
 Storybook: https://orbit-mainframev-chore-ts-add-jsx.surge.sh