### PR TITLE
Collapse: fix a11y violation (interactive nested elements)

### DIFF
--- a/packages/orbit-components/src/Collapse/Collapse.stories.tsx
+++ b/packages/orbit-components/src/Collapse/Collapse.stories.tsx
@@ -213,6 +213,12 @@ export const Uncontrolled: Story = {
   args: {
     expanded: undefined,
   },
+
+  parameters: {
+    controls: {
+      exclude: "expanded",
+    },
+  },
 };
 
 export const Rtl: Story = {

--- a/packages/orbit-components/src/Collapse/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Collapse/__tests__/index.test.tsx
@@ -4,10 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { render, screen } from "../../test-utils";
 import Collapse from "..";
 
-const toggleButtons = [
-  [0, "label"],
-  [1, "icon button"],
-];
+const toggleButtons = ["label", "icon button"];
 
 describe("Collapse", () => {
   const user = userEvent.setup();
@@ -31,32 +28,41 @@ describe("Collapse", () => {
     expect(screen.getByText("customLabel")).toBeInTheDocument();
   });
 
-  it.each(toggleButtons)("should trigger click handler when clicking on %s", async buttonIndex => {
-    const onClick = jest.fn();
-    render(
-      <Collapse label="Collapse" onClick={onClick}>
-        <div>children</div>
-      </Collapse>,
-    );
-    const toggleButton = screen.getAllByRole("button", { name: "Collapse" })[buttonIndex];
-    await user.click(toggleButton);
-    expect(onClick).toHaveBeenCalled();
-  });
+  it.each(toggleButtons)(
+    "should trigger click handler when clicking on %s",
+    async triggerButton => {
+      const onClick = jest.fn();
+      render(
+        <Collapse label="Collapse" onClick={onClick}>
+          <div>children</div>
+        </Collapse>,
+      );
+
+      const toggleButton =
+        triggerButton === "label"
+          ? screen.getByText("Collapse")
+          : screen.getByRole("button", { expanded: false });
+
+      await user.click(toggleButton);
+      expect(onClick).toHaveBeenCalled();
+    },
+  );
 
   describe("uncontrolled", () => {
-    it.each(toggleButtons)("should expand/collapse when clicking on %s", async buttonIndex => {
+    it("should expand/collapse when clicking on button", async () => {
       render(
         <Collapse label="Collapse">
           <article>children</article>
         </Collapse>,
       );
-      const toggleButton = screen.getAllByRole("button", { name: "Collapse" })[buttonIndex];
-      // with ByRole we can test whether the content is visible because of aria-hidden
-      expect(screen.queryByRole("article")).not.toBeInTheDocument();
-      await user.click(toggleButton);
-      expect(screen.getByRole("article")).toBeInTheDocument();
-      await user.click(toggleButton);
-      expect(screen.queryByRole("article")).not.toBeInTheDocument();
+
+      await screen.getAllByRole("button").forEach(async toggleButton => {
+        expect(screen.queryByRole("article")).not.toBeInTheDocument();
+        await user.click(toggleButton);
+        expect(screen.getByRole("article")).toBeInTheDocument();
+        await user.click(toggleButton);
+        expect(screen.queryByRole("article")).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/packages/orbit-components/src/Collapse/index.tsx
+++ b/packages/orbit-components/src/Collapse/index.tsx
@@ -64,36 +64,35 @@ const Collapse = ({
       data-test={dataTest}
       id={id}
     >
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
-      <div
-        className="block w-full cursor-pointer"
-        onClick={handleClick}
-        role="button"
-        tabIndex={-1}
-        id={labelID}
-      >
-        <Stack justify="between" align="center">
-          {label && !customLabel && <Heading type="title4">{label}</Heading>}
-          {customLabel}
-          <Stack inline grow={false} align="center" spacing="300">
-            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-            <div
-              className="flex items-center"
-              onClick={ev => {
-                ev.stopPropagation();
-              }}
-            >
-              {actions}
-            </div>
-            <ButtonLink
-              iconLeft={<AnimatedIcon expanded={expanded} />}
-              size="small"
-              type="secondary"
-              ariaLabelledby={labelID}
-              ariaExpanded={expanded}
-              ariaControls={slideID}
-            />
+      <div className="flex items-center justify-between">
+        <div
+          className="flex w-full self-stretch"
+          id={labelID}
+          role="button"
+          tabIndex={0}
+          onClick={handleClick}
+          onKeyDown={e => {
+            if (e.key === "Enter" || e.key === " ") {
+              handleClick(e);
+            }
+          }}
+        >
+          <Stack justify="between" align="center">
+            {label && !customLabel && <Heading type="title4">{label}</Heading>}
+            {customLabel}
           </Stack>
+        </div>
+        <Stack inline grow={false} align="center" spacing="none">
+          {actions && <div className="mx-300 flex items-center">{actions}</div>}
+          <ButtonLink
+            iconLeft={<AnimatedIcon expanded={expanded} />}
+            size="small"
+            type="secondary"
+            onClick={handleClick}
+            ariaLabelledby={labelID}
+            ariaExpanded={expanded}
+            ariaControls={slideID}
+          />
         </Stack>
       </div>
       <Slide maxHeight={height} expanded={expanded} id={slideID} ariaLabelledBy={labelID}>


### PR DESCRIPTION
# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


Closes https://kiwicom.atlassian.net/browse/FEPLT-2186

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR fixes an accessibility violation by addressing interactive nested elements in the Collapse component.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    actor User
    participant Label
    participant IconButton
    participant CollapseComponent
    participant Content

    Note over Label,IconButton: Two ways to trigger collapse
    
    alt Click Label
        User->>Label: Clicks label
        Label->>CollapseComponent: Triggers handleClick()
        CollapseComponent->>Content: Toggles visibility
    else Click Icon Button
        User->>IconButton: Clicks button
        IconButton->>CollapseComponent: Triggers handleClick()
        CollapseComponent->>Content: Toggles visibility
    end

    Note over CollapseComponent: Updates aria-expanded state
    Note over Content: Content slides in/out
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4553/files#diff-48429084200f269c10d3ad7773176ecf7d51b14abf7f650000c9c3e35d49b6f1>packages/orbit-components/src/Collapse/Collapse.stories.tsx</a></td><td>Added parameters to exclude 'expanded' control in the story.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4553/files#diff-2f6cc33d95212addda62ad2d66b9739f6029dea17ea502341b6fe27504cc6f2a>packages/orbit-components/src/Collapse/__tests__/index.test.tsx</a></td><td>Refactored tests to simplify button handling and improve readability.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4553/files#diff-b3b6aae52e21bdcedcc41f3be8f2f10f5b00a348c26e9ee1a08e8baff3cbe046>packages/orbit-components/src/Collapse/index.tsx</a></td><td>Updated the Collapse component to improve accessibility and interaction handling.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->
































Closes https://kiwicom.atlassian.net/browse/FEPLT-2186 





