### PR TITLE
fix(Itinerary): add overflow:hidden to ItinerarySegmentDetail

### DIFF
--- a/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentDetail/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentDetail/index.tsx
@@ -69,7 +69,8 @@ const StyledDuration = styled.div<{ $minWidth?: number }>`
 const StyledExpandable = styled.div`
   ${({ theme }) => css`
     padding-top: ${theme.orbit.spaceSmall};
-  `}
+    overflow: hidden;
+  `};
 `;
 
 StyledExpandable.defaultProps = {


### PR DESCRIPTION
Added a small 💅🏻 , that potentially can cause appearing of horizontal scroll 

before: 
![Screenshot 2024-01-16 at 11 36 55](https://github.com/kiwicom/orbit/assets/14054752/d54b267d-aa83-4c5a-a340-125ea2e468af)

after: 
![Screenshot 2024-01-16 at 11 37 47](https://github.com/kiwicom/orbit/assets/14054752/870f51a6-ca39-48e4-9921-d0b61d205ae6)

 Storybook: https://orbit-mainframev-fix-itinerary-missing-overflow.surge.sh