### PR TITLE
docs: Remove references to orbit codesandbox

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ about: Create a report to help us improve orbit-components
 
 ## Steps to Reproduce
 
-<!--- Provide a link to a live example - use CodeSandox https://codesandbox.io/s/github/designkiwicom/orbit-sandbox -->
+<!--- Provide a link to a live example - for example, CodeSandox https://codesandbox.io/ -->
 <!--- or provide an unambiguous set of steps to reproduce this bug -->
 
 1. 2. 3. 4.

--- a/docs/src/documentation/01-getting-started/02-for-developers.mdx
+++ b/docs/src/documentation/01-getting-started/02-for-developers.mdx
@@ -57,7 +57,7 @@ See [more info about the Orbit provider](/utilities/orbit-provider/).
 
 For a live preview, check out our [Storybook](https://kiwicom.github.io/orbit/) or [orbit.kiwi](https://orbit.kiwi).
 
-You can also try `orbit-components` live on [CodeSandbox](https://codesandbox.io/s/github/designkiwicom/orbit-sandbox).
+You can also try `orbit-components` directly on our [Playground](https://orbit.kiwi/playground/).
 
 ## Typescript
 

--- a/packages/orbit-components/README.md
+++ b/packages/orbit-components/README.md
@@ -42,7 +42,7 @@ or do so with [Yarn](https://yarnpkg.com/):
 
 For a live preview, check out our [Storybook](https://kiwicom.github.io/orbit/) or [orbit.kiwi](https://orbit.kiwi).
 
-You can also try `orbit-components` live on [CodeSandbox](https://codesandbox.io/s/github/designkiwicom/orbit-sandbox).
+You can also try `orbit-components` directly on our [Playground](https://orbit.kiwi/playground/).
 
 ## Contributing
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ If you want to use custom theme inside your project, it's necessary to wrap your
 
 For live preview check out [Storybook](https://kiwicom.github.io/orbit/) or [orbit.kiwi](https://orbit.kiwi).
 
-You can also try `orbit-components` live on [CodeSandbox](https://codesandbox.io/s/github/designkiwicom/orbit-sandbox).
+You can also try `orbit-components` directly on our [Playground](https://orbit.kiwi/playground/).
 
 ## Documentation
 


### PR DESCRIPTION
The given example was broken so it was replaced it by the playground.

For the issue template we just provide an example