### PR TITLE
Disable update icons automation

### DIFF
--- a/.github/workflows/cron-update-icons.yml
+++ b/.github/workflows/cron-update-icons.yml
@@ -1,8 +1,9 @@
 name: Update icons
 
 on:
-  schedule:
-    - cron: "0 10 * * *"
+  # automation currently disabled while there are some fast-moving changes. Only manual triggers
+  # schedule:
+  #   - cron: "0 10 * * *"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Automation currently disabled while there are some fast-moving changes. Only manual triggers
