### PR TITLE
chore: ignore config scripts in lerna publish

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,11 @@
     },
     "publish": {
       "allowBranch": "master",
-      "conventionalCommits": true
+      "conventionalCommits": true,
+      "ignoreChanges": [
+        "packages/orbit-design-tokens/scripts/**",
+        "packages/orbit-components/config/**"
+      ]
     }
   }
 }


### PR DESCRIPTION
Lerna now ignores changes in config scripts that have no changes on the client side of packages

This avoids that changes on the scripts folder inside `orbit-design-tokens` and on the config folder inside `orbit-components` cause a bump on the package version.