### PR TITLE
Fix playroom deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,17 +74,19 @@ jobs:
           yarn zx scripts/post-changelog.mjs
 
       - name: Build Playroom
+        if: ${{ github.event.inputs.dryrun == 'false' }}
         run: yarn components build:playroom
 
       - name: Build Storybook
+        if: ${{ github.event.inputs.dryrun == 'false' }}
         run: yarn components build:storybook
 
       - name: Get tag version
+        if: ${{ github.event.inputs.dryrun == 'false' }}
         run: |
           git fetch --tags --quiet
           echo "VERSION_TAG=$(git tag --list '@kiwicom/orbit-components@*' --sort=creatordate | sed '$!d' | sed -n '$ s|.*@||; s/\./-/gp')" >> $GITHUB_ENV
 
-      - name: Get Storybook domain
-        run: |
-          echo "DOMAIN=https://kiwicom-orbit-v${VERSION_TAG}.surge.sh" >> $GITHUB_ENV
-          yarn components deploy:surge ${DOMAIN} --token ${{ secrets.SURGE_TOKEN }}
+      - name: Publish Storybook and Playroom
+        if: ${{ github.event.inputs.dryrun == 'false' }}
+        run: yarn components deploy:surge https://kiwicom-orbit-v${VERSION_TAG}.surge.sh --token ${{ secrets.SURGE_TOKEN }}

--- a/scripts/post-changelog.mjs
+++ b/scripts/post-changelog.mjs
@@ -101,7 +101,10 @@ const getPlayroomLink = (package_, tags) => {
 
   const latestTag = tags.all.find(tag => tag.includes("@kiwicom/orbit-components@"));
   const releaseVersion = latestTag.split("@").pop();
-  return `**Playroom for ${releaseVersion} is available [here](https://kiwicom-orbit-v${releaseVersion.replaceAll(".", "-")}.surge.sh)** 🕹️ \n`;
+  return `**Playroom for ${releaseVersion} is available [here](https://kiwicom-orbit-v${releaseVersion.replaceAll(
+    ".",
+    "-",
+  )}.surge.sh/playroom/)** 🕹️ \n`;
 };
 
 async function publishChangelog(package_) {


### PR DESCRIPTION
This PR addresses 3 issues:

- We were trying to deploy playroom even on dry-run
- The URL for the playroom deployment was not being generated correctly
- The messaged published in Slack did not have the correct playroom link

FEPLT-2238

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR fixes issues related to the deployment of Playroom, including preventing deployment during dry runs, correcting the URL generation for Playroom, and ensuring the correct link is published in Slack.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Workflow
    participant Build as Build Process
    participant Surge as Surge.sh
    participant PR as Pull Request

    Note over GH: Workflow starts
    
    alt dryrun is false
        GH->>Build: Build Playroom
        GH->>Build: Build Storybook
        GH->>GH: Get version tag
        GH->>Surge: Publish to kiwicom-orbit-v{VERSION}.surge.sh
        GH->>PR: Post changelog with Playroom link
    end

    Note over GH: Workflow ends
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4605/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7>.github/workflows/publish.yml</a></td><td>Added conditions to prevent deployment during dry runs and consolidated the deployment step for Storybook and Playroom.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4605/files#diff-6275299c5d0ba6ea99016e8d8bc6b28d605ba57b49d221d410f097347287b22e>scripts/post-changelog.mjs</a></td><td>Updated the Playroom link to include the correct path in the URL.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.yml`, `.mjs`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


