### PR TITLE
Tile + TileGroup Accessibility

### DIFF
--- a/docs/src/documentation/03-components/02-structure/tile/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/02-structure/tile/03-accessibility.mdx
@@ -1,0 +1,36 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/tile/accessibility/
+---
+
+# Accessibility
+
+## Tile
+
+The Tile component has been designed with accessibility in mind.
+
+The component offers flexibility in terms of the HTML element used for the root node. By default, it will render a `div` element.
+
+### Expandable / Clickable
+
+The prop `expandable` makes the Tile clickable. In that case, assistive props like `aria-expanded` are handled automatically.
+
+The component will render, by default, a `div` element with `role="button"` and `tabindex={0}`.
+
+This also happens when the `onClick` prop is defined.
+
+For that reason, one should refrain from using other interactive elements inside the Tile, like buttons or links, including on the `header` prop.
+
+### Href
+
+When the `href` prop is defined, the Tile will render an `a` element inside of the `div`.
+For the same reason as above, one should refrain from using other interactive elements inside the Tile.
+
+### HTML Title
+
+The `htmlTitle` prop can be used to add extra information to the Tile.
+
+It will be added as the `title` attribute to the `a` element when the `href` prop is defined.
+
+Defining `htmlTitle` without defining `href` will produce no effect on the component.

--- a/docs/src/documentation/03-components/02-structure/tilegroup/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/02-structure/tilegroup/03-accessibility.mdx
@@ -1,0 +1,24 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/tilegroup/accessibility/
+---
+
+# Accessibility
+
+## TileGroup
+
+The TileGroup component has been designed with accessibility in mind.
+
+The component offers flexibility in terms of the HTML element used for the root node. By default, it will render a `div` element.
+
+If needed, it can be rendered as a list by passing the `as` prop with the value `"ul"`.
+
+In that case, the `Tile` elements used as `children` should be rendered as `li`.
+
+```jsx
+<TileGroup as="ul">
+  <Tile title="Title" as="li" />
+  <Tile title="Title" as="li" />
+</TileGroup>
+```

--- a/packages/orbit-components/src/Tile/Tile.stories.tsx
+++ b/packages/orbit-components/src/Tile/Tile.stories.tsx
@@ -95,6 +95,7 @@ export const DefaultWithHeaderPropsAsHref: Story = {
 
   args: {
     ...DefaultWithHeaderProps.args,
+    onClick: undefined,
     href: "https://www.kiwi.com/",
     external: true,
   },
@@ -114,10 +115,8 @@ export const ExpandableWithCustomDescription: StoryObj<
           <Stack justify="between" align="center" direction="row" shrink>
             <Stack spacing="none" direction="column" shrink>
               <Stack direction="row" align="center" spacing="200">
-                <Heading type="title4" as="h4">
-                  Mr. Hot potato
-                </Heading>
-                <CountryFlag code="cz" />
+                <Heading type="title4">Mr. Hot potato</Heading>
+                <CountryFlag code="cz" name="Czechia" />
               </Stack>
               <Text>13/37/1337</Text>
             </Stack>

--- a/packages/orbit-components/src/Tile/components/TileHeader/index.tsx
+++ b/packages/orbit-components/src/Tile/components/TileHeader/index.tsx
@@ -84,9 +84,7 @@ const TileHeader = ({
           <Stack spacing="none" direction="column" shrink>
             {title && (
               <div className="flex w-full items-center">
-                <Heading type="title4" as="h3">
-                  {title}
-                </Heading>
+                <Heading type="title4">{title}</Heading>
               </div>
             )}
             {description && (

--- a/packages/orbit-components/src/TileGroup/TileGroup.stories.tsx
+++ b/packages/orbit-components/src/TileGroup/TileGroup.stories.tsx
@@ -42,10 +42,8 @@ export const Playground: Story = {
               <Stack justify="between" align="center" direction="row" shrink>
                 <Stack spacing="none" direction="column" shrink>
                   <Stack direction="row" align="center" spacing="200">
-                    <Heading type="title4" as="h4">
-                      Mr. Hot potato
-                    </Heading>
-                    <CountryFlag code="cz" />
+                    <Heading type="title4">Mr. Hot potato</Heading>
+                    <CountryFlag code="cz" name="Czechia" />
                   </Stack>
                   <Text>13/37/1337</Text>
                 </Stack>

--- a/packages/orbit-components/src/utils/Slide/index.tsx
+++ b/packages/orbit-components/src/utils/Slide/index.tsx
@@ -131,7 +131,7 @@ class Slide extends React.Component<Props, State> {
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
       <div
         className={cx(
-          "orbit-slide relative w-full",
+          "orbit-slide relative w-full cursor-default",
           transitionDuration && "transition-[max-height] ease-linear",
           transitionDuration && getTransitionDurationClass(transitionDuration),
           !transitionFinished && "overflow-hidden",


### PR DESCRIPTION
Heading level inside Tile is no longer enforced.

Accessibility documentation for the Tile and TileGroup components added.

Fixed some accessibility issues in Tile and TileGroup stories.

Fixed the cursor on the Slide component (used in Tile).

FEPLT-2232

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR enhances accessibility for the Tile and TileGroup components, adds documentation, and fixes cursor issues in the Slide component.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant User
    participant Tile
    participant TileGroup
    participant Accessibility

    User->>Tile: Interacts with Tile
    
    alt Tile with href
        Tile->>Accessibility: Renders as <a> element
        Accessibility->>Tile: Applies htmlTitle attribute
    else Tile expandable/clickable
        Tile->>Accessibility: Adds role="button"
        Tile->>Accessibility: Adds tabindex={0}
    end

    User->>TileGroup: Renders TileGroup
    alt TileGroup as List
        TileGroup->>Accessibility: Renders as <ul>
        Tile->>Accessibility: Renders as <li>
    else Default TileGroup
        TileGroup->>Accessibility: Renders as <div>
    end

    Note over Tile: Updated header with<br/>Heading type="title4"
    Note over Tile: Added CountryFlag<br/>component support

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4606/files#diff-5712f110df571a77053a31912379c32c965d3a63771fd4dfc3ae88b25217ba83>docs/src/documentation/03-components/02-structure/tile/03-accessibility.mdx</a></td><td>Added accessibility documentation for the Tile component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4606/files#diff-4106be09de0a1781682197d71c6fbc44661b7825e9abcd38a4dc9fa55ccffa96>docs/src/documentation/03-components/02-structure/tilegroup/03-accessibility.mdx</a></td><td>Added accessibility documentation for the TileGroup component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4606/files#diff-1e6036c6954cd053b29f4704c95aec0b3f83ed18bf7acc0f9dab60b3af9d113d>packages/orbit-components/src/Tile/Tile.stories.tsx</a></td><td>Updated story to set onClick to undefined for href usage.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4606/files#diff-c298054507afd108fb9afa9594b594be7dcf0bcb37954695f0975c669a5bef04>packages/orbit-components/src/Tile/components/TileHeader/index.tsx</a></td><td>Removed unnecessary 'as' prop from Heading in TileHeader.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4606/files#diff-f4cab3a36a996abdd4d09a38172f4886006040e4fa4e2170eb746c835b6979af>packages/orbit-components/src/TileGroup/TileGroup.stories.tsx</a></td><td>Updated story to remove unnecessary 'as' prop from Heading.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4606/files#diff-916a83d010c8c90bc762353cc42dbfc56119e97d060641da673e7fb44afa92cc>packages/orbit-components/src/utils/Slide/index.tsx</a></td><td>Fixed cursor style on the Slide component.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




