### PR TITLE
chore: add Playroom deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,8 @@ jobs:
           yarn tokens build
           yarn tailwind-preset build
           yarn components build
+          yarn components build:playroom
+          yarn components build:storybook
 
       - name: Dry run
         if: ${{ github.event.inputs.dryrun == 'true' }}
@@ -72,3 +74,13 @@ jobs:
           yarn docs changelog
           git add docs/src/data/log.md && git commit -m "docs: update changelog" && git push
           yarn zx scripts/post-changelog.mjs
+
+      - name: Get tag version
+        run: |
+          git fetch --tags --quiet
+          echo "VERSION_TAG=$(git tag --list '@kiwicom/orbit-components@*' --sort=creatordate | sed '$!d' | sed -n '$ s|.*@||; s/\./-/gp')" >> $GITHUB_ENV
+
+      - name: Get Storybook domain
+        run: |
+          echo "DOMAIN=https://kiwicom-orbit-v${VERSION_TAG}.surge.sh" >> $GITHUB_ENV
+          yarn components deploy:surge ${DOMAIN} --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/storybook-playroom.yml
+++ b/.github/workflows/storybook-playroom.yml
@@ -52,6 +52,10 @@ jobs:
         if: github.ref != 'refs/heads/master'
         run: echo "DOMAIN=https://kiwicom-orbit-${BRANCH_URL}.surge.sh" >> $GITHUB_ENV
 
+      - name: Get Playroom DOMAIN
+        if: github.ref != 'refs/heads/master'
+        run: echo "DOMAIN_PLAYROOM=${DOMAIN}/playroom" >> $GITHUB_ENV
+
       - name: Deploy to staging
         if: github.ref != 'refs/heads/master'
         run: yarn components deploy:surge ${DOMAIN} --token ${{ secrets.SURGE_TOKEN }}
@@ -61,7 +65,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const commentBody = `Storybook staging is available at ${process.env.DOMAIN}`;
+            const commentBody = `Storybook staging is available at ${process.env.DOMAIN}\n Playroom staging is available at ${process.env.DOMAIN_PLAYROOM}`;
 
             const commentsList = await github.rest.issues.listComments({
               issue_number: context.issue.number,

--- a/docs/src/components/Footer.tsx
+++ b/docs/src/components/Footer.tsx
@@ -112,6 +112,10 @@ export default function Footer() {
               <Dot />
               <StyledFooterLink to="https://kiwicom.github.io/orbit/">Storybook</StyledFooterLink>
               <Dot />
+              <StyledFooterLink to="https://kiwicom.github.io/orbit/playroom">
+                Playroom
+              </StyledFooterLink>
+              <Dot />
               <StyledFooterLink to="/changelog/">Changelog</StyledFooterLink>
               <Dot />
               <StyledFooterLink to="/themer/">Themer</StyledFooterLink>

--- a/docs/src/components/Navbar/Links.tsx
+++ b/docs/src/components/Navbar/Links.tsx
@@ -9,7 +9,7 @@ import ReadArt from "../../images/streamline-light/read-art.svg";
 import IrisScanIcon from "../../images/streamline-light/iris-scan.svg";
 import ScriptIcon from "../../images/streamline-light/script.svg";
 
-type Link = "Components" | "Guides" | "Tokens" | "Accessibility" | "Foundation" | "Playground";
+type Link = "Components" | "Guides" | "Tokens" | "Accessibility" | "Foundation" | "Playroom";
 
 interface Props {
   links?: Link[];
@@ -31,7 +31,7 @@ const LinkIcon = ({ name }: { name?: string }) => {
       return <ColorBrushIcon {...iconStyles} />;
     case "Accessibility":
       return <IrisScanIcon {...iconStyles} />;
-    case "Playground":
+    case "Playroom":
       return <Code size="medium" />;
     default:
       return <ScriptIcon {...iconStyles} />;
@@ -59,6 +59,7 @@ const getLinkPath = (link: Link) => {
   if (link === "Tokens") return "/foundation/design-tokens/";
   if (link === "Guides") return "/development/guides/";
   if (link === "Accessibility") return "/foundation/accessibility/";
+  if (link === "Playroom") return "https://kiwicom.github.io/orbit/playroom";
 
   return link.toLowerCase();
 };
@@ -82,7 +83,7 @@ const LinkList = ({ isDesktop, links }: { isDesktop?: boolean; links: Props["lin
 );
 
 const Links = ({
-  links = ["Foundation", "Components", "Tokens", "Guides", "Accessibility", "Playground"],
+  links = ["Foundation", "Components", "Tokens", "Guides", "Accessibility", "Playroom"],
 }: Props) => {
   return (
     <>

--- a/docs/src/documentation/01-getting-started/02-for-developers.mdx
+++ b/docs/src/documentation/01-getting-started/02-for-developers.mdx
@@ -57,7 +57,7 @@ See [more info about the Orbit provider](/utilities/orbit-provider/).
 
 For a live preview, check out our [Storybook](https://kiwicom.github.io/orbit/) or [orbit.kiwi](https://orbit.kiwi).
 
-You can also try `orbit-components` directly on our [Playground](https://orbit.kiwi/playground/).
+You can also try `orbit-components` directly on our [Playroom](https://kiwicom.github.io/orbit/playroom/).
 
 ## Typescript
 

--- a/packages/orbit-components/README.md
+++ b/packages/orbit-components/README.md
@@ -42,7 +42,7 @@ or do so with [Yarn](https://yarnpkg.com/):
 
 For a live preview, check out our [Storybook](https://kiwicom.github.io/orbit/) or [orbit.kiwi](https://orbit.kiwi).
 
-You can also try `orbit-components` directly on our [Playground](https://orbit.kiwi/playground/).
+You can also try `orbit-components` directly on our [Playroom](https://kiwicom.github.io/orbit/playroom/).
 
 ## Contributing
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ If you want to use custom theme inside your project, it's necessary to wrap your
 
 For live preview check out [Storybook](https://kiwicom.github.io/orbit/) or [orbit.kiwi](https://orbit.kiwi).
 
-You can also try `orbit-components` directly on our [Playground](https://orbit.kiwi/playground/).
+You can also try `orbit-components` directly on our [Playroom](https://kiwicom.github.io/orbit/playroom).
 
 ## Documentation
 

--- a/scripts/post-changelog.mjs
+++ b/scripts/post-changelog.mjs
@@ -102,13 +102,22 @@ async function publishChangelog(package_) {
     const tags = await simpleGit().tags({ "--sort": "-taggerdate" });
     const diff = await getDiff(tags.latest ?? "", changelogPath(package_));
     const files = gitDiffParser.parse(diff);
+    let playroomLink;
+    
     if (files.length === 0) {
       console.log(`No changes in ${package_}`);
       return;
     }
+
+    if (package_ === "orbit-components") {
+      const latestTag = tags.all.find(tag => tag.includes("@kiwicom/orbit-components@"));
+      const releaseVersion = latestTag.split("@").pop().replace(".", "-");
+      playroomLink = `**Playroom for ${releaseVersion} is available [here](https://kiwicom-orbit-v${releaseVersion}.surge.sh)** 🕹️ \n`
+    }
+
     const changelog = getChangelogFromDiff(files);
     const formattedChangelog = format(changelog, package_);
-    const slackifiedChangelog = slackifyMarkdown(formattedChangelog);
+    const slackifiedChangelog = slackifyMarkdown(playroomLink || '' + formattedChangelog);
 
     if (argv.dry) {
       console.info(formattedChangelog);


### PR DESCRIPTION
# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds deployment configurations for Playroom and updates various components and documentation to reflect the new Playroom feature.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant CI as CI/CD Pipeline
    participant Build as Build Process
    participant Deploy as Deployment
    participant UI as User Interface

    CI->>Build: Add Playroom build steps
    Note over Build: yarn components build:playroom
    Note over Build: yarn components build:storybook

    Build->>Deploy: Deploy to Surge
    Note over Deploy: Generate version tag
    Note over Deploy: Create Playroom domain

    Deploy->>UI: Add Playroom links
    Note over UI: Add to Navbar
    Note over UI: Add to Footer
    Note over UI: Update documentation

    Deploy-->>CI: Post deployment info
    Note over Deploy: Add Playroom URL to PR comments
    Note over Deploy: Include in changelog updates
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4580/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7>.github/workflows/publish.yml</a></td><td>Added Playroom build and deployment steps.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4580/files#diff-e8d317e9830b79051bfbcc1eec575932dec6615fb988de111e0e5fb96dda28b5>.github/workflows/storybook-playroom.yml</a></td><td>Added Playroom domain retrieval for deployment.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4580/files#diff-65929bf9476b5a0756051f593dd3108f73a68bdc2d07db0a8845596d2473001e>docs/src/components/Footer.tsx</a></td><td>Updated footer to include a link to Playroom.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4580/files#diff-31ceb4185b96c151d4e46a45ad498a160091668876385993592553b23e085b3a>docs/src/components/Navbar/Links.tsx</a></td><td>Updated links to replace Playground with Playroom.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4580/files#diff-63047ec4daddc1cb5c3c8997fb0115ad503bb85ada4611e5853efb11c064d2ee>docs/src/documentation/01-getting-started/02-for-developers.mdx</a></td><td>Updated documentation to refer to Playroom instead of Playground.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4580/files#diff-598c347b5d2404006ea0a036de2e64434853ad024e2299f9f8db6dc5867da089>packages/orbit-components/README.md</a></td><td>Updated README to refer to Playroom instead of Playground.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4580/files#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15>readme.md</a></td><td>Updated readme to refer to Playroom instead of Playground.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4580/files#diff-6275299c5d0ba6ea99016e8d8bc6b28d605ba57b49d221d410f097347287b22e>scripts/post-changelog.mjs</a></td><td>Added logic to include Playroom link in changelog.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.yml`, `.mdx`, `.md`, `.mjs`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->








































































