### PR TITLE
fix(InputSelect): use option value as key

### DIFF
--- a/packages/orbit-components/src/InputSelect/index.tsx
+++ b/packages/orbit-components/src/InputSelect/index.tsx
@@ -262,7 +262,7 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
       if (results.groups.length === 0) {
         return results.all.map((option, idx) => {
           const { title, description, prefix, value: optValue } = option;
-          const optionId = randomId(title);
+          const optionId = randomId(`${title}_${optValue}`);
           const isSelected = optValue === selectedOption?.value;
           const optionRef = React.createRef() as React.RefObject<HTMLDivElement>;
           refs[idx] = optionRef;
@@ -317,7 +317,7 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
                   refs[optionIdx] = optionRef;
 
                   const { title, description, prefix, value: optValue } = option;
-                  const optionId = randomId(title);
+                  const optionId = randomId(`${title}_${optValue}`);
                   const isSelected = optValue === selectedOption?.value;
 
                   return (
@@ -359,7 +359,7 @@ const InputSelect = React.forwardRef<HTMLInputElement, Props>(
             const optionIdx = idx;
             refs[optionIdx] = optionRef;
 
-            const optionId = randomId(`all_${title}`);
+            const optionId = randomId(`all_${title}_${optValue}`);
             const isSelected = optValue === selectedOption?.value;
 
             return (


### PR DESCRIPTION
We were using title as key in`InputSelectOption` for the dropdown which was causing duplicate keys if there were options with the same title (and different value). I changed the keys to be created from title-value combination to secure uniqueness. Once this was done, filtering started to work properly and options were not duplicated.

Closes https://kiwicom.atlassian.net/browse/FEPLT-2096