### PR TITLE
docs: fix icons list story

### DIFF
--- a/packages/orbit-components/src/Icon/IconList.tsx
+++ b/packages/orbit-components/src/Icon/IconList.tsx
@@ -14,6 +14,7 @@ const List = styled.div`
 const Container = styled.div`
   display: flex;
   flex-direction: row;
+  gap: ${defaultTokens.spaceLarge};
   justify-content: flex-start;
   align-items: center;
   align-content: center;
@@ -24,7 +25,7 @@ const Container = styled.div`
   border-radius: ${defaultTokens.borderRadiusLarge};
   border: ${defaultTokens.borderWidthCard} ${defaultTokens.borderStyleCard}
     ${defaultTokens.paletteCloudNormal};
-  padding-right: ${defaultTokens.spaceLarge};
+  padding: 0 ${defaultTokens.spaceLarge};
 `;
 
 const IconImport = styled.div`
@@ -43,10 +44,7 @@ const IconList = () => (
     {Object.keys(Icons)
       .filter(n => n !== "__namedExportsOrder")
       .map(icon => {
-        const Icon = styled(Icons[icon])`
-          padding: 0 ${defaultTokens.spaceLarge};
-          flex-shrink: 0;
-        `;
+        const Icon = Icons[icon];
 
         const iconName = `${icon}`;
         return (


### PR DESCRIPTION
The Icon list story was broken. This PR fixes that

**Before:**
<img width="975" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/0752a6bf-a1f5-4019-af72-4201c04f6983">

**Now:**
<img width="975" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/86a8e514-2133-4bf8-84bc-1b73faee0236">

 Storybook: https://orbit-mainframev-docs-fix-icons-list.surge.sh