### PR TITLE
Limit prose action to 300 changed files

### DIFF
--- a/.github/workflows/lint-prose.yml
+++ b/.github/workflows/lint-prose.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   prose:
     runs-on: ubuntu-latest
+    # https://github.com/reviewdog/reviewdog/issues/1696
+    if: ${{ github.event.pull_request.changed_files < 301 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
There is a limitation on the action that can't be executed when the PR has more than 300 files. Limiting this so the job does not fail in bigger PRs.