### PR TITLE
ci: allow Dependabot user to write in PRs

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -16,6 +16,8 @@ env: # Set environment variables for every job and step in this workflow
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # for dependabot
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
According to the GitHub docs, the Dependabot gets read-only permissions
on the GITHUB_TOKEN. Since we want to create a comment with the staging
Storybook link, we need to grant write permission in the CI job.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions

Closes [FEPLT-1950](https://kiwicom.atlassian.net/browse/FEPLT-1950)

[FEPLT-1950]: https://kiwicom.atlassian.net/browse/FEPLT-1950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ