### PR TITLE
fix(tailwind): set disablePreflight to false by default

### DIFF
--- a/packages/orbit-tailwind-preset/src/presets/__tests__/__snapshots__/configs.test.ts.snap
+++ b/packages/orbit-tailwind-preset/src/presets/__tests__/__snapshots__/configs.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`orbitPreset should match snapshot 1`] = `
+exports[`orbitPreset should have preflight disabled 1`] = `
 {
   "blocklist": [],
   "content": {

--- a/packages/orbit-tailwind-preset/src/presets/__tests__/configs.test.ts
+++ b/packages/orbit-tailwind-preset/src/presets/__tests__/configs.test.ts
@@ -3,14 +3,19 @@ import resolveConfig from "tailwindcss/resolveConfig";
 import orbitPreset from "../..";
 
 describe("orbitPreset", () => {
-  it("should match snapshot", () => {
-    const cfg = resolveConfig(orbitPreset());
+  it("should have preflight disabled", () => {
+    const cfg = resolveConfig(orbitPreset({ disablePreflight: true }));
     expect(cfg).toMatchSnapshot();
     expect(cfg.corePlugins).not.toContain("preflight");
   });
 
   it("should have preflight enabled", () => {
     const config = resolveConfig(orbitPreset({ disablePreflight: false }));
+    expect(config.corePlugins).toContain("preflight");
+  });
+
+  it("should have enabled by default", () => {
+    const config = resolveConfig(orbitPreset());
     expect(config.corePlugins).toContain("preflight");
   });
 });

--- a/packages/orbit-tailwind-preset/src/presets/components/index.ts
+++ b/packages/orbit-tailwind-preset/src/presets/components/index.ts
@@ -76,7 +76,7 @@ const getBackgroundColors = (tokens: typeof defaultTokens) => {
 };
 
 const cfg = (options?: Options): Config => {
-  const { disablePreflight = true } = options || {};
+  const { disablePreflight = false } = options || {};
   // make palette colors (foundation colors) defined as css vars and make components tokens inherit it
   const tokens = getTokens(cssVarsFoundation);
   const componentTokens = getComponentLevelTokens(tokens);
@@ -85,7 +85,7 @@ const cfg = (options?: Options): Config => {
     content: ["auto"],
     presets: [orbitFoundationPreset(tokens)],
     corePlugins: {
-      preflight: disablePreflight ? false : undefined,
+      preflight: !disablePreflight,
     },
     theme: {
       extend: {


### PR DESCRIPTION
As stated questioned [here](https://skypicker.slack.com/archives/C05FDP4UM3N/p1702999264540639) and stated [here](https://github.com/kiwicom/orbit/blob/master/packages/orbit-tailwind-preset/README.md), it should be by default `false` 
 Storybook: https://orbit-mainframev-fix-tailwind-preflight-def.surge.sh