### PR TITLE
chore: format generated tokens file

### DIFF
--- a/packages/orbit-design-tokens/scripts/fetchBaseTokens.mjs
+++ b/packages/orbit-design-tokens/scripts/fetchBaseTokens.mjs
@@ -1,4 +1,5 @@
 import { $, fetch, fs, path } from "zx";
+import prettier from "prettier";
 import dotenv from "dotenv-safe";
 import dedent from "dedent";
 import { solidPaintToWebRgb, toHex } from "figx";
@@ -150,7 +151,10 @@ async function getColorTokensFromFigma() {
           } else {
             await fs.writeFile(
               path.join(OUTPUT_PATH, `${palette}.json`),
-              JSON.stringify(saveTokens(palette, tokens), null, 2),
+              prettier.format(JSON.stringify(saveTokens(palette, tokens), null, 2), {
+                ...prettier.resolveConfig.sync(""),
+                parser: "json",
+              }),
             );
           }
         }


### PR DESCRIPTION
Our tokens cronjob [was failing](https://github.com/kiwicom/orbit/actions/runs/7801192554/job/21275717181) because it was always trying to commit files that, in the end, were only modified by removing the empty line at EOF.

This empty line was added because the `fetch:colors` script generates the palette files every time, without formatting it with prettier rules, hence the absence of an empty line at EOF.

Now we use prettier to format the document, avoiding false changes