### PR TITLE
fix(docs): ensure Tailwind color preview renders correctly

### DIFF
--- a/docs/src/components/DesignTokensList/components/DesignTokenColor.tsx
+++ b/docs/src/components/DesignTokensList/components/DesignTokenColor.tsx
@@ -61,9 +61,13 @@ const StyledDesignTokenCircleShape = styled(StyledDesignTokenBase)<ColorProps>`
     `};
 `;
 
+/**
+ * We replace <alpha-value> by 1 to ensure the colors render properly
+ * in the documentation page.
+ */
 export const StyledDesignTokenColor = styled(StyledDesignTokenBase)<ColorProps>`
   ${({ $color, theme, size }) => css`
-    background: ${$color};
+    background: ${typeof $color === "string" ? $color.replace("<alpha-value>", "1") : $color};
     border-radius: ${theme.orbit.borderRadiusCircle};
     box-shadow: 0 0 0 1px ${theme.orbit.paletteCloudLight};
     ${size !== "small" &&


### PR DESCRIPTION
When we adopted `rgba` values for the color tokens, we left the <alpha-value> placeholder as is, as it's meant to be used through opacity modifiers (docs: https://tailwindcss.com/docs/accent-color#changing-the-opacity).

For example: bg-blue-light/50 to apply a 50 percent opacity to a light blue background.

# This Pull Request meets the following criteria:

### For Tailwind migrations:

- [ ] Visual regression test suite has been added if does not exist.
- [ ] `tailwind-migration-status.yaml` file has been updated with the migrated component(s).

### For new components:

- [ ] Tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`

 Storybook: https://orbit-mainframev-rcsl-fix-docs.surge.sh