### PR TITLE
Add missing / in baseUrl

### DIFF
--- a/packages/orbit-components/playroom.config.js
+++ b/packages/orbit-components/playroom.config.js
@@ -15,7 +15,7 @@ module.exports = {
     defaultFoundation.breakpoint.mediumMobile,
     defaultFoundation.breakpoint.desktop,
   ],
-  baseUrl: process.env.IS_MASTER_BRANCH === "true" ? "/orbit/playroom" : "/playroom/",
+  baseUrl: process.env.IS_MASTER_BRANCH === "true" ? "/orbit/playroom/" : "/playroom/",
   webpackConfig: () => ({
     resolve: {
       extensions: [".js", ".jsx", ".ts", ".tsx", ".css"],


### PR DESCRIPTION
Missing a `/`

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds a missing `/` in the `baseUrl` configuration for the playroom setup.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant App
    participant PlayroomConfig
    participant Environment

    App->>Environment: Check IS_MASTER_BRANCH
    Environment-->>PlayroomConfig: Return branch status
    alt IS_MASTER_BRANCH is true
        PlayroomConfig-->>App: Use "/orbit/playroom/" baseUrl
    else IS_MASTER_BRANCH is false
        PlayroomConfig-->>App: Use "/playroom/" baseUrl
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4593/files#diff-033ffa0d3e8d2ddc295aaf1a5bc55da63e0b57d00bf8b257f756c41cfa75c50e>packages/orbit-components/playroom.config.js</a></td><td>Fixed the baseUrl by adding a missing '/' at the end of the URL.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


