### PR TITLE
chore: remove streamline tokens

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -6,8 +6,6 @@ env: # Set environment variables for every job and step in this workflow
   CLICOLOR: "1" # Enable colors for *NIX commands
   PY_COLORS: "1" # Enable colors for Python-based utilities
   FORCE_COLOR: "1" # Force colors in the terminal
-  STREAMLINE_SECRET: ${{ secrets.STREAMLINE_SECRET }}
-  STREAMLINE_FAMILIES: ${{ secrets.STREAMLINE_FAMILIES }}
 
 permissions:
   contents: read

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -12,8 +12,6 @@ env: # Set environment variables for every job and step in this workflow
   CLICOLOR: "1" # Enable colors for *NIX commands
   PY_COLORS: "1" # Enable colors for Python-based utilities
   FORCE_COLOR: "1" # Force colors in the terminal
-  STREAMLINE_SECRET: ${{ secrets.STREAMLINE_SECRET }}
-  STREAMLINE_FAMILIES: ${{ secrets.STREAMLINE_FAMILIES }}
 
 jobs:
   deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,6 @@ env: # Set environment variables for every job and step in this workflow
   CLICOLOR: "1" # Enable colors for *NIX commands
   PY_COLORS: "1" # Enable colors for Python-based utilities
   FORCE_COLOR: "1" # Force colors in the terminal
-  STREAMLINE_SECRET: ${{ secrets.STREAMLINE_SECRET }}
-  STREAMLINE_FAMILIES: ${{ secrets.STREAMLINE_FAMILIES }}
 
 jobs:
   types:


### PR DESCRIPTION
Tokens are no longer needed, since icons are statically stored on the repo. They will also be removed from the repo secrets