### PR TITLE
Cronjob improvements

### DIFF
--- a/.github/workflows/cron-tracking.yml
+++ b/.github/workflows/cron-tracking.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # every month at 08:00:00
     - cron: "0 8 1 * *"
+  workflow_dispatch:
 
 jobs:
   doc-updates:

--- a/.github/workflows/cron-update-contributors.yml
+++ b/.github/workflows/cron-update-contributors.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 11 * * *"
   workflow_dispatch:
 
+env:
+  new_files: false
+
 jobs:
   cron-update-contributors:
     runs-on: ubuntu-latest
@@ -29,17 +32,19 @@ jobs:
           git add --all
           if git diff-index --quiet HEAD; then
             echo "No changes to contributors. Exiting."
-            exit 0
+            echo "new_files=false" >> $GITHUB_ENV
           else
             git checkout -b docs/update-contributors
             git commit -m "docs: update contributors"
             git push origin docs/update-contributors
+            echo "new_files=true" >> $GITHUB_ENV
           fi
         env:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
 
       - name: Create PR
         uses: actions/github-script@v6
+        if: env.new_files == 'true'
         with:
           script: |
             github.rest.pulls.create({

--- a/.github/workflows/cron-update-icons.yml
+++ b/.github/workflows/cron-update-icons.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 10 * * *"
   workflow_dispatch:
 
+env:
+  new_files: false
+
 jobs:
   cron-update-icons:
     runs-on: ubuntu-latest
@@ -29,17 +32,19 @@ jobs:
           git add --all
           if git diff-index --quiet HEAD; then
             echo "No changes to icons. Exiting."
-            exit 0
+            echo "new_files=false" >> $GITHUB_ENV
           else
             git checkout -b feat/update-icons-and-svgs
             git commit -m "feat(icons): update icons from figma"
             git push origin feat/update-icons-and-svgs
+            echo "new_files=true" >> $GITHUB_ENV
           fi
         env:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
 
       - name: Create PR
         uses: actions/github-script@v6
+        if: env.new_files == 'true'
         with:
           script: |
             github.rest.pulls.create({

--- a/.github/workflows/cron-update-statuses.yml
+++ b/.github/workflows/cron-update-statuses.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 9 * * *"
   workflow_dispatch:
 
+env:
+  new_files: false
+
 jobs:
   cron-update-statuses:
     runs-on: ubuntu-latest
@@ -29,15 +32,17 @@ jobs:
           git add --all
           if git diff-index --quiet HEAD; then
             echo "No changes to component statuses. Exiting."
-            exit 0
+            echo "new_files=false" >> $GITHUB_ENV
           else
             git checkout -b docs/update-component-statuses
             git commit -m "chore: update component statuses"
             git push origin docs/update-component-statuses
+            echo "new_files=true" >> $GITHUB_ENV
           fi
 
       - name: Create PR
         uses: actions/github-script@v6
+        if: env.new_files == 'true'
         with:
           script: |
             github.rest.pulls.create({

--- a/.github/workflows/cron-update-tokens.yml
+++ b/.github/workflows/cron-update-tokens.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 8 * * *"
   workflow_dispatch:
 
+env:
+  new_files: false
+
 jobs:
   cron-update-tokens:
     runs-on: ubuntu-latest
@@ -31,17 +34,19 @@ jobs:
           git add --all
           if git diff-index --quiet HEAD; then
             echo "No changes to tokens. Exiting."
-            exit 0
+            echo "new_files=false" >> $GITHUB_ENV
           else
             git checkout -b feat/update-palette-tokens
             git commit -m "feat(tokens): update palette"
             git push origin feat/update-palette-tokens
+            echo "new_files=true" >> $GITHUB_ENV
           fi
         env:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
 
       - name: Create PR
         uses: actions/github-script@v6
+        if: env.new_files == 'true'
         with:
           script: |
             github.rest.pulls.create({


### PR DESCRIPTION
Yet another two improvements to our cronjobs. We can now trigger the tracking one manually. And we avoid pipeline fail by conditionally running the action that tries to create a PR (it now only runs if there are new files)