### PR TITLE
feat(ButtonPrimitive): improve accessibility by using type and role

### DIFF
--- a/packages/orbit-components/src/primitives/ButtonPrimitive/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/__tests__/index.test.tsx
@@ -87,16 +87,15 @@ describe("ButtonPrimitive", () => {
 
   it("should behave as button", async () => {
     const children = "Lorem ipsum";
-    const dataTest = "test";
     const onClick = jest.fn();
 
     render(
-      <ButtonPrimitive dataTest={dataTest} onClick={onClick} tabIndex={0} asComponent="div">
+      <ButtonPrimitive onClick={onClick} tabIndex={0} asComponent="div">
         {children}
       </ButtonPrimitive>,
     );
 
-    const button = screen.getByTestId(dataTest);
+    const button = screen.getByRole("button");
 
     await user.tab();
     fireEvent.keyDown(button, { keyCode: 13 });

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.tsx
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.tsx
@@ -34,8 +34,7 @@ const ButtonPrimitiveComponent = React.forwardRef(function Component(
   }: ComponentProps,
   ref: React.ForwardedRef<HTMLButtonElement | HTMLAnchorElement>,
 ) {
-  const isButtonWithHref = asComponent === "button" && href;
-  const Element = isButtonWithHref ? "a" : asComponent;
+  const Element = asComponent === "button" && href ? "a" : asComponent;
   const buttonType = submit ? "submit" : "button";
 
   const handleKeyDown = (ev: React.KeyboardEvent<HTMLAnchorElement | HTMLButtonElement>) =>
@@ -50,7 +49,8 @@ const ButtonPrimitiveComponent = React.forwardRef(function Component(
       aria-expanded={ariaExpanded}
       aria-label={title}
       aria-labelledby={ariaLabelledby}
-      type={!isButtonWithHref ? buttonType : undefined}
+      type={asComponent === "button" && !href ? buttonType : undefined}
+      role={!href && onClick ? "button" : undefined}
       disabled={disabled}
       onKeyDown={handleKeyDown}
       href={!disabled ? href : null}


### PR DESCRIPTION
The problem with `type` was reported [here](https://skypicker.slack.com/archives/C7T7QG7M5/p1704728934322549) and took the opportunity to add the `role` attribute as well so that accessibility is improved.
 Storybook: https://orbit-mainframev-feat-add-type-and-role-button.surge.sh