### PR TITLE
fix(Card): border radius incorrectly set on mobile

### DIFF
--- a/packages/orbit-components/src/Card/index.tsx
+++ b/packages/orbit-components/src/Card/index.tsx
@@ -46,7 +46,7 @@ export default function Card({
     <div
       id={id}
       className={cx(
-        "orbit-card font-base bg-white-normal [&>*]:border-elevation-flat-border-color [&>*:first-child]:rounded-t-normal [&>*:last-child]:rounded-b-normal w-full [&>*:first-child]:border-t",
+        "orbit-card font-base bg-white-normal [&>*]:border-elevation-flat-border-color lm:[&>*:first-child]:rounded-t-normal lm:[&>*:last-child]:rounded-b-normal w-full [&>*:first-child]:border-t",
         spaceAfter != null && spaceAfterClasses[spaceAfter],
       )}
       data-test={dataTest}


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/C7T7QG7M5/p1704719626364449)
 Storybook: https://orbit-mainframev-fix-Card-border-radius.surge.sh