### PR TITLE
fix(Layout): get back negative margins on Mobile in LayoutColumn

### DIFF
--- a/packages/orbit-components/src/Card/index.tsx
+++ b/packages/orbit-components/src/Card/index.tsx
@@ -46,7 +46,7 @@ export default function Card({
     <div
       id={id}
       className={cx(
-        "font-base bg-white-normal [&>*]:border-elevation-flat-border-color [&>*:first-child]:rounded-t-normal [&>*:last-child]:rounded-b-normal w-full [&>*:first-child]:border-t",
+        "orbit-card font-base bg-white-normal [&>*]:border-elevation-flat-border-color [&>*:first-child]:rounded-t-normal [&>*:last-child]:rounded-b-normal w-full [&>*:first-child]:border-t",
         spaceAfter != null && spaceAfterClasses[spaceAfter],
       )}
       data-test={dataTest}

--- a/packages/orbit-components/src/Layout/LayoutColumn/index.tsx
+++ b/packages/orbit-components/src/Layout/LayoutColumn/index.tsx
@@ -6,11 +6,11 @@ import styled, { css } from "styled-components";
 import defaultTheme from "../../defaultTheme";
 import type { Props } from "./types";
 import type { Devices } from "../../utils/mediaQuery/types";
-import { DEVICES } from "../../utils/mediaQuery/consts";
-import mq from "../../utils/mediaQuery";
+import { DEVICES, QUERIES } from "../../utils/mediaQuery/consts";
+import mq, { getBreakpointWidth } from "../../utils/mediaQuery";
 
 const StyledColumn = styled.div<{ spanEntireRow?: boolean; hideOn: Devices[] }>`
-  ${({ spanEntireRow, hideOn }) => css`
+  ${({ spanEntireRow, hideOn, theme }) => css`
     ${Boolean(hideOn) &&
     hideOn.length > 0 &&
     Object.values(DEVICES).map(viewport =>
@@ -32,6 +32,14 @@ const StyledColumn = styled.div<{ spanEntireRow?: boolean; hideOn: Devices[] }>`
     css`
       grid-column: 1 / -1;
     `};
+
+    @media (max-width: ${+getBreakpointWidth(QUERIES.LARGEMOBILE, theme, true) - 1}px) {
+      .orbit-card {
+        margin-right: -${theme.orbit.spaceMedium};
+        margin-left: -${theme.orbit.spaceMedium};
+        width: auto;
+      }
+    }
   `}
 `;
 


### PR DESCRIPTION
We used to have negative margins in the first Card inside LayoutColumn, it was applied for Mobile, to remove the Card padding and have content "full-width" on Mobile, without paddings on the sides. I guess it was an accidental breaking change and better will be to get it back, maybe it was removed during the Card migration to TW 

The Slack-related [thread](https://skypicker.slack.com/archives/C7T7QG7M5/p1701769129228689)
 Storybook: https://orbit-mainframev-fix-layout-padding.surge.sh