### PR TITLE
chore: run workflow once the PR is created by job

### DIFF
--- a/.github/workflows/cron-update-icons.yml
+++ b/.github/workflows/cron-update-icons.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/github-script@v6
         if: env.new_files == 'true'
         with:
+          github-token: ${{ secrets.PAT }}
           script: |
             github.rest.pulls.create({
               owner: context.repo.owner,


### PR DESCRIPTION
This PR includes news settings of GitHub actions workflow - once the once the PR is (automatically) created then its respective GH actions are triggered.

Jira ticket: https://kiwicom.atlassian.net/browse/FEPLT-2003