### PR TITLE
Update v19 migration guide with size prop removal

### DIFF
--- a/docs/src/documentation/05-development/04-migration-guides/01-v19.mdx
+++ b/docs/src/documentation/05-development/04-migration-guides/01-v19.mdx
@@ -25,3 +25,22 @@ The `UserSingle` icon has been renamed to `UserSingleLight`. No changes have bee
 - <UserSingle />
 + <UserSingleLight />
 ```
+
+### Removal of `size` prop in InputGroup
+
+Following the removal of the `size` prop from the `InputField` and `Select` components in version 7, the `size` prop in the `InputGroup` component was having no effect at all.
+Therefore, it has now been removed.
+
+```diff
+- <InputGroup size="small">
++ <InputGroup>
+```
+
+### Removal of `inputSize` prop in ErrorFormTooltip
+
+The `inputSize` prop in the `ErrorFormTooltip` component has been removed as it was not being used at all, for the same reason mentioned above.
+
+```diff
+- <ErrorFormTooltip inputSize="small" />
++ <ErrorFormTooltip />
+```


### PR DESCRIPTION
The following breaking changes were missing from the migration guide:
- The size prop was removed from InputGroup
- The inputSize prop was removed from ErrorFormTooltip.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the v19 migration guide to include the removal of the `size` prop from `InputGroup` and the `inputSize` prop from `ErrorFormTooltip`.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant Dev as Developer
    participant App as Application
    participant Components as UI Components

    Dev->>App: Start Migration to v19
    
    rect rgb(200, 200, 200)
        Note over Dev,Components: Component Updates
        Dev->>Components: Replace UserSingle with UserSingleLight
        Dev->>Components: Remove size prop from InputGroup
        Dev->>Components: Remove inputSize prop from ErrorFormTooltip
    end

    App->>Components: Use Updated Components
    Note over App,Components: All components now use simplified props

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4558/files#diff-8ce7b27b9dc3505a7158fe777deb77198c7d3e131e37e7d4b5479fd0ff8ebcbb>docs/src/documentation/05-development/04-migration-guides/01-v19.mdx</a></td><td>Updated migration guide to reflect breaking changes regarding the removal of <code>size</code> and <code>inputSize</code> props.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




