### PR TITLE
ci: do not print dry-run changelog from script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,6 @@ jobs:
             yarn lerna version --no-private --no-push --no-git-tag-version --yes
           fi
           git diff
-          yarn zx scripts/post-changelog.mjs --dry
 
       - name: Publish
         if: ${{ github.event.inputs.dryrun == 'false' }}


### PR DESCRIPTION
The output is misleading when we execute this job in dry-run mode
as it fetches the diff content of the latest tag. Since on dry-run
we don't create any tags on lerna calls, we were fetching the diff
of older tags, thus the results are not what we expect.

It is more sensible to rely on the git diff output which contains
the changes in the changelog and package.json files.
