### PR TITLE
Remove unnecessary GH_TOKEN from publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,6 @@ jobs:
         if: ${{ github.event.inputs.dryrun == 'false' }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # must be of type Automation to create releases
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_CHANGELOG_WEBHOOK_URL: ${{ secrets.SLACK_CHANGELOG_WEBHOOK_URL }}
         run: |
           echo "scope=@kiwicom" > ~/.npmrc


### PR DESCRIPTION
The PAT token is enough to have the push rights.

The branch protection rules for the master branch were also adjusted. We had @RobinCsl and @mvidalgarcia as exceptions but that is not needed since they're already admins.

[FEPLT-1948](https://kiwicom.atlassian.net/browse/FEPLT-1948)

[FEPLT-1948]: https://kiwicom.atlassian.net/browse/FEPLT-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ