### PR TITLE
docs: add Icons to playground

### DIFF
--- a/docs/src/pages/playground-full.tsx
+++ b/docs/src/pages/playground-full.tsx
@@ -39,7 +39,7 @@ const PlaygroundIframe = () => {
             <LiveProvider
               code={code}
               theme={shadesOfPurple}
-              scope={{ ...Icons, ...components, defaultTheme }}
+              scope={{ ...Icons, Icons, ...components, defaultTheme }}
             >
               <LiveError />
               <GlobalStyle />


### PR DESCRIPTION
One can now use `Icons.[X]` on the playground, avoiding the clash with the `Seat` name, and also allowing more code snippets compatibility.

Full context [here](https://skypicker.slack.com/archives/C7T7QG7M5/p1705306119592589?thread_ts=1705066629.203219&cid=C7T7QG7M5).
 Storybook: https://orbit-mainframev-docs-add-Icons-to-playground.surge.sh