### PR TITLE
chore: escape chars in icon fetching script

### DIFF
--- a/packages/orbit-components/config/fetchIcons.mts
+++ b/packages/orbit-components/config/fetchIcons.mts
@@ -231,7 +231,10 @@ async function saveOrbitIcons(data: { name: string; svg: string; id: string }[])
             const nodeId = nodes[id] as string;
             return {
               id,
-              name: nodeId.toLowerCase().replace(/\+kg/, "").replace(/\s+/g, "-"),
+              name: nodeId
+                .toLowerCase()
+                .replace(/\+kg|\(|\)/g, "")
+                .replace(/\s+/g, "-"),
               svg: await res.text(),
             };
           }),


### PR DESCRIPTION
Parenthesis chars are being used and they need to be escaped

This will fix the problem observed in [#4358](https://github.com/kiwicom/orbit/pull/4358)