### PR TITLE
chore: add missing tailwind migrated components

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -26,6 +26,7 @@ function fetchComponentDirs() {
       "**/data/",
       "**/common/",
       "**/helpers/",
+      "**/*.tsx-snapshots/",
     ],
   });
 
@@ -40,7 +41,6 @@ function fetchComponentDirs() {
     "icons",
     "tracking",
     "tailwind",
-    "icons",
   ];
 
   return dirs.reduce(filterOut, whiteListedDirs);

--- a/docs/src/data/tailwind-migration-status.yaml
+++ b/docs/src/data/tailwind-migration-status.yaml
@@ -1,4 +1,5 @@
 Accordion: true
+AccordionSection: true
 AirportIllustration: true
 Alert: true
 AlertButton: true
@@ -17,6 +18,7 @@ ButtonMobileStore: true
 ButtonPrimitive: true
 CallOutBanner: true
 Card: true
+CardHeader: true
 CardSection: true
 CarrierLogo: true
 Checkbox: true
@@ -48,6 +50,7 @@ ItinerarySegment: true
 ItinerarySegmentBanner: true
 ItinerarySegmentDetail: true
 ItinerarySegmentStop: true
+ItinerarySeparator: true
 Layout: true
 LayoutColumn: true
 LinkList: true
@@ -68,7 +71,6 @@ Pagination: true
 Popover: true
 Portal: true
 Radio: true
-NewSeatIcon: false
 Seat: true
 SeatLegend: true
 SegmentedSwitch: true
@@ -107,7 +109,7 @@ Textarea: true
 Timeline: false
 TimelineStep: false
 Toast: true
-ToastRoot: false
+ToastRoot: true
 Tooltip: true
 Truncate: true
 Wizard: false

--- a/packages/orbit-components/src/utils/toggleDown/index.ts
+++ b/packages/orbit-components/src/utils/toggleDown/index.ts
@@ -1,5 +1,9 @@
 import { keyframes } from "styled-components";
 
+/**
+ * @deprecated This utility is deprecated and will be removed in future versions.
+ * Please use an alternative solution.
+ */
 const toggleDown = (contentHeight: number) => keyframes`
   0% { max-height: 0; opacity: 0; overflow: hidden }
   100% { max-height: ${contentHeight}px; opacity: 1; overflow: visible }

--- a/packages/orbit-components/src/utils/toggleUp/index.ts
+++ b/packages/orbit-components/src/utils/toggleUp/index.ts
@@ -1,5 +1,9 @@
 import { keyframes } from "styled-components";
 
+/**
+ * @deprecated This utility is deprecated and will be removed in future versions.
+ * Please use an alternative solution.
+ */
 const toggleUp = (contentHeight: number) => keyframes`
   0% { max-height: ${contentHeight}px; opacity: 1 }
   100% { max-height: 0; opacity: 0 }


### PR DESCRIPTION
- chore: add missing tailwind migrated components

- feat: deprecate toggleUp and toggleDown utilities
These utilities are not being used by anyone.

![image](https://github.com/kiwicom/orbit/assets/8863238/f73dacfc-e5d7-45ce-b3b0-5fad8fc579ec)


- chore: ignore snapshots folders in commitlint