### PR TITLE
ci: change pages to contents write permissions in storybook job

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # for dependabot
-      pages: write # for deploying to GitHub Pages on master
+      contents: write # for deploying to GitHub Pages on master
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Change `pages: write` to `contents: write` to (hopefully) be able to deploy storybook to GH Pages