### PR TITLE
chore: update contributors

### DIFF
--- a/docs/plugins/contributors/fetchedUsers.json
+++ b/docs/plugins/contributors/fetchedUsers.json
@@ -420,18 +420,18 @@
     "github": "https://github.com/williamkolmacka"
   },
   {
-    "id": 5772786,
+    "id": 129299274,
     "name": null,
-    "username": "majlan",
+    "username": "jozef-mikusinec-kiwicom",
     "error": "",
-    "twitter": "milanseitler",
-    "website": "seitler.cz",
-    "info": "Designer & ex-developer",
+    "twitter": null,
+    "website": "",
+    "info": null,
     "core": false,
     "active": false,
     "dribble": "",
-    "avatar_url": "https://avatars.githubusercontent.com/u/5772786?v=4",
+    "avatar_url": "https://avatars.githubusercontent.com/u/129299274?v=4",
     "position": "",
-    "github": "https://github.com/majlan"
+    "github": "https://github.com/jozef-mikusinec-kiwicom"
   }
 ]


### PR DESCRIPTION
- Automatically generated PR on 2023-11-24.
- Updates contributors for docs
 Storybook: https://orbit-mainframev-docs-update-contributors.surge.sh