### PR TITLE
ci: use orbit bot to publish releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Setup git config
         run: |
-          git config user.name "mainframev"
-          git config user.email "vgenaev@gmail.com"
+          git config user.name "kiwicom-orbit-bot"
+          git config user.email "frontend-platform@kiwi.com"
 
       - name: Build
         run: |


### PR DESCRIPTION
Closes [FEPLT-1943](https://kiwicom.atlassian.net/browse/FEPLT-1943)

[FEPLT-1943]: https://kiwicom.atlassian.net/browse/FEPLT-1943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


- Bot has write permissions
- Bot can bypass required PR in `master` branch.