### PR TITLE
fix(Modal): check if e.target.className exists

### DIFF
--- a/packages/orbit-components/src/Modal/index.tsx
+++ b/packages/orbit-components/src/Modal/index.tsx
@@ -204,6 +204,7 @@ const Modal = React.forwardRef<Instance, Props>(
         modalContent.current &&
         event.target instanceof Element &&
         !modalContent.current.contains(event.target) &&
+        event.target.className &&
         (event.target.className.includes("orbit-modal-wrapper") ||
           event.target.className.includes("orbit-modal-body"));
 


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/C7B5YNYHW/p1704968537274009). Not sure tbh, if this is happening somewhere not in Cypress, but added check for safety. 
 Storybook: https://orbit-mainframev-fix-modal.surge.sh