### PR TITLE
Add accessibility props to Switch

### DIFF
--- a/docs/src/documentation/03-components/07-interaction/switch/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/07-interaction/switch/03-accessibility.mdx
@@ -1,0 +1,53 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/switch/accessibility/
+---
+
+## Accessibility
+
+The Switch component has been designed with accessibility in mind.
+
+It supports keyboard navigation and includes the following properties that provide additional information to screen readers:
+
+| Name           | Type     | Description                                                                                                                                                                                                                                                                 |
+| :------------- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ariaControls   | `string` | Allows you to specify an `aria-controls` attribute to establish the relationship between the Switch and element which is controlled by it. `ariaControls` works only with a unique `id` of an element.                                                                      |
+| ariaLabel      | `string` | Allows you to specify an `aria-label` attribute of the component.                                                                                                                                                                                                           |
+| ariaLabelledby | `string` | Allows you to specify an `aria-labelledby` attribute of the component. This attribute references the id(s) of element(s) that label(s) the Switch, separated by a space. The elements with those ids can be hidden, so that their text is only announced by screen readers. |
+
+While these props are optional, we recommend including them to ensure proper functionality with assistive technologies.
+This helps users better understand the component's context and improves the overall experience.
+
+### Example
+
+The following code snippet shows how to use these properties:
+
+```jsx
+<Card
+  title="Billing details"
+  actions={
+    <Switch
+      checked={isExpanded}
+      onChange={handleShowBillingDetails}
+      ariaLabel="Toggle billing details section"
+      ariaControls="BillingDetailsForm"
+    />
+  }
+>
+  {isExpanded && (
+    <CardSection>
+      <BillingDetailsForm id="BillingDetailsForm" />
+    </CardSection>
+  )}
+</Card>
+```
+
+Using the `ariaLabel` prop enables screen readers to properly announce the Switch component.
+Alternatively, you can use the `ariaLabelledby` prop to reference another element that serves as a label for the Switch component.
+
+For enhanced accessibility, it is recommended to have these label strings translated and dynamically updated based on the user's current journey state
+(e.g. if a billing details section is expanded and the user is about to collapse it, the screen reader should properly announce it).
+
+The `ariaControls` prop establishes a connection between the Switch and the element it controls.
+This relationship enables users to navigate directly from the Switch to this element, improving the overall navigation experience.

--- a/packages/orbit-components/src/Switch/README.md
+++ b/packages/orbit-components/src/Switch/README.md
@@ -16,14 +16,16 @@ After adding import to your project you can use it simply like:
 
 The table below contains all types of the props available in the Switch component.
 
-| Name           | Type                    | Default      | Description                             |
-| :------------- | :---------------------- | :----------- | :-------------------------------------- |
-| dataTest       | `string`                |              | Optional prop for testing purposes.     |
-| id             | `string`                |              | Set `id` for `Switch` input             |
-| **onChange**   | `() => void \| Promise` |              | Function for handling onChange event.   |
-| onFocus        | `() => void \| Promise` |              | Function for handling onFocus event.    |
-| onBlur         | `() => void \| Promise` |              | Function for handling onBlur event.     |
-| **checked**    | `boolean`               |              | If `true`, the Switch will be checked.  |
-| ariaLabelledby | `string`                |              | Optional prop for a11y element          |
-| icon           | `React.Node`            | `<Circle />` | Optional property for custom icon.      |
-| disabled       | `boolean`               | `false`      | If `true`, the Switch will be disabled. |
+| Name           | Type                    | Default      | Description                                |
+| :------------- | :---------------------- | :----------- | :----------------------------------------- |
+| dataTest       | `string`                |              | Optional prop for testing purposes.        |
+| id             | `string`                |              | Set `id` for `Switch` input.               |
+| **onChange**   | `() => void \| Promise` |              | Function for handling onChange event.      |
+| onFocus        | `() => void \| Promise` |              | Function for handling onFocus event.       |
+| onBlur         | `() => void \| Promise` |              | Function for handling onBlur event.        |
+| **checked**    | `boolean`               |              | If `true`, the Switch will be checked.     |
+| icon           | `React.Node`            | `<Circle />` | Optional property for custom icon.         |
+| disabled       | `boolean`               | `false`      | If `true`, the Switch will be disabled.    |
+| ariaControls   | `string`                |              | Optional prop for `aria-controls` value.   |
+| ariaLabel      | `string`                |              | Optional prop for `aria-label` value.      |
+| ariaLabelledby | `string`                |              | Optional prop for `aria-labelledby` value. |

--- a/packages/orbit-components/src/Switch/Switch.stories.tsx
+++ b/packages/orbit-components/src/Switch/Switch.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta<typeof Switch> = {
   args: {
     checked: false,
     onChange: action("onChange"),
+    ariaLabel: "Set up price alerts",
   },
 
   parameters: {
@@ -42,6 +43,7 @@ export const CustomIcon: Story = {
   args: {
     checked: true,
     icon: "Lock",
+    ariaLabel: "Lock the price",
   },
 
   argTypes: {
@@ -64,7 +66,6 @@ export const Playground: Story = {
   args: {
     ...CustomIcon.args,
     id: "switch-id",
-    ariaLabelledby: "aria-labelledby",
     disabled: false,
     onFocus: action("onFocus"),
     onBlur: action("onBlur"),

--- a/packages/orbit-components/src/Switch/index.tsx
+++ b/packages/orbit-components/src/Switch/index.tsx
@@ -8,7 +8,22 @@ import handleKeyDown from "../utils/handleKeyDown";
 import type { Props } from "./types";
 
 const Switch = React.forwardRef<HTMLInputElement, Props>(
-  ({ onChange, checked, dataTest, id, icon, onBlur, onFocus, disabled, ariaLabelledby }, ref) => {
+  (
+    {
+      onChange,
+      checked,
+      dataTest,
+      id,
+      icon,
+      onBlur,
+      onFocus,
+      disabled,
+      ariaControls,
+      ariaLabel,
+      ariaLabelledby,
+    },
+    ref,
+  ) => {
     return (
       <label className="inline-block">
         <div
@@ -28,7 +43,6 @@ const Switch = React.forwardRef<HTMLInputElement, Props>(
             disabled={disabled}
             aria-checked={checked}
             role="switch"
-            aria-labelledby={ariaLabelledby}
             onKeyDown={!disabled ? handleKeyDown<HTMLInputElement>(undefined, onChange) : undefined}
             onBlur={!disabled ? onBlur : undefined}
             onChange={!disabled ? onChange : undefined}
@@ -36,6 +50,9 @@ const Switch = React.forwardRef<HTMLInputElement, Props>(
             type="checkbox"
             data-test={dataTest}
             id={id}
+            aria-controls={ariaControls}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledby}
           />
           <div
             className={cx(

--- a/packages/orbit-components/src/Switch/types.d.ts
+++ b/packages/orbit-components/src/Switch/types.d.ts
@@ -8,9 +8,11 @@ import type * as Common from "../common/types";
 export interface Props extends Common.Globals {
   readonly icon?: React.ReactNode;
   readonly checked: boolean;
-  readonly ariaLabelledby?: string;
   readonly disabled?: boolean;
   readonly onChange: React.ChangeEventHandler<HTMLInputElement>;
   readonly onFocus?: React.FocusEventHandler<HTMLInputElement>;
   readonly onBlur?: React.FocusEventHandler<HTMLInputElement>;
+  readonly ariaControls?: string;
+  readonly ariaLabel?: string;
+  readonly ariaLabelledby?: string;
 }


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2212

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds accessibility properties to the Switch component, enhancing its usability with assistive technologies. It introduces `ariaControls`, `ariaLabel`, and updates the documentation accordingly.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant User
    participant Switch
    participant ScreenReader
    participant ControlledElement

    Note over Switch: Enhanced with aria attributes

    User->>Switch: Interacts with Switch
    Switch-->>ScreenReader: Announces aria-label/labelledby
    
    alt Switch controls another element
        Switch-->>ControlledElement: References via aria-controls
        ScreenReader->>User: Announces relationship
    end
    
    alt Switch is toggled
        Switch->>ScreenReader: Announces checked state
        Switch->>ControlledElement: Updates controlled element
    end

    Note over Switch,ScreenReader: Improved accessibility<br/>with aria properties

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4590/files#diff-cdf85c2d406b9d2a33f14f9d7055276cba41d7fc3b24d6abe2290672e5b713a2>docs/src/documentation/03-components/07-interaction/switch/03-accessibility.mdx</a></td><td>Added documentation for accessibility features of the Switch component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4590/files#diff-26e4279cf018fd46b884dba98ee8b960cf0f33b16e5e1466ac84181c1162e18f>packages/orbit-components/src/Switch/README.md</a></td><td>Updated README to include new accessibility props for the Switch component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4590/files#diff-b11eb84bd6e924397dbbb0da0ba3df0497e4fc4faed1b78b9d583bbd041ef28b>packages/orbit-components/src/Switch/Switch.stories.tsx</a></td><td>Added examples demonstrating the use of new accessibility props in Switch stories.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4590/files#diff-8085cec61311e1d6452119b644f435ebe84d2aa2c9a494983a536e7930e598bb>packages/orbit-components/src/Switch/index.tsx</a></td><td>Modified Switch component to accept and handle new accessibility props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4590/files#diff-a8989851b2a5b00046431d42e95badb53eb6f6d6700f359a0e182740a0685848>packages/orbit-components/src/Switch/types.d.ts</a></td><td>Updated type definitions to include new accessibility props.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






















