### PR TITLE
fix(ButtonPrimitive): add missing shrink-0 and grow-0

### DIFF
--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.tsx
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.tsx
@@ -160,6 +160,7 @@ const ButtonPrimitive = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, 
         className={cx(
           className,
           "orbit-button-primitive font-base duration-fast group relative max-w-full items-center border-none text-center leading-none transition-all [&>*]:align-middle [&_.orbit-loading-spinner]:stroke-[currentColor]",
+          "flex-none",
           fullWidth && "w-full",
           centered || children == null
             ? "justify-center"


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/C7T7QG7M5/p1699451085622079) 
Before migration to Tailwind `ButtonPrimitive` had `flex: 0 0 auto` 

Added a small story to replicate the behavior, where you can see that it's fixed 

Giving solution to [FEPLT-1804](https://kiwicom.atlassian.net/browse/FEPLT-1804)



[FEPLT-1804]: https://kiwicom.atlassian.net/browse/FEPLT-1804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
 Storybook: https://orbit-mainframev-fix-button-missing-flex-and-shrink.surge.sh