### PR TITLE
Timeline: fixing multiple requests

### DIFF
--- a/packages/orbit-components/src/Timeline/README.md
+++ b/packages/orbit-components/src/Timeline/README.md
@@ -1,12 +1,12 @@
 # Timeline
 
-To implement Timeline component into your project you'll need to add the import:
+To implement the `Timeline` component into your project you'll need to add the import:
 
 ```jsx
 import Timeline, { TimelineStep } from "@kiwicom/orbit-components/lib/Timeline";
 ```
 
-After adding import into your project you can use it simply like:
+After adding import to your project you can use it simply like:
 
 ```jsx
 <Timeline>
@@ -18,7 +18,7 @@ After adding import into your project you can use it simply like:
 
 ## Props
 
-Table below contains all types of the props available in the **Timeline** component.
+The table below contains all types of props available in the **Timeline** component.
 
 | Name         | Type                | Default | Description                                                                                                                                                     |
 | :----------- | :------------------ | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -38,15 +38,15 @@ import TimelineStep from "@kiwicom/orbit-components/lib/Timeline/TimelineStep";
 
 #### Props
 
-Table below contains all types of the props in **TimelineStep** component.
+The table below contains all types of the props in **TimelineStep** component.
 
-| Name         | Type            | Default | Description                          |
-| :----------- | :-------------- | :------ | :----------------------------------- |
-| **children** | `React.Node`    |         | The content of the component         |
-| label        | `React.Node`    |         | Text for `label` component inside    |
-| subLabel     | `React.Node`    |         | Text for `subLabel` component inside |
-| type         | [`enum`](#enum) |         | Type of current process step         |
-| active       | `boolean`       |         | Controlled state of the step         |
+| Name         | Type            | Default | Description                                 |
+| :----------- | :-------------- | :------ | :------------------------------------------ |
+| **children** | `React.Node`    |         | Optional. The content of the `TimelineStep` |
+| label        | `React.Node`    |         | Text for `label` component inside.          |
+| subLabel     | `React.Node`    |         | Text for `subLabel` component inside.       |
+| type         | [`enum`](#enum) |         | Type of current process step.               |
+| active       | `boolean`       |         | Controlled state of the step.               |
 
 ### enum
 

--- a/packages/orbit-components/src/Timeline/README.md
+++ b/packages/orbit-components/src/Timeline/README.md
@@ -20,13 +20,13 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the **Timeline** component.
 
-| Name         | Type                | Default | Description                                                                                                                                                    |
-| :----------- | :------------------ | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **children** | `React.Node`        |         | List of [`TimelineStep`](#TimelineStep) components                                                                                                             |
-| dataTest     | `string`            |         | Optional prop for testing purposes.                                                                                                                            |
-| id           | `string`            |         | Set `id` for `Timeline`                                                                                                                                        |
-| spaceAfter   | `enum`              |         | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken) |
-| direction    | `"column" \| "row"` |         | Allows to set direction, by default on desktop is `row` and on mobile is set to `column`                                                                       |
+| Name         | Type                | Default | Description                                                                                                                                                     |
+| :----------- | :------------------ | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **children** | `React.Node`        |         | List of [`TimelineStep`](#TimelineStep) components.                                                                                                             |
+| dataTest     | `string`            |         | Optional prop for testing purposes.                                                                                                                             |
+| id           | `string`            |         | Set `id` for `Timeline`.                                                                                                                                        |
+| spaceAfter   | `enum`              |         | Additional `margin-bottom` after component. [See this docs](https://github.com/kiwicom/orbit/tree/master/packages/orbit-components/src/common/getSpacingToken). |
+| direction    | `"column" \| "row"` |         | Allows to set direction, by default on desktop is `row` and on mobile is set to `column`.                                                                       |
 
 ## Subcomponents
 

--- a/packages/orbit-components/src/Timeline/Timeline.stories.tsx
+++ b/packages/orbit-components/src/Timeline/Timeline.stories.tsx
@@ -45,6 +45,17 @@ export const Default = () => {
   );
 };
 
+export const DefaultWithOptionalChildren = () => {
+  return (
+    <Timeline>
+      <TimelineStep label="Waiting for your passport or ID details" type="success" />
+      <TimelineStep label="Waiting for check-in" />
+      <TimelineStep label="Processing check-in" />
+      <TimelineStep label="Boarding pass ready" />
+    </Timeline>
+  );
+};
+
 export const AllSuccessfull = () => {
   return (
     <Timeline>

--- a/packages/orbit-components/src/Timeline/Timeline.stories.tsx
+++ b/packages/orbit-components/src/Timeline/Timeline.stories.tsx
@@ -38,7 +38,7 @@ export const Default = () => {
       <TimelineStep label="Carrier is refunding" subLabel="6th May 20:50">
         The carrier has sent us a refund. There might be more depending on their policy.
       </TimelineStep>
-      <TimelineStep label="Refunded" subLabel="7th May 10:30">
+      <TimelineStep label="Refunded">
         We’ll forward you all refunds from the carrier(s) after we receive it.
       </TimelineStep>
     </Timeline>

--- a/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepDesktop.tsx
+++ b/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepDesktop.tsx
@@ -42,13 +42,11 @@ const TimelineStepDesktop = ({
 }: Props) => {
   return (
     <Stack inline shrink direction="column" align="center" spaceAfter="large">
-      {subLabel && (
-        <StyledText>
-          <Text align="center" size="small">
-            {subLabel}
-          </Text>
-        </StyledText>
-      )}
+      <StyledText>
+        <Text align="center" size="small">
+          {subLabel}
+        </Text>
+      </StyledText>
       <StyledRelative inner>
         <StyledProgressLine desktop status={type} prevStatus={prevType} nextStatus={nextType} />
         <TypeIcon type={type} active={!!active} />

--- a/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepDesktop.tsx
+++ b/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepDesktop.tsx
@@ -64,9 +64,11 @@ const TimelineStepDesktop = ({
             {label}
           </Text>
         </StyledText>
-        <StyledDescription active={active || (last && type === "success")}>
-          <Text align="center">{children}</Text>
-        </StyledDescription>
+        {children && (
+          <StyledDescription active={active || (last && type === "success")}>
+            <Text align="center">{children}</Text>
+          </StyledDescription>
+        )}
       </Stack>
     </Stack>
   );

--- a/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepDesktop.tsx
+++ b/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepDesktop.tsx
@@ -41,7 +41,7 @@ const TimelineStepDesktop = ({
   subLabel,
 }: Props) => {
   return (
-    <Stack inline shrink direction="column" align="center" spaceAfter="large">
+    <Stack inline shrink direction="column" align="center">
       <StyledText>
         <Text align="center" size="small">
           {subLabel}

--- a/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepMobile.tsx
+++ b/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepMobile.tsx
@@ -16,7 +16,12 @@ interface Props extends StepProps {
 const TimelineStepMobile = ({ type, subLabel, label, nextType, children, active, last }: Props) => {
   return (
     <StyledRelative>
-      <Stack flex spaceAfter="large" align="stretch" desktop={{ align: "start" }}>
+      <Stack
+        flex
+        spaceAfter={last ? undefined : "large"}
+        align="stretch"
+        desktop={{ align: "start" }}
+      >
         <TypeIcon type={type} active={!!active} mobile />
         {!last && <StyledProgressLine status={nextType} prevStatus={type} />}
         <Stack flex shrink direction="column" spacing="XXSmall">

--- a/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepMobile.tsx
+++ b/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepMobile.tsx
@@ -30,9 +30,11 @@ const TimelineStepMobile = ({ type, subLabel, label, nextType, children, active,
               </StyledText>
             )}
           </Stack>
-          <StyledText active={active || (last && type === "success")}>
-            <Text>{children}</Text>
-          </StyledText>
+          {children && (
+            <StyledText active={active || (last && type === "success")}>
+              <Text>{children}</Text>
+            </StyledText>
+          )}
         </Stack>
       </Stack>
     </StyledRelative>

--- a/packages/orbit-components/src/Timeline/TimelineStep/index.js.flow
+++ b/packages/orbit-components/src/Timeline/TimelineStep/index.js.flow
@@ -3,7 +3,7 @@ import * as React from "react";
 
 export type Type = "success" | "warning" | "critical" | "info";
 export type Props = {|
-  +children: React.Node,
+  +children?: React.Node,
   +subLabel?: React.Node,
   +label: React.Node,
   +active?: boolean,

--- a/packages/orbit-components/src/Timeline/TimelineStep/primitives/StyledText.ts
+++ b/packages/orbit-components/src/Timeline/TimelineStep/primitives/StyledText.ts
@@ -1,12 +1,16 @@
 import styled, { css } from "styled-components";
 
 import defaultTheme from "../../../defaultTheme";
+import mq from "../../../utils/mediaQuery";
 
 const StyledText = styled.div<{ active?: boolean }>`
   ${({ theme, active }) => css`
     > p {
       color: ${active ? theme.orbit.paletteInkDark : theme.orbit.paletteInkLight};
     }
+    ${mq.desktop(css`
+      min-height: ${theme.orbit.spaceMedium};
+    `)};
   `};
 `;
 

--- a/packages/orbit-components/src/Timeline/TimelineStep/types.d.ts
+++ b/packages/orbit-components/src/Timeline/TimelineStep/types.d.ts
@@ -7,7 +7,7 @@ import type * as Common from "../../common/types";
 
 export type Type = "success" | "warning" | "critical" | "info";
 export interface Props extends Common.Globals, Common.SpaceAfter {
-  readonly children: React.ReactNode;
+  readonly children?: React.ReactNode;
   readonly label: React.ReactNode;
   readonly subLabel?: React.ReactNode;
   readonly active?: boolean;


### PR DESCRIPTION
Recently we got several requests regarding `Timeline`. They are quite small, so I resolved all of them in a single PR 

This PR gives a solution to these requests: 
- redundant margins in `TimelineStep` with `spaceAfter` prop, removed for Desktop, for Mobile only the last one.  ([request](https://skypicker.slack.com/archives/C7T7QG7M5/p1699366523532359))
- optional children in `TimelineStep` ([request](https://skypicker.slack.com/archives/C7T7QG7M5/p1700837336908099),  [FEPLT-1840](https://kiwicom.atlassian.net/browse/FEPLT-1840)) 
- height issue with desktop `Timeline`, when there are no one or more `subLabel` props ([request](https://skypicker.slack.com/archives/C7T7QG7M5/p1701691187175999)) 

[FEPLT-1840]: https://kiwicom.atlassian.net/browse/FEPLT-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
 Storybook: https://orbit-mainframev-fix-timeline-issue.surge.sh