### PR TITLE
Fix Itinerary text (wrap and alignment)

### DIFF
--- a/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentStop/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItinerarySegment/ItinerarySegmentStop/index.tsx
@@ -67,7 +67,7 @@ const ItinerarySegmentStop = ({
               <ItineraryText
                 type={cancelledDate ? textType : "secondary"}
                 size="small"
-                align="right"
+                align="end"
                 as="div"
                 withBackground={!!cancelledDate}
               >
@@ -80,7 +80,7 @@ const ItinerarySegmentStop = ({
               </ItineraryText>
             )}
             {cancelledDate && (
-              <ItineraryText type="secondary" size="small" align="right" strikeThrough as="div">
+              <ItineraryText type="secondary" size="small" align="end" strikeThrough as="div">
                 {cancelledDate}
               </ItineraryText>
             )}

--- a/packages/orbit-components/src/Itinerary/ItineraryText/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItineraryText/index.tsx
@@ -43,7 +43,7 @@ const ItineraryText = ({
   return (
     <Component
       className={cx(
-        "orbit-text font-base m-0",
+        "orbit-text font-base m-0 text-wrap",
         alternativeTextTypeColors[type],
         withBackground && backgroundClasses[type],
         sizeClasses[size],


### PR DESCRIPTION
Although the ticket only mentions RTL, the wrapping problem was happening on both RTL and LTR.

Long text now wraps properly.

This also fixes the alignment of dates on RTL.

[FEPLT-1932](https://kiwicom.atlassian.net/browse/FEPLT-1932)

Before:
<img width="1337" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/1145d0df-84e7-46dc-9f63-d13743097f96">

Now:
<img width="1337" alt="image" src="https://github.com/kiwicom/orbit/assets/6265045/e088d02f-2dd0-440b-819d-11c15f38db17">
