### PR TITLE
docs: fix table style after tw migration

### DIFF
--- a/docs/src/docs-table.tsx
+++ b/docs/src/docs-table.tsx
@@ -40,7 +40,6 @@ const sortingIcon = (sortingStatus: SORTING_ORDER) => {
 const TableWrap = styled.div`
   ${({ theme }) => css`
     table {
-      td,
       th {
         background-color: ${theme.orbit.paletteCloudLight};
         text-align: left;
@@ -327,7 +326,7 @@ const PropsTable = ({ children }) => {
     <StyledTableOuter ref={outer} showShadows={shadows} showLeft={left} showRight={right}>
       <StyledTableInner ref={inner} onScroll={handleScroll} showShadows={shadows}>
         <TableWrap ref={tableWrap}>
-          <Table type="primary">
+          <Table type="primary" striped={false}>
             <PropsTableHead
               tableHeaders={tableHeaders}
               handleSortingChange={handleSortingChange}


### PR DESCRIPTION
Some style selectors were introduced during the migration to Tailwind. This PR adjusts that selector and avoid the `striped` default style (that was previously being overwritten via styles).
 Storybook: https://orbit-mainframev-docs-fix-table.surge.sh

[FEPLT-1820](https://kiwicom.atlassian.net/browse/FEPLT-1820)

[FEPLT-1820]: https://kiwicom.atlassian.net/browse/FEPLT-1820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ