### PR TITLE
fix(Icon): icon components are now correctly typed

### DIFF
--- a/docs/src/components/Navbar/Links.tsx
+++ b/docs/src/components/Navbar/Links.tsx
@@ -32,7 +32,7 @@ const LinkIcon = ({ name }: { name?: string }) => {
     case "Accessibility":
       return <IrisScanIcon {...iconStyles} />;
     case "Playground":
-      return <Code {...iconStyles} />;
+      return <Code size="medium" />;
     default:
       return <ScriptIcon {...iconStyles} />;
   }

--- a/packages/orbit-components/src/Icon/createIcon.tsx
+++ b/packages/orbit-components/src/Icon/createIcon.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
 
 import whiteListProps from "./helpers/whiteListProps";
+import type { Props } from "./types";
 
 import OrbitIcon from ".";
 
 const createIcon = (def: React.ReactNode, viewBox: string, displayName: string) => {
-  const icon = props => (
+  const icon = (props: Props) => (
     <OrbitIcon viewBox={viewBox} {...whiteListProps(props)}>
       {def}
     </OrbitIcon>


### PR DESCRIPTION
Icon components now have their props correctly typed.

[FEPLT-1920](https://kiwicom.atlassian.net/browse/FEPLT-1920)

[FEPLT-1920]: https://kiwicom.atlassian.net/browse/FEPLT-1920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ