### PR TITLE
chore: fix changelog for 11.0.0

### DIFF
--- a/docs/src/data/log.md
+++ b/docs/src/data/log.md
@@ -44,7 +44,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     The `readOnly` prop was passed directly to the native HTML select element as an
     attribute, which is not supported.
 
-> The attribute is not supported or relevant to <select> or input types that ...
+> The attribute is not supported or relevant to select or input types that ...
 
 https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly
 

--- a/packages/orbit-components/CHANGELOG.md
+++ b/packages/orbit-components/CHANGELOG.md
@@ -47,7 +47,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 The `readOnly` prop was passed directly to the native HTML select element as an
 attribute, which is not supported.
 
-> The attribute is not supported or relevant to <select> or input types that ...
+> The attribute is not supported or relevant to select or input types that ...
 
 https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly
 * **Separator:** 'color' prop now accepts Tailwind classname instead of a token,


### PR DESCRIPTION
The usage of `<select>` (as text) was [breaking the Gatsby build](https://github.com/kiwicom/orbit/actions/runs/6892312173/job/18749293540). This changes to not include the brackets `<>`.
 Storybook: https://orbit-mainframev-fix-changelog-11-0-0.surge.sh