### PR TITLE
Make "smallMobile" of the Hide component hide stuff on screens of size 0-320px

### DIFF
--- a/docs/src/documentation/03-components/12-layout/layout/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/12-layout/layout/01-guidelines.mdx
@@ -15,8 +15,6 @@ To choose the best component for your use case, see our [developing layouts guid
 
 ## When not to use
 
-- For content only on large screens---use a [desktop component](/components/responsive/desktop/).
-- For content only on small screens---use a [Mobile component](/components/responsive/mobile/).
 - For more control over what appears on different screen sizes---use a
   [Hide component](/components/responsive/hide/).
 

--- a/docs/src/documentation/03-components/13-responsive/hide/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/13-responsive/hide/01-guidelines.mdx
@@ -13,11 +13,6 @@ import ResponsiveDontHideEssentialSnippet from "snippets/responsive-dont-hide-es
 
 - To control what content appears on what screens.
 
-## When not to use
-
-- For content only on large screens---use a [Desktop component](/components/responsive/desktop/).
-- For content only on small screens---use a [Mobile component](/components/responsive/mobile/).
-
 ## Component status
 
 <ComponentStatus component="Hide" />

--- a/docs/src/documentation/03-components/14-utility/truncate/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/14-utility/truncate/01-guidelines.mdx
@@ -17,8 +17,6 @@ redirect_from:
 
 - For more control over what appears on different screen sizes---use a
   [Hide component](/components/responsive/hide/).
-- For content only on small screens---use a [Mobile component](/components/responsive/mobile/).
-- For content only on large screens---use a [Desktop component](/components/responsive/desktop/).
 
 ## Component status
 

--- a/packages/orbit-components/src/Hide/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Hide/__tests__/index.test.tsx
@@ -12,7 +12,7 @@ describe("Hide", () => {
     );
     expect(container.childNodes[1]).toMatchInlineSnapshot(`
       <div
-        class="inline-block sm:max-mm:hidden lm:max-tb:hidden ld:hidden"
+        class="inline-block max-mm:hidden lm:max-tb:hidden ld:hidden"
       >
         content
       </div>

--- a/packages/orbit-components/src/Hide/index.tsx
+++ b/packages/orbit-components/src/Hide/index.tsx
@@ -8,7 +8,7 @@ import type { Props } from "./types";
 const Hide = ({ on = [], block, children }: Props) => (
   <div
     className={cx(block ? "block" : "inline-block", {
-      "sm:max-mm:hidden": on.includes("smallMobile"),
+      "max-mm:hidden": on.includes("smallMobile"),
       "mm:max-lm:hidden": on.includes("mediumMobile"),
       "lm:max-tb:hidden": on.includes("largeMobile"),
       "tb:max-de:hidden": on.includes("tablet"),

--- a/packages/orbit-components/src/deprecated/Desktop/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/deprecated/Desktop/__tests__/index.test.tsx
@@ -8,7 +8,7 @@ describe("Desktop", () => {
     render(<Desktop>kek</Desktop>);
     expect(screen.getByText("kek")).toMatchInlineSnapshot(`
       <div
-        class="inline-block sm:max-mm:hidden mm:max-lm:hidden lm:max-tb:hidden tb:max-de:hidden"
+        class="inline-block max-mm:hidden mm:max-lm:hidden lm:max-tb:hidden tb:max-de:hidden"
       >
         kek
       </div>


### PR DESCRIPTION
"smallMobile" is the smallest screen size that Orbit recognizes. It ought to hide everything for screens of size 0px - 413px.

The alternative would be to add a new screen size smaller than "smallMobile".

Also removes deprecated components Desktop and Mobile from docs
 Storybook: https://orbit-mainframev-jozef-hide-small-mobile.surge.sh