### PR TITLE
Fix storybook controls

### DIFF
--- a/packages/orbit-components/.storybook/main.ts
+++ b/packages/orbit-components/.storybook/main.ts
@@ -8,7 +8,7 @@ function getAbsolutePath(value: string): string {
 
 const config: StorybookConfig = {
   staticDirs: [path.resolve(__dirname, "../static"), path.resolve(__dirname, "../.playroom")],
-  stories: ["../src/**/*.@(mdx|stories.*)"],
+  stories: ["../src/**/*.stories.*"],
   framework: getAbsolutePath("@storybook/react-webpack5"),
 
   addons: [
@@ -60,10 +60,6 @@ const config: StorybookConfig = {
       return cfg;
     }
     return undefined;
-  },
-
-  typescript: {
-    reactDocgen: "react-docgen-typescript",
   },
 };
 


### PR DESCRIPTION
This re-enables the storybook controls. We are really not using the reactDogen features anyway, so we can disabled them.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR re-enables the storybook controls by modifying the stories path and removing unused reactDocgen configuration.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant SB as Storybook Config
    participant FS as File System
    
    SB->>FS: Configure stories pattern
    Note over SB,FS: Set pattern to "../src/**/*.stories.*"
    FS-->>SB: Load matching story files
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4588/files#diff-994e6f1d31a2e5f36f95762e4357350bc358f8f371c4af32256e6a5841d86259>packages/orbit-components/.storybook/main.ts</a></td><td>Updated the stories path and removed reactDocgen configuration.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->




