### PR TITLE
chore: use exact versions of tokens and tailwind

### DIFF
--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -78,8 +78,8 @@
     "styled-components": "^5"
   },
   "dependencies": {
-    "@kiwicom/orbit-design-tokens": "^6.3.1",
-    "@kiwicom/orbit-tailwind-preset": "^3.1.0",
+    "@kiwicom/orbit-design-tokens": "6.3.1",
+    "@kiwicom/orbit-tailwind-preset": "3.1.0",
     "@popperjs/core": "^2.9.2",
     "clsx": "^2.0.0",
     "color2k": "^2.0.2",


### PR DESCRIPTION
Just removed carrots to avoid situations like [this](https://skypicker.slack.com/archives/C05FDP4UM3N/p1702547609300429?thread_ts=1702460689.042279&cid=C05FDP4UM3N) , when there is a available higher versions 
 of let's say tokens package and it has some unspotted breaking change(
 
 Storybook: https://orbit-mainframev-chore-use-exact-versions.surge.sh