### PR TITLE
Fix accidentally broken stories

### DIFF
--- a/packages/orbit-components/src/Accordion/Accordion.stories.tsx
+++ b/packages/orbit-components/src/Accordion/Accordion.stories.tsx
@@ -27,13 +27,19 @@ const Footer = () => {
 const meta: Meta<typeof Accordion> = {
   title: "Accordion",
   component: Accordion,
+
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof Accordion>;
 
 export const Default: Story = {
-  render: () => {
+  render: function Render() {
     const [expandedSection, setExpandedSection] = React.useState("0X1");
 
     return (
@@ -77,7 +83,7 @@ export const Default: Story = {
 };
 
 export const AccordionWithDisabledSections: Story = {
-  render: () => {
+  render: function Render() {
     const [expandedSection, setExpandedSection] = React.useState("0X1");
 
     return (
@@ -134,7 +140,7 @@ export const AccordionWithDisabledSections: Story = {
 };
 
 export const AccordionWithCustomActions: Story = {
-  render: () => {
+  render: function Render() {
     const [expandedSection, setExpandedSection] = React.useState("0X1");
 
     return (
@@ -188,7 +194,7 @@ export const AccordionWithCustomActions: Story = {
 };
 
 export const AccordionWithStickyFooter: Story = {
-  render: () => {
+  render: function Render() {
     const [expandedSection, setExpandedSection] = React.useState("0X1");
 
     return (

--- a/packages/orbit-components/src/BadgeList/BadgeList.stories.tsx
+++ b/packages/orbit-components/src/BadgeList/BadgeList.stories.tsx
@@ -33,6 +33,12 @@ export const Default: Story = {
       </BadgeListItem>
     </BadgeList>
   ),
+
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const Types: Story = {
@@ -55,6 +61,12 @@ export const Types: Story = {
       </BadgeList>
     );
   },
+
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const Sizes: Story = {
@@ -68,6 +80,12 @@ export const Sizes: Story = {
       </BadgeListItem>
     </BadgeList>
   ),
+
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const Playground: Story = {
@@ -154,4 +172,10 @@ export const RTL: Story = {
       </BadgeList>
     </RenderInRtl>
   ),
+
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };

--- a/packages/orbit-components/src/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/orbit-components/src/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -38,6 +38,12 @@ export const Default = {
       <BreadcrumbsItem>4. Level</BreadcrumbsItem>
     </Breadcrumbs>
   ),
+
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const Playground: Story = {
@@ -104,6 +110,12 @@ export const Rtl: Story = {
       </Breadcrumbs>
     </RenderInRtl>
   ),
+
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const BackLink: Story = {
@@ -115,5 +127,8 @@ export const BackLink: Story = {
 
   parameters: {
     info: "Render the back button as a link.",
+    controls: {
+      disable: true,
+    },
   },
 };

--- a/packages/orbit-components/src/SegmentedSwitch/SegmentedSwitch.stories.tsx
+++ b/packages/orbit-components/src/SegmentedSwitch/SegmentedSwitch.stories.tsx
@@ -68,3 +68,11 @@ Rtl.story = {
     info: "This is a preview of this component in RTL setup.",
   },
 };
+
+Rtl.args = {
+  label: "Gender",
+  help: "When Chuck Norris plays dodgeball, the balls dodge him.",
+  error: "Chuck Norris makes onions cry.",
+  maxWidth: "",
+  showTooltip: false,
+};

--- a/packages/orbit-components/src/Tag/Tag.stories.tsx
+++ b/packages/orbit-components/src/Tag/Tag.stories.tsx
@@ -102,7 +102,7 @@ export const Default: Story = {
   parameters: {
     info: "Check Orbit.Kiwi for more detailed design guidelines.",
     controls: {
-      exclude: ["content", "size", "removable", "selected", "dateTag", "type", "iconLeft"],
+      disable: true,
     },
   },
 };

--- a/packages/orbit-components/src/Wizard/Wizard.stories.tsx
+++ b/packages/orbit-components/src/Wizard/Wizard.stories.tsx
@@ -115,10 +115,6 @@ export const Playground = ({
   );
 };
 
-Playground.story = {
-  parameters: { knobs: { escapeHTML: false } },
-};
-
 Playground.args = {
   labelClose: "Close",
   labelProgress: "of",


### PR DESCRIPTION
Some changes in [Storybook update PR](https://github.com/kiwicom/orbit/pull/4407) were accidentally removed [during the final rebase](https://github.com/kiwicom/orbit/compare/670e48d1c49863fb9619175f688b3965d0452f0a..9c1d46a3b13cc82d9152f2a2475e91537a75d3e6). This PR is adding them back.

Closes https://kiwicom.atlassian.net/browse/FEPLT-2082