### PR TITLE
fix(Popover): popover content now closes on ESC key press

### DIFF
--- a/packages/orbit-components/src/Popover/Popover.stories.tsx
+++ b/packages/orbit-components/src/Popover/Popover.stories.tsx
@@ -360,7 +360,6 @@ export const LazyContentSimulated: Story = {
 export const InsideCard: Story = {
   render: args => {
     const [isOpened, setIsOpened] = React.useState(false);
-    const [isOpenedPopover, setIsOpenedPopover] = React.useState(false);
 
     return (
       <>
@@ -370,25 +369,15 @@ export const InsideCard: Story = {
               setIsOpened(true);
             }}
             onClose={() => setIsOpened(false)}
-          >
-            <Popover
-              {...args}
-              opened={isOpenedPopover}
-              onClose={() => {
-                setIsOpenedPopover(false);
-              }}
-              content={<div>Content</div>}
-            >
-              <Button
-                onClick={ev => {
-                  ev.stopPropagation();
-                  setIsOpenedPopover(true);
-                }}
-              >
-                Open Popover
-              </Button>
-            </Popover>
-          </CardSection>
+            title={<Text>Card title</Text>}
+            actions={
+              <Popover {...args} content={<div>Content</div>}>
+                <Button asComponent="div" type="secondary">
+                  Open Popover
+                </Button>
+              </Popover>
+            }
+          />
         </Card>
         {isOpened && <Modal onClose={() => setIsOpened(false)}>kek</Modal>}
       </>

--- a/packages/orbit-components/src/Popover/README.md
+++ b/packages/orbit-components/src/Popover/README.md
@@ -18,36 +18,36 @@ After adding import to your project you can use it simply like:
 
 The table below contains all types of props available in the Popover component.
 
-| Name           | Type                     | Default             | Description                                                                                                                                      |
-| :------------- | :----------------------- | :------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------- |
-| actions        | `React.Node`             |                     | Actions to display in the Popover [See Functional specs](#functional-specs).                                                                     |
-| **content**    | `React.Node`             |                     | The content to display in the Popover.                                                                                                           |
-| **children**   | `React.Node`             |                     | The reference element where the Popover will appear.                                                                                             |
-| dataTest       | `string`                 |                     | Optional prop for testing purposes.                                                                                                              |
-| id             | `string`                 |                     | Set `id` for `Popover`                                                                                                                           |
-| offset         | [`offset`](#offset)      | `{left: 0, top: 0}` | Optional prop to set position offset                                                                                                             |
-| fixed          | `boolean`                |                     | Changes position to fixed from absolute, good for use in sticky components.                                                                      |
-| noPadding      | `boolean`                | `true`              | Adds or removes padding around popover's content.                                                                                                |
-| opened         | `boolean`                |                     | Prop for programmatically controlling Popover inner state. If `opened` is present open triggers are ignored.                                     |
-| overlapped     | `boolean`                | `false`             | If `true`, the content of Popover will overlap the trigger children.                                                                             |
-| renderInPortal | `boolean`                | `true`              | Optional prop, set it to `false` if you're rendering Popover inside a custom portal, defaults to `true`                                          |
-| width          | `string`                 |                     | Width of popover, if undefined, it is set to `auto`.                                                                                             |
-| maxHeight      | `string`                 |                     | The maximum height of the content of the popover, if undefined, it is set to `100%`.                                                             |
-| onClose        | `() => void \| Promise`  |                     | Function for handling onClose.                                                                                                                   |
-| onOpen         | `() => void \| Promise`  |                     | Function for handling onOpen.                                                                                                                    |
-| placement      | [`placement](#placement) | `bottom-start`      | 12 different placements to choose from                                                                                                           |
-| lockScrolling  | `boolean`                | `true`              | Whether to prevent scrolling of the rest of the page while Popover is open on mobile. This is on by default to provide a better user experience. |
-| noFlip         | `boolean`                | `false`             | Turns off automatic flipping of the Popover when there is not enough space                                                                       |
-| allowOverflow  | `boolean`                | `false`             | Allows the Popover to be cut off instead of moving it while scrolling to keep it visible.                                                        |
-| labelClose     | `React.Node`             | `Close`             | The label for close button.                                                                                                                      |
-| renderTimeout  | `number`                 | `0`                 | The timeout for rendering the Popover.                                                                                                           |
-| zIndex         | `number`                 | `710`               | The zIndex value of the Popover component.                                                                                                       |
-| ariaLabel      | `string`                 |                     | Optional prop for `aria-label` value.                                                                                                            |
-| ariaLabelledby | `string`                 |                     | Optional prop for `aria-labelledby` value.                                                                                                       |
+| Name           | Type                      | Default             | Description                                                                                                                                      |
+| :------------- | :------------------------ | :------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------- |
+| actions        | `React.Node`              |                     | Actions to display in the Popover [See Functional specs](#functional-specs).                                                                     |
+| **content**    | `React.Node`              |                     | The content to display in the Popover.                                                                                                           |
+| **children**   | `React.Node`              |                     | The reference element where the Popover will appear.                                                                                             |
+| dataTest       | `string`                  |                     | Optional prop for testing purposes.                                                                                                              |
+| id             | `string`                  |                     | Set `id` for `Popover`                                                                                                                           |
+| offset         | [`offset`](#offset)       | `{left: 0, top: 0}` | Optional prop to set position offset                                                                                                             |
+| fixed          | `boolean`                 |                     | Changes position to fixed from absolute, good for use in sticky components.                                                                      |
+| noPadding      | `boolean`                 | `true`              | Adds or removes padding around popover's content.                                                                                                |
+| opened         | `boolean`                 |                     | Prop for programmatically controlling Popover inner state. If `opened` is present open triggers are ignored.                                     |
+| overlapped     | `boolean`                 | `false`             | If `true`, the content of Popover will overlap the trigger children.                                                                             |
+| renderInPortal | `boolean`                 | `true`              | Optional prop, set it to `false` if you're rendering Popover inside a custom portal, defaults to `true`                                          |
+| width          | `string`                  |                     | Width of popover, if undefined, it is set to `auto`.                                                                                             |
+| maxHeight      | `string`                  |                     | The maximum height of the content of the popover, if undefined, it is set to `100%`.                                                             |
+| onClose        | `() => void \| Promise`   |                     | Function for handling onClose.                                                                                                                   |
+| onOpen         | `() => void \| Promise`   |                     | Function for handling onOpen.                                                                                                                    |
+| placement      | [`placement`](#placement) | `bottom-start`      | 12 different placements to choose from                                                                                                           |
+| lockScrolling  | `boolean`                 | `true`              | Whether to prevent scrolling of the rest of the page while Popover is open on mobile. This is on by default to provide a better user experience. |
+| noFlip         | `boolean`                 | `false`             | Turns off automatic flipping of the Popover when there is not enough space                                                                       |
+| allowOverflow  | `boolean`                 | `false`             | Allows the Popover to be cut off instead of moving it while scrolling to keep it visible.                                                        |
+| labelClose     | `React.Node`              | `Close`             | The label for close button.                                                                                                                      |
+| renderTimeout  | `number`                  | `0`                 | The timeout for rendering the Popover.                                                                                                           |
+| zIndex         | `number`                  | `710`               | The zIndex value of the Popover component.                                                                                                       |
+| ariaLabel      | `string`                  |                     | Optional prop for `aria-label` value.                                                                                                            |
+| ariaLabelledby | `string`                  |                     | Optional prop for `aria-labelledby` value.                                                                                                       |
 
-## enum
+## placement
 
-| Placement        |
+| value            |
 | :--------------- |
 | `"top"`          |
 | `"right"`        |
@@ -76,9 +76,9 @@ The table below contains all types of props available in the Popover component.
 
 - Whenever event `onClick` fires, the script inside this component will calculate possible positions that can be applied and the first possible will be applied.
 
-- You can prefer one position that will be used if possible, otherwise the default order in [`enum`](#enum) table will be used.
+- You can prefer one position that will be used if possible, otherwise the default order in [`placement`](#placement) table will be used.
 
-- You can prefer align that will be used if possible, otherwise the default order in [`enum`](#enum) table will be used.
+- You can prefer align that will be used if possible, otherwise the default order in [`placement`](#placement) table will be used.
 
 - Actions are a way to override default close behavior with your own actions, mainly `Buttons` keep in mind that one of the actions should close the popover.
 

--- a/packages/orbit-components/src/Popover/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Popover/__tests__/index.test.tsx
@@ -142,4 +142,36 @@ describe("Popover", () => {
     await user.click(screen.getByTestId("content-button"));
     expect(contentOnClick).toHaveBeenCalled();
   });
+
+  it("should open on Enter and close on Esc", async () => {
+    render(
+      <Popover content={<div>kek</div>}>
+        <Button dataTest="popover-trigger">Open popover</Button>
+      </Popover>,
+    );
+
+    screen.getByTestId("popover-trigger").focus();
+
+    await user.keyboard("{Enter}");
+    expect(screen.queryByText("kek")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByText("kek")).not.toBeInTheDocument();
+  });
+
+  it("should open on Click and close on Esc", async () => {
+    render(
+      <Popover content={<div>kek</div>}>
+        <Button dataTest="popover-trigger">Open popover</Button>
+      </Popover>,
+    );
+
+    const popoverTrigger = screen.getByTestId("popover-trigger");
+
+    await user.click(popoverTrigger);
+    expect(screen.queryByText("kek")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByText("kek")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
closes https://kiwicom.atlassian.net/browse/FEPLT-2185 

# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds functionality to close the Popover component when the ESC key is pressed, enhancing user experience and accessibility.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Popover
    participant Document

    Note over User,Document: New Keyboard Interactions

    alt Enter Key Press
        User->>Popover: Press Enter (when focused)
        Popover->>Popover: Show content
        Popover->>Document: Add keydown listener
    end

    alt Click Interaction
        User->>Popover: Click trigger
        Popover->>Popover: Show content
        Popover->>Document: Add keydown listener
    end

    alt Escape Key Press
        User->>Document: Press Escape
        Document->>Popover: Trigger handleEsc
        Popover->>Popover: closePopover()
        Popover->>Popover: Hide content
        Popover->>Document: Remove keydown listener
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4557/files#diff-ca29b1b6c6e3ddd66c963c9eb160b7558afe340a282948a873269ca514eda188>packages/orbit-components/src/Popover/Popover.stories.tsx</a></td><td>Updated the story to remove unnecessary state management for the Popover component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4557/files#diff-9ca39918a965f479ab1b26f600baee10d735108736c0babb261fe247b0605444>packages/orbit-components/src/Popover/README.md</a></td><td>Updated documentation to reflect changes in the Popover component's props and behavior.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4557/files#diff-79bc5314c287684d5433a86b13bf18b4711347b950f3d806e0b0a13737fea98e>packages/orbit-components/src/Popover/__tests__/index.test.tsx</a></td><td>Added tests to verify that the Popover opens on Enter and closes on ESC key press.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4557/files#diff-1749fd3089b157f03d9a036ffcccba86319fe6c34eb3331487f8bcdf94be5c2f>packages/orbit-components/src/Popover/index.tsx</a></td><td>Implemented logic to handle ESC key press for closing the Popover.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


















































