### PR TITLE
fix(OrbitProvider): be more defensive when transforming palette color…

### DIFF
--- a/packages/orbit-components/src/OrbitProvider/index.tsx
+++ b/packages/orbit-components/src/OrbitProvider/index.tsx
@@ -2,9 +2,8 @@
 
 import * as React from "react";
 import { ThemeProvider as StyledThemeProvider } from "styled-components";
-import { tokensToCssVars } from "@kiwicom/orbit-design-tokens";
+import { tokensToCssVars, defaultTokens } from "@kiwicom/orbit-design-tokens";
 import { parseToRgba } from "color2k";
-import type { defaultTokens } from "@kiwicom/orbit-design-tokens";
 
 import QueryContextProvider from "./QueryContext/Provider";
 import RandomIdProvider from "./RandomId/Provider";
@@ -14,9 +13,18 @@ import type { Props } from "./types";
 const getCssVarsForWL = (theme: typeof defaultTokens) =>
   Object.keys(theme).reduce((acc, key) => {
     if (key.startsWith("palette")) {
-      acc[key] = parseToRgba(theme[key] as string)
-        .slice(0, -1)
-        .join(", ");
+      try {
+        acc[key] = parseToRgba(theme[key] as string)
+          .slice(0, -1)
+          .join(", ");
+      } catch (e) {
+        console.error(
+          "OrbitProvider-getCssVarsForWL: couldn't parse palette color, using fallback value from defaultTheme",
+          key,
+          e,
+        );
+        acc[key] = parseToRgba(defaultTokens[key]).slice(0, -1).join(", ");
+      }
     }
     return acc;
   }, {});


### PR DESCRIPTION
…s to RGBA

There was an issue that some input colors had extraneous spaces by mistake, which caused color2k's toRgba function to throw an exception.

# This Pull Request meets the following criteria:

### For tailwind migrations:

- [ ] Visual regression test suite has been added and run before the migration.
- [ ] `tailwind-migration-status.yaml` file has been updated with the migrated component(s).
- [ ] Visual regression test suite has been run after the PR approval and no visual changes were identified.

### For new components:

- [ ] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have both `.flow` and `d.ts` files and are exported in `index.js.flow` and `index.d.ts`

 Storybook: https://orbit-mainframev-rcsl-try-catch-color2k.surge.sh