### PR TITLE
fix(InputSelect): it now filters options when they change via props

### DIFF
--- a/packages/orbit-components/src/InputSelect/index.tsx
+++ b/packages/orbit-components/src/InputSelect/index.tsx
@@ -61,7 +61,10 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
 
     const [isOpened, setIsOpened] = React.useState(false);
     const [inputValue, setInputValue] = React.useState(
-      defaultSelected ? options.find(opt => opt.value === defaultSelected.value)?.title : "",
+      defaultSelected
+        ? options.find(opt => opt.value === defaultSelected.value)?.title ||
+            String(defaultSelected.title)
+        : "",
     );
     const [selectedOption, setSelectedOption] = React.useState<null | Option>(
       defaultSelected || null,
@@ -86,6 +89,21 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
       all: Option[];
       flattened: Option[];
     }>(groupedOptions);
+
+    React.useEffect(() => {
+      if (inputValue.length === 0) {
+        setResults(groupedOptions);
+      } else {
+        const filtered = options.filter(({ title }) => {
+          return title.toLowerCase().includes(inputValue.toLowerCase());
+        });
+        setResults({
+          groups: [],
+          all: filtered,
+          flattened: filtered,
+        });
+      }
+    }, [inputValue, options, groupedOptions]);
 
     const handleClose = (selection?: Option | null) => {
       if (!selection) {
@@ -122,19 +140,6 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
     const handleInputChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
       const { value } = ev.currentTarget;
       if (onChange) onChange(ev);
-
-      if (value.length === 0) {
-        setResults(groupedOptions);
-      } else {
-        const filtered = options.filter(({ title }) => {
-          return title.toLowerCase().includes(value.toLowerCase());
-        });
-        setResults({
-          groups: [],
-          all: filtered,
-          flattened: filtered,
-        });
-      }
 
       if (!isOpened) setIsOpened(true);
       setInputValue(value);


### PR DESCRIPTION
InputSelect component now applies the filter to the options when they change via props. In the past, it was applying only when the input changed. If the options received via props changed as well, the filtering was applied before the change, so it was not applied on the correct set of options.

[FEPLT-1985](https://kiwicom.atlassian.net/browse/FEPLT-1985)

[FEPLT-1985]: https://kiwicom.atlassian.net/browse/FEPLT-1985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ