### PR TITLE
fix(Popover): remove redundant max-w-fit class

### DIFF
--- a/packages/orbit-components/src/Popover/components/ContentWrapper.tsx
+++ b/packages/orbit-components/src/Popover/components/ContentWrapper.tsx
@@ -144,8 +144,7 @@ const PopoverContentWrapper = ({
           "fixed",
           "inset-x-0 top-0",
           "h-full w-full",
-          // TODO: use bg-ink-dark/60 tw class
-          "bg-[rgba(37,42,49,.6)]",
+          "bg-ink-dark/60",
           "duration-normal transition-[opacity,transform] ease-in-out",
           "z-[999]",
           "lm:hidden",

--- a/packages/orbit-components/src/Popover/index.tsx
+++ b/packages/orbit-components/src/Popover/index.tsx
@@ -150,7 +150,7 @@ const Popover = ({
   return (
     <>
       <div
-        className="relative max-w-fit"
+        className="relative inline-block"
         ref={ref}
         role="button"
         // https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/C04HMMQ6VNE/p1701938825267999). It wasn't present in the component before and caused bug, so I think better will be to remove `max-w-fit`. 
 Storybook: https://orbit-mainframev-fix-popover-issues-reported.surge.sh
 
 Giving solution to [FEPLT-1865](https://kiwicom.atlassian.net/browse/FEPLT-1865)


[FEPLT-1865]: https://kiwicom.atlassian.net/browse/FEPLT-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ