### PR TITLE
fix(Itinerary): some text wasn't truncating properly

### DIFF
--- a/packages/orbit-components/src/Itinerary/ItineraryTemporaryText/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItineraryTemporaryText/index.tsx
@@ -45,6 +45,7 @@ const TemporaryText = ({
 }: TextProps) => {
   return (
     <StyledTemporaryText
+      className="orbit-text"
       $type={type}
       size={size}
       weight={weight}


### PR DESCRIPTION
Truncate component was only targeting text and heading classes, not contemplating the TemporaryText styled component.

Reported [here](https://skypicker.slack.com/archives/C7T7QG7M5/p1702566892095489).
 Storybook: https://orbit-mainframev-fix-temporary-text-truncate.surge.sh