### PR TITLE
fix(ButtonPrimitive): do not force icon sizes in children

### DIFF
--- a/packages/orbit-components/src/primitives/ButtonPrimitive/sizes.ts
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/sizes.ts
@@ -1,9 +1,9 @@
 import type { Size } from "./types";
 
 export const sizeStyles: Record<Size, string> = {
-  small: "h-form-box-small text-small [&_svg]:h-icon-small [&_svg]:w-icon-small",
-  normal: "h-form-box-normal text-normal [&_svg]:h-icon-medium [&_svg]:w-icon-medium",
-  large: "h-form-box-large text-large [&_svg]:h-icon-large [&_svg]:w-icon-large",
+  small: "h-form-box-small text-small",
+  normal: "h-form-box-normal text-normal",
+  large: "h-form-box-large text-large",
 };
 
 export const paddingNoIconsStyles: Record<Size, string> = {


### PR DESCRIPTION
Removed enforcing of icon sizes in `ButtonPrimitive` 

icon sizes for props `iconLeft` and `iconRight` are regulated by `size` prop of `ButtonPrimitive` 

icons in children should be controlled by their size prop individually as it was before, otherwise, it leads to bugs, like reported [here](https://skypicker.slack.com/archives/C04HMMQ6VNE/p1701938430885789) 
 Storybook: https://orbit-mainframev-fix-button-primitive-with-icons.surge.sh
 
 Giving solution to [FEPLT-1869
](https://kiwicom.atlassian.net/browse/FEPLT-1869)
