### PR TITLE
feat(NavigationBar): allow for transparent background when at the top…

### DIFF
--- a/packages/orbit-components/src/NavigationBar/NavigationBar.stories.tsx
+++ b/packages/orbit-components/src/NavigationBar/NavigationBar.stories.tsx
@@ -33,6 +33,7 @@ const meta: Meta<typeof NavigationBar> = {
     onShow: action("onShow"),
     onHide: action("onHide"),
     bottomStyle: "shadow",
+    transparentBgAtTop: false,
   },
 
   argTypes: {

--- a/packages/orbit-components/src/NavigationBar/README.md
+++ b/packages/orbit-components/src/NavigationBar/README.md
@@ -24,18 +24,19 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the NavigationBar component.
 
-| Name         | Type                    | Default                  | Description                                                                                           |
-| :----------- | :---------------------- | :----------------------- | :---------------------------------------------------------------------------------------------------- |
-| **children** | `React.Node`            |                          | The content of the NavigationBar.                                                                     |
-| dataTest     | `string`                |                          | Optional prop for testing purposes.                                                                   |
-| id           | `string`                |                          | Set `id` for `NavigationBar`.                                                                         |
-| onMenuOpen   | `() => void \| Promise` |                          | Function for handling onClick event on HamburgerMenu icon. If `null`, the HamburgerMenu won't appear. |
-| onHide       | `() => void \| Promise` |                          | Function for handling event when the NavigationBar disappears.                                        |
-| onShow       | `() => void \| Promise` |                          | Function for handling event when the NavigationBar appears.                                           |
-| hideOnScroll | `boolean`               | `true`                   | Turn on or off hiding navigation bar on scroll                                                        |
-| openTitle    | `string`                | `"Open navigation menu"` | Property for passing translation string to open Button.                                               |
-| bottomStyle  | `"shadow" \| "border"`  | `"shadow"`               | Property for setting bottom style of NavigationBar.                                                   |
-| ariaLabel    | `string`                | `"navigation"`           | Optional prop for `aria-label` value (accessibility).                                                 |
+| Name               | Type                    | Default                  | Description                                                                                                 |
+| :----------------- | :---------------------- | :----------------------- | :---------------------------------------------------------------------------------------------------------- |
+| **children**       | `React.Node`            |                          | The content of the NavigationBar.                                                                           |
+| dataTest           | `string`                |                          | Optional prop for testing purposes.                                                                         |
+| id                 | `string`                |                          | Set `id` for `NavigationBar`.                                                                               |
+| onMenuOpen         | `() => void \| Promise` |                          | Function for handling onClick event on HamburgerMenu icon. If `null`, the HamburgerMenu won't appear.       |
+| onHide             | `() => void \| Promise` |                          | Function for handling event when the NavigationBar disappears.                                              |
+| onShow             | `() => void \| Promise` |                          | Function for handling event when the NavigationBar appears.                                                 |
+| hideOnScroll       | `boolean`               | `true`                   | Turn on or off hiding navigation bar on scroll                                                              |
+| openTitle          | `string`                | `"Open navigation menu"` | Property for passing translation string to open Button.                                                     |
+| bottomStyle        | `"shadow" \| "border"`  | `"shadow"`               | Property for setting bottom style of NavigationBar.                                                         |
+| ariaLabel          | `string`                | `"navigation"`           | Optional prop for `aria-label` value (accessibility).                                                       |
+| transparentBgAtTop | `boolean`               | `false`                  | Property for setting the background to be transparent when the NavigationBar is at the top of the viewport. |
 
 ## Accessibility
 

--- a/packages/orbit-components/src/NavigationBar/index.tsx
+++ b/packages/orbit-components/src/NavigationBar/index.tsx
@@ -21,6 +21,7 @@ const NavigationBar = ({
   hideOnScroll = true,
   bottomStyle = "shadow",
   ariaLabel = "navigation",
+  transparentBgAtTop = false,
 }: Props) => {
   const resolveCallback = React.useCallback(
     state => {
@@ -32,12 +33,17 @@ const NavigationBar = ({
   const [shown, setShown] = useStateWithCallback<boolean>(true, resolveCallback);
 
   const [prevScrollPosition, setPrevScrollPosition] = React.useState(0);
+  const [isTransparentBg, setTransparentBg] = React.useState(transparentBgAtTop);
 
   const handleNavigationBarPosition = React.useCallback(() => {
     const currentScrollPosition =
       window.scrollY ||
       window.pageYOffset ||
       (document.documentElement && document.documentElement.scrollTop);
+
+    if (transparentBgAtTop) {
+      setTransparentBg(currentScrollPosition <= 0);
+    }
 
     if (!hideOnScroll) return;
 
@@ -51,7 +57,7 @@ const NavigationBar = ({
     }
 
     setPrevScrollPosition(currentScrollPosition);
-  }, [prevScrollPosition, setShown, hideOnScroll]);
+  }, [prevScrollPosition, setShown, hideOnScroll, transparentBgAtTop, setTransparentBg]);
 
   React.useEffect(() => {
     window.addEventListener("scroll", handleNavigationBarPosition);
@@ -60,17 +66,40 @@ const NavigationBar = ({
     };
   });
 
+  React.useEffect(() => {
+    const currentScrollPosition =
+      window.scrollY ||
+      window.pageYOffset ||
+      (document.documentElement && document.documentElement.scrollTop);
+    if (transparentBgAtTop) {
+      setTransparentBg(currentScrollPosition <= 0);
+    } else {
+      setTransparentBg(false);
+    }
+  }, [transparentBgAtTop]);
+
+  React.useEffect(() => {
+    if (!hideOnScroll) {
+      setShown(true);
+    }
+  }, [hideOnScroll, setShown]);
+
   return (
     <nav
       data-test={dataTest}
       id={id}
       className={cx(
-        "bg-white-normal px-400 py-300 tb:p-300 z-navigation-bar fixed inset-x-0 top-0 box-border flex w-full translate-x-0 items-center",
-        "duration-normal transform-gpu transition-transform ease-in-out",
+        "px-400 py-300 tb:p-300 z-navigation-bar fixed inset-x-0 top-0 box-border flex w-full translate-x-0 items-center",
+        "duration-normal transform-gpu ease-in-out",
         "tb:h-1600 h-1300", // As defined on the const above
         shown ? "translate-y-0" : "tb:-translate-y-1600 -translate-y-1300", // As defined on the const above
-        bottomStyle === "shadow" && "shadow-fixed",
-        bottomStyle === "border" && "border-cloud-normal border-b",
+        transparentBgAtTop
+          ? "transition-[transform,background-color,border-color]"
+          : "transition-transform",
+        !isTransparentBg && bottomStyle === "shadow" && "shadow-fixed",
+        isTransparentBg && bottomStyle === "border" && "border-transparent", // important for the transition to work well
+        !isTransparentBg && bottomStyle === "border" && "border-cloud-normal border-b",
+        isTransparentBg ? "bg-transparent" : "bg-white-normal",
       )}
       aria-label={ariaLabel}
     >

--- a/packages/orbit-components/src/NavigationBar/types.d.ts
+++ b/packages/orbit-components/src/NavigationBar/types.d.ts
@@ -13,4 +13,5 @@ export interface Props extends Common.Globals {
   readonly hideOnScroll?: boolean;
   readonly bottomStyle?: "shadow" | "border";
   readonly ariaLabel?: string;
+  readonly transparentBgAtTop?: boolean;
 }


### PR DESCRIPTION
… of the screen

This was requested on Slack.

# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`

Here's a preview of the change:

https://github.com/user-attachments/assets/19f14867-fd9e-4312-bb9a-459b10ef2955



<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces a new feature to the `NavigationBar` component, allowing for a transparent background when the navigation bar is at the top of the viewport.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant User
    participant NavigationBar
    participant Window

    Note over NavigationBar: Initialize with transparentBgAtTop prop

    alt transparentBgAtTop is true
        Window->>NavigationBar: Initial scroll position check
        NavigationBar->>NavigationBar: Set transparent bg if at top
    end

    User->>Window: Scrolls page
    Window->>NavigationBar: Scroll event
    
    alt transparentBgAtTop is true
        NavigationBar->>NavigationBar: Check scroll position
        alt scroll position <= 0
            NavigationBar->>NavigationBar: Set background transparent
        else scroll position > 0
            NavigationBar->>NavigationBar: Set background white
        end
    end

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4542/files#diff-5b9e7f0bd4b59c37f009a917cd150fb4fe0cb7ddb52eb5d575c12e20763edc81>packages/orbit-components/src/NavigationBar/NavigationBar.stories.tsx</a></td><td>Added a new prop <code>transparentBgAtTop</code> to the NavigationBar story.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4542/files#diff-5cfcc97b511eca6782561475d76b51610305e6b768ad9c3b3c2afe3f74e6ead8>packages/orbit-components/src/NavigationBar/README.md</a></td><td>Updated the documentation to include the new <code>transparentBgAtTop</code> prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4542/files#diff-baa0d116f2cd2a7ed17331472d0251da1103511273373bd3424fe42f4639d759>packages/orbit-components/src/NavigationBar/index.tsx</a></td><td>Implemented the logic for the <code>transparentBgAtTop</code> prop in the NavigationBar component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4542/files#diff-4b8aace655a5d59f1921958c3558a02c9cdbb18dc5faf77b7d39855458def35e>packages/orbit-components/src/NavigationBar/types.d.ts</a></td><td>Added type definition for the new <code>transparentBgAtTop</code> prop.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






