### PR TITLE
NavigationBar/Popover a11y enhancements

### DIFF
--- a/docs/src/__examples__/NavigationBar/DEFAULT.tsx
+++ b/docs/src/__examples__/NavigationBar/DEFAULT.tsx
@@ -38,6 +38,7 @@ export default {
           options: ["shadow", "border"],
           defaultValue: "shadow",
         },
+        { name: "ariaLabel", type: "text", defaultValue: "" },
       ],
     },
   ],

--- a/docs/src/__examples__/Popover/DEFAULT.tsx
+++ b/docs/src/__examples__/Popover/DEFAULT.tsx
@@ -73,6 +73,8 @@ export default {
             "bottom-end",
           ],
         },
+        { name: "ariaLabel", type: "text", defaultValue: "" },
+        { name: "ariaLabelledby", type: "text", defaultValue: "" },
       ],
     },
   ],

--- a/packages/orbit-components/src/NavigationBar/NavigationBar.stories.tsx
+++ b/packages/orbit-components/src/NavigationBar/NavigationBar.stories.tsx
@@ -55,9 +55,13 @@ export const NavigationBarComponent: Story = {
           Flights
         </ButtonLink>
         <Stack direction="row" spacing="100" justify="end" shrink>
-          <ButtonLink iconLeft={<StarFull />} type="secondary" />
-          <ButtonLink iconLeft={<QuestionCircle />} type="secondary" />
-          <ButtonLink iconLeft={<AccountCircle />} type="secondary" />
+          <ButtonLink aria-label="Favourites" iconLeft={<StarFull />} type="secondary" />
+          <ButtonLink
+            aria-label="Questions and Answers"
+            iconLeft={<QuestionCircle />}
+            type="secondary"
+          />
+          <ButtonLink aria-label="Account" iconLeft={<AccountCircle />} type="secondary" />
         </Stack>
       </Stack>
     </NavigationBar>

--- a/packages/orbit-components/src/NavigationBar/README.md
+++ b/packages/orbit-components/src/NavigationBar/README.md
@@ -35,3 +35,8 @@ Table below contains all types of the props available in the NavigationBar compo
 | hideOnScroll | `boolean`               | `true`                   | Turn on or off hiding navigation bar on scroll                                                        |
 | openTitle    | `string`                | `"Open navigation menu"` | Property for passing translation string to open Button.                                               |
 | bottomStyle  | `"shadow" \| "border"`  | `"shadow"`               | Property for setting bottom style of NavigationBar.                                                   |
+| ariaLabel    | `string`                | `"navigation"`           | Optional prop for `aria-label` value (accessibility).                                                 |
+
+## Accessibility
+
+- The `ariaLabel` prop allows you to specify an `aria-label` attribute for the component. This attribute provides additional information to screen readers, enhancing the accessibility of the component. By using `ariaLabel`, you can ensure that users who rely on assistive technologies receive the necessary context and information about the component's purpose and functionality.

--- a/packages/orbit-components/src/NavigationBar/index.tsx
+++ b/packages/orbit-components/src/NavigationBar/index.tsx
@@ -20,6 +20,7 @@ const NavigationBar = ({
   onHide,
   hideOnScroll = true,
   bottomStyle = "shadow",
+  ariaLabel = "navigation",
 }: Props) => {
   const resolveCallback = React.useCallback(
     state => {
@@ -71,6 +72,7 @@ const NavigationBar = ({
         bottomStyle === "shadow" && "shadow-fixed",
         bottomStyle === "border" && "border-cloud-normal border-b",
       )}
+      aria-label={ariaLabel}
     >
       <div className="me-200 block w-full">{children}</div>
       {onMenuOpen && (

--- a/packages/orbit-components/src/NavigationBar/types.d.ts
+++ b/packages/orbit-components/src/NavigationBar/types.d.ts
@@ -12,4 +12,5 @@ export interface Props extends Common.Globals {
   readonly openTitle?: string;
   readonly hideOnScroll?: boolean;
   readonly bottomStyle?: "shadow" | "border";
+  readonly ariaLabel?: string;
 }

--- a/packages/orbit-components/src/Popover/Popover.stories.tsx
+++ b/packages/orbit-components/src/Popover/Popover.stories.tsx
@@ -33,6 +33,9 @@ const listChoiceContent = Array.from({ length: 3 }, (_, idx) => (
 
 const selects = (
   <Stack direction="column">
+    <h2 id="passengers" className="sr-only">
+      Passengers
+    </h2>
     <Stack flex shrink align="center" justify="between">
       <Stack inline direction="column" spacing="none">
         <Text>Adult</Text>
@@ -70,6 +73,8 @@ const meta: Meta<typeof Popover> = {
   args: {
     onOpen: action("open"),
     onClose: action("close"),
+    ariaLabel: "Passengers select",
+    ariaLabelledby: "passengers",
   },
 
   parameters: {
@@ -123,6 +128,8 @@ export const Placement: Story = {
         "renderTimeout",
         "onOpen",
         "onClose",
+        "ariaLabel",
+        "ariaLabelledby",
       ],
     },
   },
@@ -160,6 +167,8 @@ export const OpenedByProp: Story = {
         "renderTimeout",
         "onOpen",
         "onClose",
+        "ariaLabel",
+        "ariaLabelledby",
       ],
     },
   },
@@ -188,6 +197,8 @@ export const Overlapped: Story = {
         "renderTimeout",
         "onOpen",
         "onClose",
+        "ariaLabel",
+        "ariaLabelledby",
       ],
     },
   },
@@ -283,6 +294,8 @@ export const ScrollingPage: Story = {
         "onOpen",
         "onClose",
         "labelClose",
+        "ariaLabel",
+        "ariaLabelledby",
       ],
     },
   },

--- a/packages/orbit-components/src/Popover/README.md
+++ b/packages/orbit-components/src/Popover/README.md
@@ -42,6 +42,8 @@ The table below contains all types of props available in the Popover component.
 | labelClose     | `React.Node`             | `Close`             | The label for close button.                                                                                                                      |
 | renderTimeout  | `number`                 | `0`                 | The timeout for rendering the Popover.                                                                                                           |
 | zIndex         | `number`                 | `710`               | The zIndex value of the Popover component.                                                                                                       |
+| ariaLabel      | `string`                 |                     | Optional prop for `aria-label` value.                                                                                                            |
+| ariaLabelledby | `string`                 |                     | Optional prop for `aria-labelledby` value.                                                                                                       |
 
 ## enum
 
@@ -110,3 +112,11 @@ The table below contains all types of props available in the Popover component.
   <Button>Open Popover</Button>
 </Popover>
 ```
+
+## Accessibility
+
+- The `Button` component inside the `Popover` component is the most common trigger component for the opening and closing of the popover. The Popover component includes the `role="button"` attribute. Ensure that the `Button` is set as a non-interactive component (for example, using the `asComponent` prop) to avoid the accessibility violation of nesting interactive controls (`Interactive controls must not be nested`).
+
+- The `ariaLabelledby` prop allows you to specify an `aria-labelledby` attribute for the popover content component. This attribute provides a reference to one or more elements that label the popover content. By using `ariaLabelledby`, the accessibility of popover component is improved and easier for users with assistive technologies to understand the context and purpose of the content.
+
+- The `ariaLabel` prop allows you to specify an `aria-label` attribute for the popover content component. This attribute provides additional information to screen readers, enhancing the accessibility of the component. By using `ariaLabel`, you can ensure that users who rely on assistive technologies receive the necessary context and information about the component's purpose and functionality.

--- a/packages/orbit-components/src/Popover/components/ContentWrapper.tsx
+++ b/packages/orbit-components/src/Popover/components/ContentWrapper.tsx
@@ -45,6 +45,8 @@ export interface Props extends Common.Globals {
   actions?: React.ReactNode;
   offset?: Offset;
   onClose: (ev?: MouseEvent | React.SyntheticEvent<HTMLElement>) => void;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
 }
 
 const PopoverContentWrapper = ({
@@ -67,6 +69,8 @@ const PopoverContentWrapper = ({
   allowOverflow,
   lockScrolling = true,
   actions,
+  ariaLabelledby,
+  ariaLabel,
 }: Props) => {
   const [actionsHeight, setActionsHeight] = React.useState<number | null>(null);
   const { isInsideModal } = React.useContext(ModalContext);
@@ -198,6 +202,8 @@ const PopoverContentWrapper = ({
             shown ? "lm:opacity-100" : "lm:opacity-0",
           )}
           style={cssVars}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledby}
         >
           <div
             ref={content}

--- a/packages/orbit-components/src/Popover/index.tsx
+++ b/packages/orbit-components/src/Popover/index.tsx
@@ -33,6 +33,8 @@ const Popover = ({
   actions,
   overlapped,
   dataTest,
+  ariaLabel,
+  ariaLabelledby,
 }: Props) => {
   const ref = React.useRef<HTMLDivElement | null>(null);
   const popoverId = useRandomId();
@@ -142,6 +144,8 @@ const Popover = ({
       referenceElement={ref.current}
       onClose={handleOut}
       placement={placement}
+      ariaLabel={ariaLabel}
+      ariaLabelledby={ariaLabelledby}
     >
       {content}
     </PopoverContent>
@@ -157,9 +161,7 @@ const Popover = ({
         // @ts-expect-error expected
         // eslint-disable-next-line react/no-unknown-property
         popovertarget={id || popoverId}
-        // according to our docs button should be used for opening popover inside children (uncontrolled behavior),
-        // that's why this div shouldn't be focusable in order to avoid double focus
-        tabIndex={-1}
+        tabIndex={0}
         onClick={handleClick}
         onKeyDown={handleKeyDown<HTMLDivElement>(handleClick)}
       >

--- a/packages/orbit-components/src/Popover/types.d.ts
+++ b/packages/orbit-components/src/Popover/types.d.ts
@@ -32,4 +32,6 @@ export interface Props extends Common.Globals {
   readonly renderInPortal?: boolean;
   readonly onClose?: Common.Callback;
   readonly zIndex?: number;
+  readonly ariaLabel?: string;
+  readonly ariaLabelledby?: string;
 }


### PR DESCRIPTION
Based on the a11y, some of the violations are caused by incorrect implementation of Nitro component(s) (Navbar). These components import Orbit components.

EDIT: I've also changed the `tabIndex` value for Popover component to make it accessible.

Closes https://kiwicom.atlassian.net/browse/FEPLT-2170


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR enhances accessibility for the NavigationBar and Popover components by adding `ariaLabel` and `ariaLabelledby` props, improving screen reader support.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Screen Reader
    participant NavigationBar
    participant Popover

    User->>NavigationBar: Interacts with navigation
    NavigationBar->>Screen Reader: Announces "navigation" (new ariaLabel)
    NavigationBar->>Screen Reader: Announces button labels (new aria-labels for ButtonLinks)

    User->>Popover: Opens popover
    Popover->>Screen Reader: Announces custom label (new ariaLabel)
    Popover->>Screen Reader: Associates with heading (new ariaLabelledby)
    
    Note over NavigationBar,Popover: Accessibility Improvements:<br/>- Added aria-label support<br/>- Added aria-labelledby support<br/>- Enhanced screen reader context
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4540/files#diff-9af4a2c9623201949b399db556564c2695009152e5339da803156adb8627055b>docs/src/__examples__/NavigationBar/DEFAULT.tsx</a></td><td>Added <code>ariaLabel</code> prop to the NavigationBar example.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4540/files#diff-75026a419a27c1f4d178149db48b26bde704f601267bfd98d7e17c440ef50c49>docs/src/__examples__/Popover/DEFAULT.tsx</a></td><td>Added <code>ariaLabel</code> and <code>ariaLabelledby</code> props to the Popover example.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4540/files#diff-5b9e7f0bd4b59c37f009a917cd150fb4fe0cb7ddb52eb5d575c12e20763edc81>packages/orbit-components/src/NavigationBar/NavigationBar.stories.tsx</a></td><td>Updated ButtonLink components to include <code>aria-label</code> for accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4540/files#diff-5cfcc97b511eca6782561475d76b51610305e6b768ad9c3b3c2afe3f74e6ead8>packages/orbit-components/src/NavigationBar/README.md</a></td><td>Documented the new <code>ariaLabel</code> prop in the NavigationBar README.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4540/files#diff-baa0d116f2cd2a7ed17331472d0251da1103511273373bd3424fe42f4639d759>packages/orbit-components/src/NavigationBar/index.tsx</a></td><td>Implemented <code>ariaLabel</code> prop in the NavigationBar component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4540/files#diff-4b8aace655a5d59f1921958c3558a02c9cdbb18dc5faf77b7d39855458def35e>packages/orbit-components/src/NavigationBar/types.d.ts</a></td><td>Added <code>ariaLabel</code> prop to the NavigationBar props interface.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4540/files#diff-ca29b1b6c6e3ddd66c963c9eb160b7558afe340a282948a873269ca514eda188>packages/orbit-components/src/Popover/Popover.stories.tsx</a></td><td>Added <code>ariaLabel</code> and <code>ariaLabelledby</code> props to Popover stories.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4540/files#diff-9ca39918a965f479ab1b26f600baee10d735108736c0babb261fe247b0605444>packages/orbit-components/src/Popover/README.md</a></td><td>Documented the new <code>ariaLabel</code> and <code>ariaLabelledby</code> props in the Popover README.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4540/files#diff-b0931fcfaa0b25339540369377e32c14696117b693788953e12415e5ebea91f2>packages/orbit-components/src/Popover/components/ContentWrapper.tsx</a></td><td>Added <code>ariaLabel</code> and <code>ariaLabelledby</code> props to the Popover content wrapper.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4540/files#diff-1749fd3089b157f03d9a036ffcccba86319fe6c34eb3331487f8bcdf94be5c2f>packages/orbit-components/src/Popover/index.tsx</a></td><td>Implemented <code>ariaLabel</code> and <code>ariaLabelledby</code> props in the Popover component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4540/files#diff-c14fc421ca967c7f213b4976131790c77e3893b5b3c17c11e085346d74150fa9>packages/orbit-components/src/Popover/types.d.ts</a></td><td>Added <code>ariaLabel</code> and <code>ariaLabelledby</code> props to the Popover props interface.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->












