### PR TITLE
Update browserslist-config

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,10 +1,5 @@
 [production]
 extends @kiwicom/browserslist-config
 
-ios_saf 14
-ios_saf 15
-safari 14
-safari 15
-
 [test]
 current node

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@kiwicom/browserslist-config:registry=https://registry.npmjs.org

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/types": "^7.21.4",
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
-    "@kiwicom/browserslist-config": "^4.0.0",
+    "@kiwicom/browserslist-config": "^4.0.3",
     "@octokit/rest": "^19.0.5",
     "@size-limit/file": "^8.0.0",
     "@size-limit/webpack": "^8.0.0",

--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -49,9 +49,7 @@
     "component"
   ],
   "browserslist": [
-    "extends @kiwicom/browserslist-config",
-    "iOS >= 14",
-    "Safari >= 14"
+    "extends @kiwicom/browserslist-config"
   ],
   "files": [
     "es",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2759,10 +2759,10 @@
   resolved "https://registry.npmjs.org/@kiwicom/babel-plugin-orbit-components/-/babel-plugin-orbit-components-3.6.6.tgz"
   integrity sha512-t278JTrEmwVoutWHBNpAjebmRAkvZuDx6Yq857lL68KU/tc3w91VgDhY+FY8yM1X1FURCcyyhdun0YOIkQPUgQ==
 
-"@kiwicom/browserslist-config@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/@kiwicom/browserslist-config/-/browserslist-config-4.0.0.tgz"
-  integrity sha512-CkBXOf5noNBSh8nOQl6/qMBEz1GwYQpIxDTyImqJDwSiXgY/lWHgW9TQT8n9akhFMd4uB9tAFsWFPk8EhzogfA==
+"@kiwicom/browserslist-config@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@kiwicom/browserslist-config/-/browserslist-config-4.0.3.tgz#38e2429b20df4c5efccda83190bac441aaa8b4d9"
+  integrity sha512-/ojOUmU8P+rR2y61VMfOkUQNyxBwpMMno29tICCy4jheBbvAg6hnKzFN7qhzZ98SZEgB2ObDrhFWYdWj9tyVGA==
 
 "@kwsites/file-exists@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
The dependency was updated and so the manual resolutions are no longer needed.

The `.npmrc` is needed for Kiwi users only and is harmless for open source users.