### PR TITLE
fix: update browserlist in package.json

### DIFF
--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -51,7 +51,9 @@
     "component"
   ],
   "browserslist": [
-    "extends @kiwicom/browserslist-config"
+    "extends @kiwicom/browserslist-config",
+    "iOS >= 14",
+    "Safari >= 14"
   ],
   "files": [
     "es",


### PR DESCRIPTION
This should finally fix [this issue](https://skypicker.slack.com/archives/C7T7QG7M5/p1699626858575329). Although the output is different than with `loose: false`, it still should fix it, since class properties defined in [the constructor](https://stackoverflow.com/questions/60026651/safari-unexpected-token-expected-an-opening-before-a-methods-paramet)

the screenshots of output (after vs before) 

![Screenshot 2023-11-13 at 13 51 51](https://github.com/kiwicom/orbit/assets/14054752/51ab34df-85e4-4769-a3ed-f2cba4fe19ee)
![Screenshot 2023-11-13 at 13 52 34](https://github.com/kiwicom/orbit/assets/14054752/fd591794-0487-47d3-9460-c0a0bc45f114)

 Storybook: https://orbit-mainframev-fix-browser-support.surge.sh