### PR TITLE
Add space-x-reverse class for rtl in InputTag

### DIFF
--- a/packages/orbit-components/src/InputField/InputTags/index.tsx
+++ b/packages/orbit-components/src/InputField/InputTags/index.tsx
@@ -56,7 +56,7 @@ const InputTags = ({ children }: { children: React.ReactNode }) => {
       <div
         className={cx(
           "overflow-x-scroll whitespace-nowrap",
-          "space-x-xs flex items-center",
+          "space-x-xs flex items-center rtl:space-x-reverse",
           "scrollbar-none",
         )}
         ref={tagsRef}


### PR DESCRIPTION
The `rtl:space-x-reverse` class was missing so that spacing is correctly applied on RTL
 Storybook: https://orbit-mainframev-input-field-missing-rtl-spacing-class.surge.sh