### PR TITLE
docs: fix Popover example with missing OrbitProvider

### DIFF
--- a/docs/src/__examples__/Popover/DEFAULT.tsx
+++ b/docs/src/__examples__/Popover/DEFAULT.tsx
@@ -1,34 +1,43 @@
 import React from "react";
-import { Popover, Button, ButtonLink, Stack } from "@kiwicom/orbit-components";
+import {
+  Popover,
+  Button,
+  ButtonLink,
+  Stack,
+  OrbitProvider,
+  defaultTheme,
+} from "@kiwicom/orbit-components";
 import { QuestionCircle } from "@kiwicom/orbit-components/icons";
 
 export default {
   Example: () => (
-    <Popover
-      renderInPortal={false}
-      content={
-        <Stack spacing="small">
-          <ButtonLink
-            external
-            type="secondary"
-            fullWidth
-            href="https://orbit.kiwi/components/popover/react/"
-          >
-            Reference
-          </ButtonLink>
-          <ButtonLink
-            external
-            type="secondary"
-            fullWidth
-            href="https://orbit.kiwi/components/popover/"
-          >
-            Guidelines
-          </ButtonLink>
-        </Stack>
-      }
-    >
-      <Button circled title="Help" iconLeft={<QuestionCircle />} />
-    </Popover>
+    <OrbitProvider theme={defaultTheme} useId={React.useId}>
+      <Popover
+        renderInPortal={false}
+        content={
+          <Stack spacing="small">
+            <ButtonLink
+              external
+              type="secondary"
+              fullWidth
+              href="https://orbit.kiwi/components/popover/react/"
+            >
+              Reference
+            </ButtonLink>
+            <ButtonLink
+              external
+              type="secondary"
+              fullWidth
+              href="https://orbit.kiwi/components/popover/"
+            >
+              Guidelines
+            </ButtonLink>
+          </Stack>
+        }
+      >
+        <Button circled title="Help" iconLeft={<QuestionCircle />} />
+      </Popover>
+    </OrbitProvider>
   ),
   exampleKnobs: [
     {

--- a/docs/src/__examples__/Popover/TRIGGER.tsx
+++ b/docs/src/__examples__/Popover/TRIGGER.tsx
@@ -1,35 +1,44 @@
 import React from "react";
-import { Popover, Button, ButtonLink, Stack } from "@kiwicom/orbit-components";
+import {
+  Popover,
+  Button,
+  ButtonLink,
+  Stack,
+  OrbitProvider,
+  defaultTheme,
+} from "@kiwicom/orbit-components";
 import { ChevronDown } from "@kiwicom/orbit-components/icons";
 
 export default {
   Example: () => (
-    <Popover
-      renderInPortal={false}
-      content={
-        <Stack spacing="small">
-          <ButtonLink
-            external
-            type="secondary"
-            fullWidth
-            href="https://orbit.kiwi/components/popover/react/"
-          >
-            Reference
-          </ButtonLink>
-          <ButtonLink
-            external
-            type="secondary"
-            fullWidth
-            href="https://orbit.kiwi/components/popover/"
-          >
-            Guidelines
-          </ButtonLink>
-        </Stack>
-      }
-    >
-      <Button iconRight={<ChevronDown />} type="secondary">
-        Learn more
-      </Button>
-    </Popover>
+    <OrbitProvider theme={defaultTheme} useId={React.useId}>
+      <Popover
+        renderInPortal={false}
+        content={
+          <Stack spacing="small">
+            <ButtonLink
+              external
+              type="secondary"
+              fullWidth
+              href="https://orbit.kiwi/components/popover/react/"
+            >
+              Reference
+            </ButtonLink>
+            <ButtonLink
+              external
+              type="secondary"
+              fullWidth
+              href="https://orbit.kiwi/components/popover/"
+            >
+              Guidelines
+            </ButtonLink>
+          </Stack>
+        }
+      >
+        <Button iconRight={<ChevronDown />} type="secondary">
+          Learn more
+        </Button>
+      </Popover>
+    </OrbitProvider>
   ),
 };


### PR DESCRIPTION
Reported [here](https://skypicker.slack.com/archives/C7T7QG7M5/p1705071967841679). The OrbitProvider was missing,
 Storybook: https://orbit-mainframev-docs-fix-popover-example-provider.surge.sh