### PR TITLE
Add accessibility props to Seat

### DIFF
--- a/docs/src/documentation/03-components/08-visuals/seat/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/08-visuals/seat/03-accessibility.mdx
@@ -1,0 +1,60 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/seat/accessibility/
+---
+
+# Accessibility
+
+## Seat
+
+The Seat component has been designed with accessibility in mind.
+
+It can be used with keyboard navigation, and it includes the following properties that allow to improve the experience for users of assistive technologies:
+
+| Name            | Type     | Description                                                                                                                 |
+| :-------------- | :------- | :-------------------------------------------------------------------------------------------------------------------------- |
+| aria-labelledby | `string` | Id(s) of elements that announce the component to screen readers.                                                            |
+| title           | `string` | Adds the `title` attribute to the rendered SVG element. Announced by screen readers after the `aria-labelledby` element(s). |
+| description     | `string` | Adds the `description` attribute to the rendered SVG element. Announced by screen readers after the `title` value.          |
+
+All the props above are optional, but recommended to use to ensure the best experience for all users.
+
+The `aria-labelledby` prop can reference multiple ids, separated by a space.
+The elements with those ids can be hidden, so that their text is only announced by screen readers.
+
+The `title` and `description` props are used to provide additional context to the rendered SVG element that visually represents the seat.
+They are also announced by screen readers.
+
+The conjugation of these properties allows to provide a detailed description of the seat to users of assistive technologies.
+
+For example, the following code snippet shows how to use these properties:
+
+```jsx
+<p id="l1" style={{ display: "none", visibility: "hidden" }}>
+  For passenger John Doe
+</p>
+<Seat
+  aria-labelledby="l1"
+  title="Seat 1A"
+  description="Extra legroom"
+  label="25€"
+/>
+```
+
+It would have the screen reader announce: "For passenger John Doe. Seat 1A. Extra legroom.".
+
+Note that the `label` prop is **not** announced by screen readers, as it is intended for visual representation only.
+So be sure to include all relevant information on the three properties that are announced by screen readers.
+
+Alternatively, the paragraph element with the id `l1` is visually hidden, so that its text is only read by screen readers but not present on the screen.
+
+It is also recommended to have those strings translated and change dynamically based on the state of the user journey (eg: if the seat is selected and the user is about to deselect it, the screen reader should announce it).
+
+## SeatLegend
+
+The SeatLegend component is not interactive. However, it accepts the `aria-label` prop, that is passed to the rendered SVG element.
+
+It allows for screen readers to provide a meaningful description of the seat type, which can be useful for users of assistive technologies.
+
+The `label` prop is also announced by screen readers.

--- a/docs/src/documentation/05-development/04-migration-guides/01-v18.mdx
+++ b/docs/src/documentation/05-development/04-migration-guides/01-v18.mdx
@@ -19,3 +19,19 @@ This prop was deprecated since Orbit 17.1 and is now removed.
 The prop was semantically incorrect, since `input` elements with `type="radio"` and `type="checkbox"` cannot be read-only.
 
 A possible alternative is to use the `disabled` prop.
+
+### Seat component
+
+#### `title` and `description` props no longer have default values
+
+These props are used to give additional context to the rendered SVG element that visually represents the seat. They are not rendered on the screen, but are announced by screen readers.
+
+The previous default values were not meaningful and could lead to wrong or misleading information.
+
+As they are announced by screen readers, they should have meaningful and translated text.
+
+#### `label` and `price` props now only accept string
+
+These props used to accept React nodes as well, but this could result in some unexpected or wrong HTML structure.
+
+Therefore, these props now only accept strings.

--- a/packages/orbit-components/src/Seat/README.md
+++ b/packages/orbit-components/src/Seat/README.md
@@ -16,18 +16,8 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in Seat component.
 
-| Name        | Type                    | Default                        | Description                                  |
-| :---------- | :---------------------- | :----------------------------- | :------------------------------------------- |
-| dataTest    | `string`                |                                | Optional prop for testing purposes.          |
-| id          | `string`                |                                | Set `id` for `Seat`                          |
-| size        | [`enum`](#modal-enum)   | `medium`                       | Size of Seat component.                      |
-| type        | [`enum`](#modal-enum)   | `default`                      | Visual type of Seat                          |
-| price       | `string`                |                                | Price of Seat                                |
-| label       | `string`                |                                | Label text inside of a Seat                  |
-| selected    | `boolean`               |                                | Marks Seat as selected                       |
-| title       | `string`                | `Seat`                         | Optional prop for title of svg element       |
-| description | `string`                | `Presents options for seating` | Optional prop for Description of svg element |
-| onClick     | `() => void \| Promise` |                                | Function for handling onClick event.         |
+| title | `string` | | Adds title title to svg element. Announced by screen readers. |
+| description | `string` | | Adds description to svg element. Announced by screen readers. |
 
 ## SeatLegend
 

--- a/packages/orbit-components/src/Seat/README.md
+++ b/packages/orbit-components/src/Seat/README.md
@@ -23,7 +23,7 @@ Table below contains all types of the props available in Seat component.
 | size            | [`enum`](#modal-enum)   | `medium`  | Size of Seat component.                                              |
 | type            | [`enum`](#modal-enum)   | `default` | Visual type of Seat. If `unavailable`, the element becomes disabled. |
 | price           | `string`                |           | Price of Seat. Displayed as text underneath the svg.                 |
-| label           | `string`                |           | Label text inside of a Seat. Not announced by **screen readers**.    |
+| label           | `string`                |           | Label text inside of a Seat. Not announced by screen readers.        |
 | selected        | `boolean`               |           | Displays Seat as selected.                                           |
 | onClick         | `() => void \| Promise` |           | Function for handling onClick event.                                 |
 | aria-labelledby | `string`                |           | Id(s) of elements that announce the component to screen readers.     |

--- a/packages/orbit-components/src/Seat/README.md
+++ b/packages/orbit-components/src/Seat/README.md
@@ -34,11 +34,13 @@ Table below contains all types of the props available in Seat component.
 
 Table below contains all types of the props available in Seat/SeatLegend component.
 
-| Name     | Type                  | Default   | Description                         |
-| :------- | :-------------------- | :-------- | :---------------------------------- |
-| dataTest | `string`              |           | Optional prop for testing purposes. |
-| type     | [`enum`](#modal-enum) | `default` | Visual type of SeatLegend           |
-| label    | `string`              |           | Label text inside of a SeatLegend   |
+| Name       | Type                  | Default   | Description                                                                           |
+| :--------- | :-------------------- | :-------- | :------------------------------------------------------------------------------------ |
+| dataTest   | `string`              |           | Optional prop for testing purposes.                                                   |
+| id         | `string`              |           | `id` of the element.                                                                  |
+| type       | [`enum`](#modal-enum) | `default` | Visual type of the rendered seat icon.                                                |
+| label      | `string`              |           | Label text to be displayed next to the seat icon.                                     |
+| aria-label | `string`              |           | Adds `aria-label` attribute to the rendered SVG element. Announced by screen readers. |
 
 ### enum
 

--- a/packages/orbit-components/src/Seat/README.md
+++ b/packages/orbit-components/src/Seat/README.md
@@ -16,8 +16,19 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in Seat component.
 
-| title | `string` | | Adds title title to svg element. Announced by screen readers. |
-| description | `string` | | Adds description to svg element. Announced by screen readers. |
+| Name            | Type                    | Default   | Description                                                          |
+| :-------------- | :---------------------- | :-------- | :------------------------------------------------------------------- |
+| dataTest        | `string`                |           | Optional prop for testing purposes.                                  |
+| id              | `string`                |           | `id` of the element.                                                 |
+| size            | [`enum`](#modal-enum)   | `medium`  | Size of Seat component.                                              |
+| type            | [`enum`](#modal-enum)   | `default` | Visual type of Seat. If `unavailable`, the element becomes disabled. |
+| price           | `string`                |           | Price of Seat. Displayed as text underneath the svg.                 |
+| label           | `string`                |           | Label text inside of a Seat. Not announced by **screen readers**.    |
+| selected        | `boolean`               |           | Displays Seat as selected.                                           |
+| onClick         | `() => void \| Promise` |           | Function for handling onClick event.                                 |
+| aria-labelledby | `string`                |           | Id(s) of elements that announce the component to screen readers.     |
+| title           | `string`                |           | Adds title title to svg element. Announced by screen readers.        |
+| description     | `string`                |           | Adds description to svg element. Announced by screen readers.        |
 
 ## SeatLegend
 

--- a/packages/orbit-components/src/Seat/Seat.stories.tsx
+++ b/packages/orbit-components/src/Seat/Seat.stories.tsx
@@ -66,7 +66,7 @@ export const Playground: Story = {
   },
 };
 
-export const Legend: Story = {
+export const Legend: StoryObj<typeof SeatLegend> = {
   render: args => <SeatLegend {...args} />,
 
   parameters: {
@@ -78,5 +78,6 @@ export const Legend: Story = {
 
   args: {
     label: "Extra legroom ($ 5.99 – $ 12.98)",
+    "aria-label": "Available seat",
   },
 };

--- a/packages/orbit-components/src/Seat/Seat.stories.tsx
+++ b/packages/orbit-components/src/Seat/Seat.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Seat> = {
   parameters: {
     info: "Seat components stories. Visit Orbit.Kiwi for more detailed guidelines.",
     controls: {
-      exclude: ["onClick"],
+      exclude: ["onClick", "aria-labelledby"],
     },
   },
 
@@ -40,7 +40,7 @@ type Story = StoryObj<typeof Seat>;
 export const Default: Story = {
   parameters: {
     controls: {
-      exclude: ["type", "size", "title", "description", "selected", "onClick"],
+      exclude: ["aria-labelledby", "type", "size", "selected"],
     },
   },
 };
@@ -72,7 +72,7 @@ export const Legend: Story = {
   parameters: {
     info: "SeatLegend component. Check Orbit.Kiwi for more detailed guidelines.",
     controls: {
-      exclude: ["size", "title", "description", "selected", "onClick"],
+      exclude: ["size", "selected", "aria-labelledby"],
     },
   },
 

--- a/packages/orbit-components/src/Seat/components/SeatLegend/index.tsx
+++ b/packages/orbit-components/src/Seat/components/SeatLegend/index.tsx
@@ -8,10 +8,17 @@ import Text from "../../../Text";
 import { TYPES } from "../../consts";
 import type { Props } from "./types";
 
-const SeatLegend = ({ type = TYPES.DEFAULT, label, dataTest }: Props) => {
+const SeatLegend = ({ type = TYPES.DEFAULT, label, dataTest, "aria-label": ariaLabel }: Props) => {
   return (
     <Stack inline align="center" spacing="200">
-      <svg width="16" height="20" viewBox="0 0 16 20" fill="none" data-test={dataTest}>
+      <svg
+        width="16"
+        height="20"
+        viewBox="0 0 16 20"
+        fill="none"
+        data-test={dataTest}
+        aria-label={ariaLabel}
+      >
         <path
           className={cx(
             type === TYPES.LEGROOM && "fill-blue-light-active",

--- a/packages/orbit-components/src/Seat/components/SeatLegend/index.tsx
+++ b/packages/orbit-components/src/Seat/components/SeatLegend/index.tsx
@@ -8,10 +8,17 @@ import Text from "../../../Text";
 import { TYPES } from "../../consts";
 import type { Props } from "./types";
 
-const SeatLegend = ({ type = TYPES.DEFAULT, label, dataTest, "aria-label": ariaLabel }: Props) => {
+const SeatLegend = ({
+  type = TYPES.DEFAULT,
+  label,
+  dataTest,
+  "aria-label": ariaLabel,
+  id,
+}: Props) => {
   return (
     <Stack inline align="center" spacing="200">
       <svg
+        id={id}
         width="16"
         height="20"
         viewBox="0 0 16 20"

--- a/packages/orbit-components/src/Seat/components/SeatLegend/types.d.ts
+++ b/packages/orbit-components/src/Seat/components/SeatLegend/types.d.ts
@@ -10,4 +10,5 @@ type Type = "default" | "legroom" | "unavailable";
 export interface Props extends Common.Globals {
   readonly type?: Type;
   readonly label?: React.ReactNode;
+  readonly "aria-label"?: string;
 }

--- a/packages/orbit-components/src/Seat/index.tsx
+++ b/packages/orbit-components/src/Seat/index.tsx
@@ -24,10 +24,11 @@ const Seat = ({
   label,
   title,
   description,
+  "aria-labelledby": ariaLabelledBy = "",
 }: Props) => {
   const randomId = useRandomIdSeed();
-  const titleId = randomId("title");
-  const descrId = randomId("descr");
+  const titleId = title ? randomId("title") : "";
+  const descrId = description ? randomId("descr") : "";
   const clickable = type !== TYPES.UNAVAILABLE;
 
   return (
@@ -46,12 +47,12 @@ const Seat = ({
       >
         <svg
           viewBox={size === SIZE_OPTIONS.SMALL ? "0 0 32 36" : "0 0 46 46"}
-          aria-labelledby={`${titleId} ${descrId}`}
+          aria-labelledby={`${[ariaLabelledBy, titleId, descrId].join(" ").trim()}` || undefined}
           fill="none"
           role="img"
         >
-          <title id={titleId}>{title}</title>
-          <desc id={descrId}>{description}</desc>
+          {title && <title id={titleId}>{title}</title>}
+          {description && <desc id={descrId}>{description}</desc>}
 
           {size === SIZE_OPTIONS.SMALL ? (
             <SeatSmall type={type} selected={selected} label={label} />

--- a/packages/orbit-components/src/Seat/index.tsx
+++ b/packages/orbit-components/src/Seat/index.tsx
@@ -22,8 +22,8 @@ const Seat = ({
   id,
   price,
   label,
-  title = "Seat",
-  description = "Presents options for seating",
+  title,
+  description,
 }: Props) => {
   const randomId = useRandomIdSeed();
   const titleId = randomId("title");

--- a/packages/orbit-components/src/Seat/types.d.ts
+++ b/packages/orbit-components/src/Seat/types.d.ts
@@ -19,6 +19,7 @@ export interface Props extends Common.Globals {
   readonly size?: Size;
   readonly title?: string;
   readonly description?: string;
+  readonly "aria-labelledby"?: string;
   readonly onClick?: Common.Callback;
   readonly selected?: boolean;
   readonly label?: React.ReactNode;

--- a/packages/orbit-components/src/Seat/types.d.ts
+++ b/packages/orbit-components/src/Seat/types.d.ts
@@ -22,6 +22,6 @@ export interface Props extends Common.Globals {
   readonly "aria-labelledby"?: string;
   readonly onClick?: Common.Callback;
   readonly selected?: boolean;
-  readonly label?: React.ReactNode;
-  readonly price?: React.ReactNode;
+  readonly label?: string;
+  readonly price?: string;
 }


### PR DESCRIPTION
Proposal for adding accessibility to Seat component.

New prop `aria-labelledby` added to Seat component. The `title` and `description` props no longer have default values (Breaking change).

New prop `aria-label` added to SeatLegend component.

New accessibility documentation page added for Seat component.

FEPLT-2157