### PR TITLE
Fix whitespace class in InputTags

### DIFF
--- a/packages/orbit-components/src/InputField/InputTags/index.tsx
+++ b/packages/orbit-components/src/InputField/InputTags/index.tsx
@@ -55,7 +55,7 @@ const InputTags = ({ children }: { children: React.ReactNode }) => {
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div
         className={cx(
-          "white-space-nowrap overflow-x-scroll",
+          "overflow-x-scroll whitespace-nowrap",
           "space-x-xs flex items-center",
           "scrollbar-none",
         )}


### PR DESCRIPTION
There was a typo on the class
 Storybook: https://orbit-mainframev-inputfield-tags-fix.surge.sh