### PR TITLE
fix(Popover): fix max-height when content has actions

### DIFF
--- a/packages/orbit-components/src/Popover/components/ContentWrapper.tsx
+++ b/packages/orbit-components/src/Popover/components/ContentWrapper.tsx
@@ -207,7 +207,7 @@ const PopoverContentWrapper = ({
               "bottom-[var(--actions-height)]",
               windowHeight &&
                 actionsHeight &&
-                "max-h-[calc(var(--window-height)-var(--actions-height)-32)]",
+                "max-h-[calc(var(--window-height)-var(--actions-height)-32px)]",
               noPadding ? "p-0" : "p-md",
               "lm:max-h-[var(--max-height)]",
               "lm:rounded-normal",


### PR DESCRIPTION
Max height was not set at all on small devices when the content had actions,
preventing the scroll from working properly.

https://skypicker.slack.com/archives/C7T7QG7M5/p1704291076964889

 Storybook: https://orbit-mainframev-marco-fix-popover.surge.sh