### PR TITLE
chore: update cronjobs with new gh actions

### DIFF
--- a/.github/workflows/cron-update-contributors.yml
+++ b/.github/workflows/cron-update-contributors.yml
@@ -31,17 +31,15 @@ jobs:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v5
+        uses: actions/github-script@v6
         with:
-          base: master
-          branch: docs/update-contributors
-          token: ${{ secrets.PAT }}
-          delete-branch: true
-          title: "chore: update contributors"
-          labels: Documentation
-          body: |
-            - Automatically generated PR on ${{ env.TODAY }}.
-            - Updates contributors for docs
-          assignees: mainframev
-          reviewers: mainframev
-          draft: false
+          script: |
+            github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "chore: update contributors",
+              body: `- Automatically generated PR on ${process.env.TODAY}.\n- Updates contributors for docs`,
+              head: "docs/update-contributors",
+              base: "master",
+              maintainer_can_modify: true,
+            });

--- a/.github/workflows/cron-update-icons.yml
+++ b/.github/workflows/cron-update-icons.yml
@@ -31,17 +31,15 @@ jobs:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v5
+        uses: actions/github-script@v6
         with:
-          base: master
-          branch: feat/update-icons-and-svgs
-          token: ${{ secrets.PAT }}
-          delete-branch: true
-          title: "feat(icons): update icons from Figma"
-          labels: Icons
-          body: |
-            - Automatically generated PR on ${{ env.TODAY }}.
-            - Updates icons from Figma
-          assignees: mainframev
-          reviewers: mainframev
-          draft: false
+          script: |
+            github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: 'feat/update-icons-and-svgs',
+              base: 'master',
+              title: 'feat(icons): update icons from Figma',
+              body: `- Automatically generated PR on ${process.env.TODAY}.\n- Updates icons from Figma`,
+              maintainer_can_modify: true,
+            });

--- a/.github/workflows/cron-update-statuses.yml
+++ b/.github/workflows/cron-update-statuses.yml
@@ -29,16 +29,15 @@ jobs:
           git diff-index --quiet HEAD || git commit -m "chore: update component statuses"
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v5
+        uses: actions/github-script@v6
         with:
-          base: master
-          branch: chore/update-icons-and-svgs
-          token: ${{ secrets.PAT }}
-          delete-branch: true
-          title: "chore: update component statuses"
-          body: |
-            - Automatically generated PR on ${{ env.TODAY }}.
-            - Updates component statuses
-          assignees: mainframev
-          reviewers: mainframev
-          draft: false
+          script: |
+            github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: 'chore/update-icons-and-svgs',
+              base: 'master',
+              title: 'chore: update component statuses',
+              body: `- Automatically generated PR on ${process.env.TODAY}.\n- Updates component statuses`,
+              maintainer_can_modify: true,
+            });

--- a/.github/workflows/cron-update-tokens.yml
+++ b/.github/workflows/cron-update-tokens.yml
@@ -33,17 +33,15 @@ jobs:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v5
+        uses: actions/github-script@v6
         with:
-          base: master
-          branch: feat/update-palette-tokens
-          token: ${{ secrets.PAT }}
-          delete-branch: true
-          title: "feat(tokens): update palette tokens from figma"
-          body: |
-            - Automatically generated PR on ${{ env.TODAY }}.
-            - Updates palette tokens from Figma
-          labels: Tokens
-          assignees: mainframev
-          reviewers: mainframev
-          draft: false
+          script: |
+            github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: 'feat/update-palette-tokens',
+              base: 'master',
+              title: 'feat(tokens): update palette tokens from figma',
+              body: `- Automatically generated PR on ${process.env.TODAY }.\n- Updates palette tokens from Figma`,
+              maintainer_can_modify: true,
+            });


### PR DESCRIPTION
In the sequence of removing default assignee and reviewer, I have replaced the action that creates the PR for our cronjobs. It will now use the official GH action.