### PR TITLE
fix(Drawer): noPadding should affect only wrapper

### DIFF
--- a/packages/orbit-components/src/Drawer/Drawer.stories.tsx
+++ b/packages/orbit-components/src/Drawer/Drawer.stories.tsx
@@ -29,9 +29,11 @@ export const SideNavigation = () => {
   const dataTest = text("dataTest", "test");
   const width = text("width", "320px");
   const fixedHeader = boolean("fixedHeader", false);
+  const noPadding = boolean("noPadding", false);
 
   return (
     <Drawer
+      noPadding={noPadding}
       dataTest={dataTest}
       width={width}
       shown={shown}

--- a/packages/orbit-components/src/Drawer/index.tsx
+++ b/packages/orbit-components/src/Drawer/index.tsx
@@ -140,7 +140,7 @@ const Drawer = ({
               fixedHeader && "z-sticky sticky top-0",
               onlyIcon ? "justify-end" : "justify-between",
               bordered && "border-cloud-normal border-x-0 border-b border-t-0 border-solid",
-              !noPadding && "px-md lm:ps-xl lm:pe-lg py-0",
+              "px-md lm:ps-xl lm:pe-lg py-0",
             )}
           >
             {title && <Heading type="title2">{title}</Heading>}


### PR DESCRIPTION
As we agreed to return it as it was before, because it's just easier and won't require any hack for users to resolve the visual bug in `title` 
 Storybook: https://orbit-mainframev-fix-drawer-padding.surge.sh