### PR TITLE
fix(Card): add missing w-full

### DIFF
--- a/packages/orbit-components/src/Card/index.tsx
+++ b/packages/orbit-components/src/Card/index.tsx
@@ -46,7 +46,7 @@ export default function Card({
     <div
       id={id}
       className={cx(
-        "font-base bg-white-normal [&>*]:border-elevation-flat-border-color [&>*:first-child]:rounded-t-normal [&>*:last-child]:rounded-b-normal [&>*:first-child]:border-t",
+        "font-base bg-white-normal [&>*]:border-elevation-flat-border-color [&>*:first-child]:rounded-t-normal [&>*:last-child]:rounded-b-normal w-full [&>*:first-child]:border-t",
         spaceAfter != null && spaceAfterClasses[spaceAfter],
       )}
       data-test={dataTest}


### PR DESCRIPTION
Quick bug fix for the Card component. Before by default was full width on main wrapper. It should always take 100% width of a parent container, so it has to be by default *width: 100%*, to avoid issues when it's used inside other components like Modal, Stack and etc. 

[Slack report
](https://skypicker.slack.com/archives/C7T7QG7M5/p1699448442326269)