### PR TITLE
fix(Itinerary): icon sizes were incorrect inside SegmentDetail

### DIFF
--- a/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentDetail/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentDetail/index.tsx
@@ -98,11 +98,19 @@ const StyledIcon = styled.div<{ isFirst?: boolean; isLast?: boolean }>`
     align-items: center;
     position: relative;
     box-sizing: border-box;
-    padding: ${theme.orbit.spaceXXSmall};
+    padding: ${isFirst || isLast ? "0" : theme.orbit.spaceXXSmall} ${theme.orbit.spaceXXSmall};
     z-index: 3;
     svg {
-      padding-top: ${isFirst && theme.orbit.spaceXXSmall};
-      padding-bottom: ${isLast && theme.orbit.spaceXXSmall};
+      ${isFirst &&
+      `
+        margin-top: ${theme.orbit.spaceXSmall};
+        margin-bottom: ${theme.orbit.spaceXXSmall};
+      `}
+      ${isLast &&
+      `
+        margin-top: ${theme.orbit.spaceXXSmall};
+        margin-bottom: ${theme.orbit.spaceXSmall};
+      `}
     }
     &:after {
       content: "";


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/C7T7QG7M5/p1705066629203219).

Before:
<img width="224" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/401d46f4-110e-42aa-b70d-aa09cf5b8d61">

Now:
<img width="224" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/e6c67647-c880-49a2-bb84-7f409a526551">

 Storybook: https://orbit-mainframev-fix-itinerary-icon-in-segment.surge.sh