### PR TITLE
feat: add border-radius 9999px token and classname

### DIFF
--- a/docs/src/components/BrandedTile.tsx
+++ b/docs/src/components/BrandedTile.tsx
@@ -64,7 +64,7 @@ const StyledIcon = styled.div<{ secondary: string }>`
     height: ${ICON_SIZE};
     display: none;
     background: ${secondary};
-    border-radius: ${theme.orbit.borderRadiusCircle};
+    border-radius: ${theme.orbit.borderRadiusFull};
     ${mq.largeMobile(`
       display: grid;
       align-content: center;

--- a/docs/src/components/ComponentStatus/ComponentStatus.tsx
+++ b/docs/src/components/ComponentStatus/ComponentStatus.tsx
@@ -90,7 +90,7 @@ export const StyledStatusDot = styled.div<{ status: Status }>`
   ${({ theme, status }) => css`
     width: ${theme.orbit.spaceXSmall};
     height: ${theme.orbit.spaceXSmall};
-    border-radius: ${theme.orbit.borderRadiusCircle};
+    border-radius: ${theme.orbit.borderRadiusFull};
     background: ${theme.orbit[STATUS_COLOR[status]]};
   `};
 `;

--- a/docs/src/components/DesignTokensList/components/DesignTokenColor.tsx
+++ b/docs/src/components/DesignTokensList/components/DesignTokenColor.tsx
@@ -56,7 +56,7 @@ const StyledDesignTokenCircleShape = styled(StyledDesignTokenBase)<ColorProps>`
       display: flex;
       align-items: center;
       justify-content: center;
-      border-radius: ${theme.orbit.borderRadiusCircle};
+      border-radius: ${theme.orbit.borderRadiusFull};
       background-color: ${theme.orbit.paletteCloudDark};
     `};
 `;
@@ -68,7 +68,7 @@ const StyledDesignTokenCircleShape = styled(StyledDesignTokenBase)<ColorProps>`
 export const StyledDesignTokenColor = styled(StyledDesignTokenBase)<ColorProps>`
   ${({ $color, theme, size }) => css`
     background: ${typeof $color === "string" ? $color.replace("<alpha-value>", "1") : $color};
-    border-radius: ${theme.orbit.borderRadiusCircle};
+    border-radius: ${theme.orbit.borderRadiusFull};
     box-shadow: 0 0 0 1px ${theme.orbit.paletteCloudLight};
     ${size !== "small" &&
     css`

--- a/docs/src/components/Footer.tsx
+++ b/docs/src/components/Footer.tsx
@@ -34,7 +34,7 @@ const StyledIconLink = styled.a.attrs(() => ({
     display: block;
     padding: ${theme.orbit.spaceXSmall};
     margin-right: -${theme.orbit.spaceXSmall};
-    border-radius: ${theme.orbit.borderRadiusCircle};
+    border-radius: ${theme.orbit.borderRadiusFull};
     color: ${theme.orbit.paletteInkDark};
     &:hover,
     &:focus {

--- a/docs/src/components/Switch.tsx
+++ b/docs/src/components/Switch.tsx
@@ -38,7 +38,7 @@ const StyledHandle = styled.div`
     transition: transform ${theme.orbit.durationFast} ease-in-out;
     border: 1px solid rgba(7, 64, 92, 0.1);
     border-box: content;
-    border-radius: ${theme.orbit.borderRadiusCircle};
+    border-radius: ${theme.orbit.borderRadiusFull};
     background-color: ${theme.orbit.paletteWhite};
     background-clip: content-box;
     box-shadow: 0px 2px 3px 0px rgba(7, 64, 92, 0.16);
@@ -49,7 +49,7 @@ const StyledCircle = styled.div`
   ${({ theme }) => `
     width: 10px;
     height: 10px;
-    border-radius: ${theme.orbit.borderRadiusCircle};
+    border-radius: ${theme.orbit.borderRadiusFull};
     background-color: ${theme.orbit.paletteInkLight};
     transition: background-color ${theme.orbit.durationFast};
   `}

--- a/docs/src/components/Tile.tsx
+++ b/docs/src/components/Tile.tsx
@@ -104,7 +104,7 @@ const StyledIcon = styled.div<{ isBookmark?: boolean }>`
     width: ${ICON_SIZE};
     height: ${ICON_SIZE};
     background: ${isBookmark ? theme.orbit.paletteOrangeLight : theme.orbit.paletteProductLight};
-    border-radius: ${theme.orbit.borderRadiusCircle};
+    border-radius: ${theme.orbit.borderRadiusFull};
     color: ${isBookmark ? theme.orbit.paletteOrangeNormal : theme.orbit.paletteProductDark};
 
     svg {

--- a/docs/src/components/Usage/index.tsx
+++ b/docs/src/components/Usage/index.tsx
@@ -69,7 +69,7 @@ const StyledHeadingIcon = styled.div<{ $color: string }>`
     width: ${theme.orbit.widthIconMedium};
     height: ${theme.orbit.heightIconMedium};
     background-color: ${$color};
-    border-radius: ${theme.orbit.borderRadiusCircle};
+    border-radius: ${theme.orbit.borderRadiusFull};
     padding: 2px;
     svg {
       width: 100%;

--- a/packages/orbit-components/src/BadgeList/BadgeListItem/index.tsx
+++ b/packages/orbit-components/src/BadgeList/BadgeListItem/index.tsx
@@ -38,7 +38,7 @@ export const VerticalBadge = ({
   return (
     <div
       className={cx(
-        "me-xs size-icon-large rounded-circle flex shrink-0 items-center justify-center",
+        "me-xs size-icon-large flex shrink-0 items-center justify-center rounded-full",
         "[&_svg]:size-icon-small",
         type && BACKGROUND[type],
       )}

--- a/packages/orbit-components/src/Box/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Box/__tests__/index.test.tsx
@@ -20,7 +20,7 @@ const BORDER_RADIUS: { [K in BORDER_RADIUS_KEYS]: string } = {
   small: theme.orbit.borderRadiusSmall,
   normal: theme.orbit.borderRadiusNormal,
   large: theme.orbit.borderRadiusLarge,
-  circle: theme.orbit.borderRadiusCircle,
+  circle: theme.orbit.borderRadiusFull,
 };
 
 describe("#Box", () => {

--- a/packages/orbit-components/src/Box/helpers/tailwindClasses.ts
+++ b/packages/orbit-components/src/Box/helpers/tailwindClasses.ts
@@ -112,36 +112,36 @@ export const borderRadiusClasses: {
   [BORDER_RADIUS.SMALL]: "rounded-small",
   [BORDER_RADIUS.NORMAL]: "rounded-normal",
   [BORDER_RADIUS.LARGE]: "rounded-large",
-  [BORDER_RADIUS.CIRCLE]: "rounded-circle",
+  [BORDER_RADIUS.CIRCLE]: "rounded-full",
   [QUERIES.LARGEDESKTOP]: {
     [BORDER_RADIUS.SMALL]: "ld:rounded-small",
     [BORDER_RADIUS.NORMAL]: "ld:rounded-normal",
     [BORDER_RADIUS.LARGE]: "ld:rounded-large",
-    [BORDER_RADIUS.CIRCLE]: "ld:rounded-circle",
+    [BORDER_RADIUS.CIRCLE]: "ld:rounded-full",
   },
   [QUERIES.DESKTOP]: {
     [BORDER_RADIUS.SMALL]: "de:rounded-small",
     [BORDER_RADIUS.NORMAL]: "de:rounded-normal",
     [BORDER_RADIUS.LARGE]: "de:rounded-large",
-    [BORDER_RADIUS.CIRCLE]: "de:rounded-circle",
+    [BORDER_RADIUS.CIRCLE]: "de:rounded-full",
   },
   [QUERIES.TABLET]: {
     [BORDER_RADIUS.SMALL]: "tb:rounded-small",
     [BORDER_RADIUS.NORMAL]: "tb:rounded-normal",
     [BORDER_RADIUS.LARGE]: "tb:rounded-large",
-    [BORDER_RADIUS.CIRCLE]: "tb:rounded-circle",
+    [BORDER_RADIUS.CIRCLE]: "tb:rounded-full",
   },
   [QUERIES.LARGEMOBILE]: {
     [BORDER_RADIUS.SMALL]: "lm:rounded-small",
     [BORDER_RADIUS.NORMAL]: "lm:rounded-normal",
     [BORDER_RADIUS.LARGE]: "lm:rounded-large",
-    [BORDER_RADIUS.CIRCLE]: "lm:rounded-circle",
+    [BORDER_RADIUS.CIRCLE]: "lm:rounded-full",
   },
   [QUERIES.MEDIUMMOBILE]: {
     [BORDER_RADIUS.SMALL]: "mm:rounded-small",
     [BORDER_RADIUS.NORMAL]: "mm:rounded-normal",
     [BORDER_RADIUS.LARGE]: "mm:rounded-large",
-    [BORDER_RADIUS.CIRCLE]: "mm:rounded-circle",
+    [BORDER_RADIUS.CIRCLE]: "mm:rounded-full",
   },
 };
 

--- a/packages/orbit-components/src/Button/index.tsx
+++ b/packages/orbit-components/src/Button/index.tsx
@@ -6,7 +6,6 @@ import cx from "clsx";
 import ButtonPrimitive from "../primitives/ButtonPrimitive";
 import {
   iconOnlyStyles,
-  circledStyles,
   paddingBothIconsStyles,
   paddingLeftIconStyles,
   paddingNoIconsStyles,
@@ -72,7 +71,7 @@ const Button = React.forwardRef<HTMLButtonElement, Props>(
           children != null && iconLeft != null && iconRight == null && paddingLeftIconStyles[size],
           children != null && iconLeft == null && iconRight != null && paddingRightIconStyles[size],
           children != null && iconLeft != null && iconRight != null && paddingBothIconsStyles[size],
-          props.circled === true && circledStyles[size],
+          props.circled === true && "rounded-full",
         )}
       >
         {children}

--- a/packages/orbit-components/src/ButtonLink/index.tsx
+++ b/packages/orbit-components/src/ButtonLink/index.tsx
@@ -6,7 +6,6 @@ import cx from "clsx";
 import ButtonPrimitive from "../primitives/ButtonPrimitive";
 import {
   iconOnlyStyles,
-  circledStyles,
   paddingBothIconsStyles,
   paddingLeftIconStyles,
   paddingNoIconsStyles,
@@ -81,7 +80,7 @@ const ButtonLink = React.forwardRef<HTMLButtonElement, Props>(
               iconLeft == null && iconRight != null && paddingRightIconStyles[size],
               iconLeft != null && iconRight != null && paddingBothIconsStyles[size],
             ],
-          props.circled === true && circledStyles[size],
+          props.circled === true && "rounded-full",
         )}
       >
         {children}

--- a/packages/orbit-components/src/CarrierLogo/index.tsx
+++ b/packages/orbit-components/src/CarrierLogo/index.tsx
@@ -131,7 +131,7 @@ const CarrierLogo = ({
         <img
           className={cx(
             "max-w-none bg-transparent",
-            rounded ? "rounded-circle" : "rounded-normal",
+            rounded ? "rounded-full" : "rounded-normal",
             inlineStacked ? "not-first:-ms-xs border border-solid border-white" : "last:self-end",
             carriers.length > 1 && !inlineStacked
               ? [

--- a/packages/orbit-components/src/Loading/index.tsx
+++ b/packages/orbit-components/src/Loading/index.tsx
@@ -10,7 +10,7 @@ import useTheme from "../hooks/useTheme";
 const CircleLoader = ({ animationDelay }: { animationDelay?: string }) => {
   return (
     <div
-      className="animate-loader rounded-circle bg-cloud-dark size-xs me-[6px] [&:nth-child(3)]:m-0"
+      className="animate-loader bg-cloud-dark size-xs me-[6px] rounded-full [&:nth-child(3)]:m-0"
       style={{ animationDelay }}
     />
   );

--- a/packages/orbit-components/src/Radio/index.tsx
+++ b/packages/orbit-components/src/Radio/index.tsx
@@ -62,7 +62,7 @@ const Radio = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             "orbit-radio-icon-container",
             "relative box-border",
             "flex flex-none items-center justify-center",
-            "rounded-circle size-icon-medium",
+            "size-icon-medium rounded-full",
             "duration-fast scale-100 transition-all ease-in-out",
             "lm:border border-[2px] border-solid",
             "active:scale-95",
@@ -74,7 +74,7 @@ const Radio = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
         >
           <span
             className={cx(
-              "size-xs rounded-circle",
+              "size-xs rounded-full",
               disabled ? "bg-cloud-light" : "bg-form-element-background",
               checked ? "visible" : "invisible",
             )}

--- a/packages/orbit-components/src/Stepper/StepperStateless/index.tsx
+++ b/packages/orbit-components/src/Stepper/StepperStateless/index.tsx
@@ -18,7 +18,7 @@ const stepperButtonMixin = ({ disabled, active }: { disabled: boolean; active?: 
   cx(
     "[&_svg]:p-xxxs",
     "de:[&_svg]:size-icon-medium [&_svg]:size-icon-large",
-    "[&_svg]:rounded-circle",
+    "[&_svg]:rounded-full",
     "focus:outline-0",
     "[&_svg]:focus:outline-blue-normal [&_svg]:focus:outline [&_svg]:focus:outline-2",
     active ? "[&_svg]:bg-blue-normal" : "[&_svg]:bg-cloud-normal",

--- a/packages/orbit-components/src/Switch/index.tsx
+++ b/packages/orbit-components/src/Switch/index.tsx
@@ -39,7 +39,7 @@ const Switch = React.forwardRef<HTMLInputElement, Props>(
           />
           <div
             className={cx(
-              "rounded-circle bg-white-normal duration-fast shadow-switch absolute box-border inline-flex size-[24px] items-center justify-center",
+              "bg-white-normal duration-fast shadow-switch absolute box-border inline-flex size-[24px] items-center justify-center rounded-full",
               "peer-focus:outline-blue-normal peer-focus:outline peer-focus:outline-2",
               "[&_svg]:size-icon-small",
               !disabled && "active:shadow-action-active",

--- a/packages/orbit-components/src/Tag/index.tsx
+++ b/packages/orbit-components/src/Tag/index.tsx
@@ -98,7 +98,7 @@ const Tag = React.forwardRef<HTMLDivElement, Props>(
           <div
             className={cx(
               "orbit-tag-close-container",
-              "ms-xs rounded-circle flex",
+              "ms-xs flex rounded-full",
               "duration-fast transition-[color,_opacity] ease-in-out",
               "focus:opacity-100",
               !selected &&

--- a/packages/orbit-components/src/Wizard/WizardStepIcon.tsx
+++ b/packages/orbit-components/src/Wizard/WizardStepIcon.tsx
@@ -15,7 +15,7 @@ export const StyledStepIconContainer = styled.div<{ $disabled?: boolean; $glow?:
     justify-content: center;
     width: 20px;
     height: 20px;
-    border-radius: ${theme.orbit.borderRadiusCircle};
+    border-radius: ${theme.orbit.borderRadiusFull};
     background: ${$disabled
       ? theme.orbit.paletteCloudNormalHover
       : theme.orbit.paletteProductNormal};

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/sizes.ts
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/sizes.ts
@@ -30,12 +30,6 @@ export const paddingBothIconsStyles: Record<Size, string> = {
   large: "px-button-padding-md",
 };
 
-export const circledStyles: Record<Size, string> = {
-  small: "rounded-form-box-small",
-  normal: "rounded-form-box-normal",
-  large: "rounded-form-box-large",
-};
-
 export const iconOnlyStyles: Record<Size, string> = {
   small: "w-form-box-small",
   normal: "w-form-box-normal",

--- a/packages/orbit-design-tokens/output/deprecated-tokens.json
+++ b/packages/orbit-design-tokens/output/deprecated-tokens.json
@@ -2022,6 +2022,11 @@
     "category": "Background colors",
     "version": "6.0.0"
   },
+  "borderRadiusCircle": {
+    "replacement": "borderRadiusFull",
+    "category": "Border radius",
+    "version": "8.0.0"
+  },
   "widthBreakpointMediumMobile": {
     "replacement": "breakpointMediumMobile",
     "category": "Breakpoints",

--- a/packages/orbit-design-tokens/output/docs-tokens.json
+++ b/packages/orbit-design-tokens/output/docs-tokens.json
@@ -16415,8 +16415,8 @@
   },
   "borderRadiusCircle": {
     "type": "border-radius",
-    "deprecated": false,
-    "replacement": null,
+    "deprecated": true,
+    "replacement": "borderRadiusFull",
     "schema": {
       "namespace": "global",
       "object": "border-radius",
@@ -16499,6 +16499,28 @@
     "scss": {
       "name": "borderRadiusLarge",
       "value": "6px"
+    }
+  },
+  "borderRadiusFull": {
+    "type": "border-radius",
+    "deprecated": false,
+    "replacement": null,
+    "schema": {
+      "namespace": "global",
+      "object": "border-radius",
+      "variant": "full"
+    },
+    "javascript": {
+      "name": "borderRadiusFull",
+      "value": "9999px"
+    },
+    "foundation": {
+      "name": "borderRadiusFull",
+      "value": "foundation.borderRadius.full"
+    },
+    "scss": {
+      "name": "borderRadiusFull",
+      "value": "9999px"
     }
   },
   "breakpointMediumMobile": {

--- a/packages/orbit-design-tokens/output/tokens.css
+++ b/packages/orbit-design-tokens/output/tokens.css
@@ -715,6 +715,7 @@
   --border-radius-small: 2;
   --border-radius-normal: 3;
   --border-radius-large: 6;
+  --border-radius-full: 9999;
   --breakpoint-medium-mobile: 414;
   --breakpoint-large-mobile: 576;
   --breakpoint-tablet: 768;

--- a/packages/orbit-design-tokens/output/tokens.less
+++ b/packages/orbit-design-tokens/output/tokens.less
@@ -714,6 +714,7 @@
 @border-radius-small: 2;
 @border-radius-normal: 3;
 @border-radius-large: 6;
+@border-radius-full: 9999;
 @breakpoint-medium-mobile: 414;
 @breakpoint-large-mobile: 576;
 @breakpoint-tablet: 768;

--- a/packages/orbit-design-tokens/output/tokens.scss
+++ b/packages/orbit-design-tokens/output/tokens.scss
@@ -727,6 +727,7 @@ $border-radius-circle: 50%;
 $border-radius-small: 2px;
 $border-radius-normal: 3px;
 $border-radius-large: 6px;
+$border-radius-full: 9999px;
 $breakpoint-medium-mobile: 414;
 $breakpoint-large-mobile: 576;
 $breakpoint-tablet: 768;

--- a/packages/orbit-design-tokens/output/tokens.styl
+++ b/packages/orbit-design-tokens/output/tokens.styl
@@ -714,6 +714,7 @@ $border-radius-circle= 50%;
 $border-radius-small= 2;
 $border-radius-normal= 3;
 $border-radius-large= 6;
+$border-radius-full= 9999;
 $breakpoint-medium-mobile= 414;
 $breakpoint-large-mobile= 576;
 $breakpoint-tablet= 768;

--- a/packages/orbit-design-tokens/output/tokens.xml
+++ b/packages/orbit-design-tokens/output/tokens.xml
@@ -2864,6 +2864,10 @@
     <value>6</value>
   </token>
   <token>
+    <name>borderRadiusFull</name>
+    <value>9999</value>
+  </token>
+  <token>
     <name>breakpointMediumMobile</name>
     <value>414</value>
   </token>

--- a/packages/orbit-design-tokens/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/orbit-design-tokens/src/__tests__/__snapshots__/index.test.ts.snap
@@ -191,6 +191,7 @@ exports[`defaultTokens should match snapshot 1`] = `
   "borderColorTagFocus": "#0172CB",
   "borderRadiusBadge": "12px",
   "borderRadiusCircle": "50%",
+  "borderRadiusFull": "9999px",
   "borderRadiusLarge": "6px",
   "borderRadiusNormal": "3px",
   "borderRadiusSmall": "2px",

--- a/packages/orbit-design-tokens/src/dictionary/definitions/foundation/borderRadius.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/foundation/borderRadius.json
@@ -20,6 +20,11 @@
         "type": "border-radius",
         "value": 6,
         "internal": true
+      },
+      "full": {
+        "type": "border-radius",
+        "value": 9999,
+        "internal": true
       }
     }
   }

--- a/packages/orbit-design-tokens/src/dictionary/definitions/global/borderRadius.json
+++ b/packages/orbit-design-tokens/src/dictionary/definitions/global/borderRadius.json
@@ -3,7 +3,10 @@
     "border-radius": {
       "circle": {
         "type": "border-radius",
-        "value": "{foundation.border-radius.circle}"
+        "value": "{foundation.border-radius.circle}",
+        "deprecated": true,
+        "deprecated-replace": "{global.border-radius.full}",
+        "deprecated-version": "8.0.0"
       },
       "small": {
         "type": "border-radius",
@@ -16,6 +19,10 @@
       "large": {
         "type": "border-radius",
         "value": "{foundation.border-radius.large}"
+      },
+      "full": {
+        "type": "border-radius",
+        "value": "{foundation.border-radius.full}"
       }
     }
   }

--- a/packages/orbit-design-tokens/src/js/createTokens.ts
+++ b/packages/orbit-design-tokens/src/js/createTokens.ts
@@ -730,6 +730,7 @@ export interface Tokens {
   borderRadiusSmall: string;
   borderRadiusNormal: string;
   borderRadiusLarge: string;
+  borderRadiusFull: string;
   breakpointMediumMobile: number;
   breakpointLargeMobile: number;
   breakpointTablet: number;
@@ -1657,6 +1658,7 @@ const createTokens: CreateTokens = foundation => ({
   borderRadiusSmall: foundation.borderRadius.small,
   borderRadiusNormal: foundation.borderRadius.normal,
   borderRadiusLarge: foundation.borderRadius.large,
+  borderRadiusFull: foundation.borderRadius.full,
   breakpointMediumMobile: foundation.breakpoint.mediumMobile,
   breakpointLargeMobile: foundation.breakpoint.largeMobile,
   breakpointTablet: foundation.breakpoint.tablet,

--- a/packages/orbit-design-tokens/src/js/defaultFoundation.ts
+++ b/packages/orbit-design-tokens/src/js/defaultFoundation.ts
@@ -110,6 +110,7 @@ export interface BorderRadius {
   small: string;
   normal: string;
   large: string;
+  full: string;
 }
 export interface Breakpoint {
   smallMobile: number;
@@ -287,7 +288,7 @@ const red = {
 };
 const social = { facebook: "#3B5998", facebookHover: "#385490", facebookActive: "#354F88" };
 const white = { normal: "#FFFFFF", normalActive: "#E7ECF1", normalHover: "#F1F4F7" };
-const borderRadius = { circle: "50%", small: "2px", normal: "3px", large: "6px" };
+const borderRadius = { circle: "50%", small: "2px", normal: "3px", large: "6px", full: "9999px" };
 const breakpoint = {
   smallMobile: 320,
   mediumMobile: 414,

--- a/packages/orbit-tailwind-preset/src/__fixtures__/BorderRadius.tsx
+++ b/packages/orbit-tailwind-preset/src/__fixtures__/BorderRadius.tsx
@@ -6,7 +6,7 @@ const BorderRadius = () => {
       <div className="rounded-small">small</div>
       <div className="rounded-normal">normal</div>
       <div className="rounded-large">large</div>
-      <div className="rounded-circle">circle</div>
+      <div className="rounded-full">full</div>
     </div>
   );
 };

--- a/packages/orbit-tailwind-preset/src/__tests__/__snapshots__/configs.test.ts.snap
+++ b/packages/orbit-tailwind-preset/src/__tests__/__snapshots__/configs.test.ts.snap
@@ -210,6 +210,7 @@ exports[`orbitPreset should have preflight disabled 1`] = `
       "theme": {
         "borderRadius": {
           "circle": "50%",
+          "full": "9999px",
           "large": "6px",
           "none": "0",
           "normal": "3px",
@@ -1058,6 +1059,7 @@ exports[`orbitPreset should have preflight disabled 1`] = `
       "form-box-large": "52px",
       "form-box-normal": "44px",
       "form-box-small": "32px",
+      "full": "9999px",
       "large": "6px",
       "modal": "9px",
       "modal-mobile": "12px",

--- a/packages/orbit-tailwind-preset/src/foundation/getTailwindTheme.ts
+++ b/packages/orbit-tailwind-preset/src/foundation/getTailwindTheme.ts
@@ -146,6 +146,7 @@ const getTailwindTheme = (theme: typeof defaultTokens) => {
       normal: defaultFoundation.borderRadius.normal,
       large: defaultFoundation.borderRadius.large,
       circle: defaultFoundation.borderRadius.circle,
+      full: defaultFoundation.borderRadius.full,
     },
     screens: {
       sm: toPx(defaultFoundation.breakpoint.smallMobile),


### PR DESCRIPTION
As was discussed [here](https://skypicker.slack.com/archives/C05FDP4UM3N/p1706280684014429) and request [here](https://skypicker.slack.com/archives/C7T7QG7M5/p1706276434250689)
 Storybook: https://orbit-mainframev-feat-add-rounded-full.surge.sh