### PR TITLE
ci: add write-all to storybook permissions

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -16,8 +16,7 @@ env: # Set environment variables for every job and step in this workflow
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # for dependabot
+    permissions: write-all # for dependabot
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Following the merge of #4311 all master deploys of storybook were failing because one could not push to GH Pages, as the permissions only had write permissions on pull requests. This should bring those permissions back without affecting the dependabot 