### PR TITLE
fix(Card): only capture keys on expandable sections

### DIFF
--- a/packages/orbit-components/src/Card/CardSection/CardSection.ct-story.tsx
+++ b/packages/orbit-components/src/Card/CardSection/CardSection.ct-story.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+
+import RandomIdProvider from "../../OrbitProvider/RandomId/Provider";
+
+import CardSection from ".";
+
+export function CardSectionInput() {
+  return (
+    <RandomIdProvider useId={React.useId}>
+      <CardSection>
+        <input type="text" data-test="input" />
+      </CardSection>
+    </RandomIdProvider>
+  );
+}

--- a/packages/orbit-components/src/Card/CardSection/CardSection.ct.tsx
+++ b/packages/orbit-components/src/Card/CardSection/CardSection.ct.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { test, expect } from "@playwright/experimental-ct-react";
+
+import { CardSectionInput } from "./CardSection.ct-story";
+
+test.describe("interaction", () => {
+  test("typing spaces works on non-expandable sections", async ({ mount }) => {
+    const component = await mount(<CardSectionInput />);
+    const input = component.getByTestId("input");
+
+    await input.focus();
+    await input.press("Space");
+
+    expect(await input.inputValue()).toBe(" ");
+  });
+});

--- a/packages/orbit-components/src/Card/CardSection/index.tsx
+++ b/packages/orbit-components/src/Card/CardSection/index.tsx
@@ -65,7 +65,7 @@ export default function CardSection({
       tabIndex={onClick == null ? undefined : 0}
       onClick={onClick}
       // Not needed once we can use <button> or <a> like we should
-      onKeyDown={handleKeyDown(onClick)}
+      onKeyDown={onClick == null ? undefined : handleKeyDown(onClick)}
     >
       {(title != null || header != null) && expandable && (
         <button


### PR DESCRIPTION
https://skypicker.slack.com/archives/C7T7QG7M5/p1699604167098469
 Storybook: https://orbit-mainframev-oreqizer-fix-card-interaction.surge.sh