### PR TITLE
fix(Modal): remove modal header transition on mobile

### DIFF
--- a/packages/orbit-components/src/Modal/ModalHeader/index.tsx
+++ b/packages/orbit-components/src/Modal/ModalHeader/index.tsx
@@ -106,7 +106,6 @@ const ModalHeader = ({
           className={cx(
             "orbit-modal-mobile-header bg-white-normal",
             "font-base font-heading-display text-extra-large text-heading-foreground ps-lg z-overlay invisible fixed end-[48px] start-0 box-border inline-block h-[52px] truncate py-0 pe-0 leading-[52px] opacity-0",
-            "duration-fast transition-[top,opacity,visibility] ease-in-out",
             "lm:start-auto lm:end-auto lm:p-0",
             isMobileFullPage ? "top-0" : "top-[16px]",
           )}

--- a/packages/orbit-components/src/Modal/index.tsx
+++ b/packages/orbit-components/src/Modal/index.tsx
@@ -469,7 +469,6 @@ const Modal = React.forwardRef<Instance, Props>(
               scrolled
                 ? [
                     "[&_.orbit-modal-mobile-header]:visible [&_.orbit-modal-mobile-header]:opacity-100",
-                    "[&_.orbit-modal-mobile-header]:ease-in-out [&_.orbit-modal-mobile-header]:[transition:visibility_theme(transitionDuration.fast),_opacity_theme(transitionDuration.fast),_top_theme(transitionDuration.normal)]",
                     "lm:[&_.orbit-modal-mobile-header]:top-0",
                   ]
                 : "lm:[&_.orbit-modal-mobile-header]:-top-xxl",


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/C7T7QG7M5/p1705057780289579).

Before
![old](https://github.com/kiwicom/orbit/assets/6265045/7fa48749-4365-4b5e-9909-c2611f0bfcbc)

After
![after](https://github.com/kiwicom/orbit/assets/6265045/99915ad3-af34-42da-8d90-0fbdc0e49a56)

 Storybook: https://orbit-mainframev-fix-modal-modal-title-transition.surge.sh