### PR TITLE
fix(Popover): links inside tooltips inside content are now clickable

### DIFF
--- a/packages/orbit-components/src/Popover/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Popover/__tests__/index.test.tsx
@@ -107,4 +107,39 @@ describe("Popover", () => {
     if (overlay) await user.click(overlay);
     expect(screen.queryByTestId("dialog")).not.toBeInTheDocument();
   });
+
+  it("should allow interacting with nested elements", async () => {
+    const nestedOnClick = jest.fn();
+    const contentOnClick = jest.fn();
+
+    render(
+      <Popover
+        content={
+          <>
+            <Tooltip
+              content={
+                <Button dataTest="nested-button" onClick={nestedOnClick}>
+                  Nested button
+                </Button>
+              }
+            >
+              <span data-test="tooltip-trigger">Hover me</span>
+            </Tooltip>
+            <Button dataTest="content-button" onClick={contentOnClick}>
+              Content button
+            </Button>
+          </>
+        }
+      >
+        <Button dataTest="popover-trigger">Open popover</Button>
+      </Popover>,
+    );
+
+    await user.click(screen.getByTestId("popover-trigger"));
+    await user.click(screen.getByTestId("tooltip-trigger"));
+    await user.click(screen.getByTestId("nested-button"));
+    expect(nestedOnClick).toHaveBeenCalled();
+    await user.click(screen.getByTestId("content-button"));
+    expect(contentOnClick).toHaveBeenCalled();
+  });
 });

--- a/packages/orbit-components/src/Popover/components/ContentWrapper.tsx
+++ b/packages/orbit-components/src/Popover/components/ContentWrapper.tsx
@@ -116,9 +116,13 @@ const PopoverContentWrapper = ({
     };
   }, [update, actions, setActionsHeight, onClose]);
 
-  useClickOutside(content, ev => {
-    if (isLargeMobile) onClose(ev);
-  });
+  useClickOutside(
+    content,
+    ev => {
+      if (isLargeMobile) onClose(ev);
+    },
+    "click",
+  );
 
   const cssVars = {
     "--popper-top": popper.top,

--- a/packages/orbit-components/src/hooks/useClickOutside/index.ts
+++ b/packages/orbit-components/src/hooks/useClickOutside/index.ts
@@ -5,7 +5,7 @@ import useEventListener from "../useEventListener";
 const useClickOutside = <T extends HTMLElement>(
   ref: React.RefObject<T>,
   handler: (ev: MouseEvent) => void,
-  mouseEvent: "mousedown" | "mouseup" = "mousedown",
+  mouseEvent: "mousedown" | "mouseup" | "click" = "mousedown",
 ): void => {
   useEventListener(mouseEvent, event => {
     const el = ref?.current;


### PR DESCRIPTION
The outside click hook was triggering the close before the event was captured by interactable components. This was changed just for the Popover, so no breaking behavior should occur.

[FEPLT-1841](https://kiwicom.atlassian.net/browse/FEPLT-1841)

[FEPLT-1841]: https://kiwicom.atlassian.net/browse/FEPLT-1841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
 Storybook: https://orbit-mainframev-fix-clik-outside-popup-with-link.surge.sh