### PR TITLE
fix(InputSelect): make root label block

### DIFF
--- a/packages/orbit-components/src/InputSelect/InputSelect.styled.ts
+++ b/packages/orbit-components/src/InputSelect/InputSelect.styled.ts
@@ -10,6 +10,7 @@ import { Field } from "../InputField";
 export const StyledLabel = styled.label<{ spaceAfter?: Props["spaceAfter"] }>`
   position: relative;
   margin-bottom: ${getSpacingToken};
+  display: block;
 `;
 
 StyledLabel.defaultProps = {


### PR DESCRIPTION
Fixes a bug in FF & Safari for `<InputSelect>` where the child widths collapse as <label> is usually inline.

When focusing on the input element of the `<InputSelect>` component, the list of options isn't clearly visible to users of: Firefox (MacOS & Windows) and Safari (MacOS) while the viewport is is >576px. I think the cause was due to the top level  <label> being inline so it's children were collapsing.