### PR TITLE
Fix playroom deployment in master branch

### DIFF
--- a/.github/workflows/storybook-playroom.yml
+++ b/.github/workflows/storybook-playroom.yml
@@ -12,6 +12,7 @@ env: # Set environment variables for every job and step in this workflow
   CLICOLOR: "1" # Enable colors for *NIX commands
   PY_COLORS: "1" # Enable colors for Python-based utilities
   FORCE_COLOR: "1" # Force colors in the terminal
+  IS_MASTER_BRANCH: ${{ github.ref == 'refs/heads/master' }}
 
 jobs:
   deploy:
@@ -42,26 +43,24 @@ jobs:
         run: yarn components build:storybook
 
       - name: Get BRANCH_URL
-        # do not run on master branch
-        if: github.ref != 'refs/heads/master'
+        if: ${{ env.IS_MASTER_BRANCH != 'true' }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: echo "BRANCH_URL=$(sed -e 's/[^a-zA-Z0-9]/-/g' <<< ${BRANCH_NAME})" >> $GITHUB_ENV
 
-      - name: Get DOMAIN
-        if: github.ref != 'refs/heads/master'
-        run: echo "DOMAIN=https://kiwicom-orbit-${BRANCH_URL}.surge.sh" >> $GITHUB_ENV
-
-      - name: Get Playroom DOMAIN
-        if: github.ref != 'refs/heads/master'
-        run: echo "DOMAIN_PLAYROOM=${DOMAIN}/playroom" >> $GITHUB_ENV
+      - name: Get DOMAINS
+        if: ${{ env.IS_MASTER_BRANCH != 'true' }}
+        run: |
+          DOMAIN="https://kiwicom-orbit-${BRANCH_URL}.surge.sh"
+          echo "DOMAIN=$DOMAIN" >> $GITHUB_ENV
+          echo "DOMAIN_PLAYROOM=$DOMAIN/playroom" >> $GITHUB_ENV
 
       - name: Deploy to staging
-        if: github.ref != 'refs/heads/master'
+        if: ${{ env.IS_MASTER_BRANCH != 'true' }}
         run: yarn components deploy:surge ${DOMAIN} --token ${{ secrets.SURGE_TOKEN }}
 
       - name: Add comment to PR
-        if: github.ref != 'refs/heads/master'
+        if: ${{ env.IS_MASTER_BRANCH != 'true' }}
         uses: actions/github-script@v6
         with:
           script: |
@@ -93,7 +92,7 @@ jobs:
 
       - name: Deploy to production
         # run on master branch
-        if: github.ref == 'refs/heads/master'
+        if: ${{ env.IS_MASTER_BRANCH == 'true' }}
         run: yarn components deploy:storybook --ci
         env:
           GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}

--- a/packages/orbit-components/playroom.config.js
+++ b/packages/orbit-components/playroom.config.js
@@ -15,7 +15,7 @@ module.exports = {
     defaultFoundation.breakpoint.mediumMobile,
     defaultFoundation.breakpoint.desktop,
   ],
-  baseUrl: "/playroom/",
+  baseUrl: process.env.IS_MASTER_BRANCH === "true" ? "/orbit/playroom" : "/playroom/",
   webpackConfig: () => ({
     resolve: {
       extensions: [".js", ".jsx", ".ts", ".tsx", ".css"],


### PR DESCRIPTION
Because in GH_PAGES the base url starts with /orbit/, we need that configuration on the playroom config.

All other deployments (on surge) can be kept as they were.

FEPLT-2217

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR modifies the deployment configuration for the playroom in the master branch, ensuring the correct base URL is set based on the branch being deployed.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Action
    participant Env as Environment
    participant Deploy as Deployment

    GH->>Env: Set IS_MASTER_BRANCH flag
    
    alt is master branch
        GH->>Deploy: Deploy to production
        Deploy->>Deploy: Use /orbit/playroom baseUrl
        Deploy->>Deploy: Deploy to GitHub Pages
    else is not master branch
        GH->>Env: Generate BRANCH_URL
        GH->>Env: Set DOMAIN variables
        Deploy->>Deploy: Use /playroom baseUrl
        Deploy->>Deploy: Deploy to Surge
        GH->>GH: Add PR comment with preview URLs
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4592/files#diff-e8d317e9830b79051bfbcc1eec575932dec6615fb988de111e0e5fb96dda28b5>.github/workflows/storybook-playroom.yml</a></td><td>Updated deployment conditions and added environment variable for master branch.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4592/files#diff-033ffa0d3e8d2ddc295aaf1a5bc55da63e0b57d00bf8b257f756c41cfa75c50e>packages/orbit-components/playroom.config.js</a></td><td>Changed base URL configuration based on the branch.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.yml`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






