### PR TITLE
Wizard: don't wrap progress label

### DIFF
--- a/packages/orbit-components/src/Wizard/index.tsx
+++ b/packages/orbit-components/src/Wizard/index.tsx
@@ -98,8 +98,8 @@ const Wizard = ({
             setOpen(true);
           }}
         >
-          <Stack as="span" inline>
-            {typeof labelProgress !== "undefined" && <b>{labelProgress}</b>}
+          <Stack as="span" inline align="center">
+            {typeof labelProgress !== "undefined" && <b className="text-nowrap">{labelProgress}</b>}
             <span
               css={css`
                 font-weight: normal;


### PR DESCRIPTION
As reported [here](https://skypicker.slack.com/archives/C7T7QG7M5/p1707814668163539), the progress label should be kept inline.