### PR TITLE
fix(Breadcrumbs): remove extra top spacing on mobile

### DIFF
--- a/packages/orbit-components/src/Breadcrumbs/index.tsx
+++ b/packages/orbit-components/src/Breadcrumbs/index.tsx
@@ -22,7 +22,7 @@ const Breadcrumbs = ({
   const childEls = React.Children.toArray(children) as React.ReactElement<BreadcrumbsItemProps>[];
 
   return (
-    <>
+    <div>
       <Hide on={["smallMobile", "mediumMobile"]}>
         <nav
           className={cx("font-base text-small", spaceAfter && spaceAfterClasses[spaceAfter])}
@@ -60,7 +60,7 @@ const Breadcrumbs = ({
           </TextLink>
         ) : null}
       </Hide>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/C7T7QG7M5/p1704710523485419) and discussed [here](https://skypicker.slack.com/archives/C05FDP4UM3N/p1704715157783819?thread_ts=1704714259.984389&cid=C05FDP4UM3N). Using the div instead of Fragment avoid Stacks to add extra spacing between the two elements.
 Storybook: https://orbit-mainframev-fix-breadcrumbs-mobile-spacing.surge.sh