### PR TITLE
Improve accessibility for Select

### DIFF
--- a/docs/src/documentation/03-components/05-input/select/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/05-input/select/03-accessibility.mdx
@@ -1,0 +1,86 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/select/accessibility/
+---
+
+## Accessibility
+
+The Select component has been designed with accessibility in mind.
+
+It supports keyboard navigation and includes the following properties that provide additional information to screen readers:
+
+| Name           | Type     | Description                                                            |
+| :------------- | :------- | :--------------------------------------------------------------------- |
+| ariaLabel      | `string` | Allows you to specify an `aria-label` attribute of the component.      |
+| ariaLabelledby | `string` | Allows you to specify an `aria-labelledby` attribute of the component. |
+
+While these props are optional, we recommend including them to ensure proper accessibility of the component, especially if the `label` prop is not provided.
+
+These attributes help users better understand the component's purpose and context, improving the overall experience with assistive technologies.
+
+### Examples
+
+The following code snippets show different ways to use these properties:
+
+```jsx
+<Select options={options} value={categoryValue} onChange={onChange} label="Category" />
+```
+
+```jsx
+<Select
+  options={options}
+  value={categoryValue}
+  onChange={onChange}
+  ariaLabel="Select passenger category"
+/>
+```
+
+```jsx
+<Stack>
+  <p id="passengers-category-label" style={{ display: "none", visibility: "hidden" }}>
+    Select passenger category
+  </p>
+
+  <Select
+    options={options}
+    value={categoryValue}
+    onChange={onChange}
+    ariaLabelledby="passengers-category-label"
+  />
+</Stack>
+```
+
+Using the `ariaLabel` prop enables screen readers to properly announce the Select component if the `label` prop is not provided.
+
+Alternatively, you can use the `ariaLabelledby` prop to reference another element that serves as a label for the Select component. The `ariaLabelledby` prop can reference multiple ids, separated by a space. The elements with those ids can be hidden, so that their text is only announced by screen readers.
+
+Note that if both `ariaLabel` and `ariaLabelledby` props are provided, `ariaLabelledby` takes precedence.
+
+For better screen reader experience, you can always complement the `label` prop with `ariaLabel` or `ariaLabelledby`:
+
+```jsx
+<Select
+  options={options}
+  value={languageValue}
+  onChange={onChange}
+  label="Language"
+  ariaLabel="Select your language"
+/>
+```
+
+For enhanced accessibility, it is recommended to have these label strings translated.
+
+When using the `help` or `error` props, their content is set as `aria-describedby` on the element. Screen readers will announce this additional information after reading the component's label (whether provided via `label`, `ariaLabel`, or `ariaLabelledby` props).
+
+```jsx
+<Select
+  options={options}
+  value={nationalityValue}
+  onChange={onChange}
+  label="Nationality"
+  error="Required field"
+/>
+```
+
+It would have the screen reader announce: “Nationality. Required field.”.

--- a/packages/orbit-components/src/Select/README.md
+++ b/packages/orbit-components/src/Select/README.md
@@ -41,7 +41,8 @@ Table below contains all types of the props available in the Select component.
 | width           | `string`                   | `100%`  | Specifies width of the Select                                                                                  |
 | helpClosable    | `boolean`                  | `true`  | Whether to display help as a closable tooltip, or have it open only while the field is focused, same as error. |
 | customValueText | `string`                   |         | The custom text alternative of current value. [See Functional specs](#functional-specs).                       |
-| ariaLabel       | `string`                   |         | Optional prop for `aria-label` value. [See Accessibility](#accessibility).                                     |
+| ariaLabel       | `string`                   |         | Optional prop for `aria-label` value. See Accessibility tab.                                                   |
+| ariaLabelledby  | `string`                   |         | Optional prop for `aria-labelledby` value. See Accessibility tab.                                              |
 
 ### enum
 
@@ -70,7 +71,7 @@ Table below contains all types of the props available for object in Option array
 
 - The `error` prop overwrites the `help` prop, due to higher priority.
 
-- When you have limited space of `Select`, you can use `customValueText` property where you can pass text alternative of the current value. For instance, when label of selected option has `Czech Republic (+420)`, you can pass only `+420` into this property and the original label will be visually hidden.
+- When you have limited space for the `Select`, you can use `customValueText` property to pass an alternative text for the current value. For instance, when the label of the selected option is `Czech Republic (+420)`, you can pass only `+420` to this property and the original label will be visually hidden.
 
 - The `prefix` prop can accept any element. However, it is not recommended to pass it more than an icon (or flag).
 
@@ -89,8 +90,3 @@ class Component extends React.PureComponent<Props> {
   }
 }
 ```
-
-## Accessibility
-
-- The `ariaLabel` prop allows you to specify an `aria-label` attribute for the select component. This attribute provides additional information to screen readers, enhancing the accessibility of the component. By using `ariaLabel`, you can ensure that users who rely on assistive technologies receive the necessary context and information about the component's purpose and functionality.
-- If the `label` prop is not provided, the `ariaLabel` prop must be specified to ensure component accessibility.

--- a/packages/orbit-components/src/Select/Select.stories.tsx
+++ b/packages/orbit-components/src/Select/Select.stories.tsx
@@ -60,21 +60,29 @@ type Story = StoryObj<SelectPropsAndCustomArgs>;
 const getIcon = (source: string | null) => source && Icons[source];
 
 export const Default: Story = {
+  args: {
+    label: "Select item",
+  },
+
   parameters: {
     info: "Default setup of Select component. Check Orbit.Kiwi for more detailed guidelines.",
+    controls: {
+      disable: true,
+    },
   },
 };
 
 export const WithPrefixAndLabel: Story = {
   render: ({ icon, ...args }) => {
-    const Icon = typeof icon === "string" && getIcon(icon);
+    const Icon = getIcon(icon);
 
     return <Select {...args} prefix={<Icon />} />;
   },
 
   args: {
     icon: "Airplane",
-    label: "Select box",
+    label: "Select value from list",
+    inlineLabel: false,
   },
 
   argTypes: {
@@ -89,20 +97,21 @@ export const WithPrefixAndLabel: Story = {
   parameters: {
     info: "Select component with prefix icon and label. Check Orbit.Kiwi for more detailed guidelines.",
     controls: {
-      exclude: ["onChange", "onBlur", "onFocus", "help", "error", "placeholder", "inlineLabel"],
+      exclude: ["onChange", "onBlur", "onFocus", "help", "error", "placeholder"],
     },
   },
 };
 
 export const WithCountryFlagPrefix: Story = {
   render: ({ code, ...args }) => {
-    const Icon = <CountryFlag code={code} />;
+    const Icon = <CountryFlag code={code} name="Country flag" />;
 
     return <Select {...args} prefix={Icon} />;
   },
 
   args: {
     code: CODES.ANYWHERE,
+    label: "Select country",
   },
 
   argTypes: {
@@ -121,7 +130,7 @@ export const WithCountryFlagPrefix: Story = {
 
 export const WithLongLabel: Story = {
   args: {
-    label: "Select box (very long label)",
+    label: "Select value from list (very long label)",
     inlineLabel: true,
   },
 
@@ -135,7 +144,8 @@ export const WithLongLabel: Story = {
 
 export const WithPlaceholder: Story = {
   args: {
-    placeholder: "Select value from list",
+    placeholder: "Placeholder value",
+    label: "Select value from list",
   },
 
   parameters: {
@@ -177,14 +187,14 @@ export const WithErrorMessage: Story = {
 
 export const Playground: Story = {
   render: ({ icon, ...args }) => {
-    const Icon = typeof icon === "string" && getIcon(icon);
+    const Icon = getIcon(icon);
 
     return <Select {...args} prefix={<Icon />} />;
   },
 
   args: {
     ...WithPrefixAndLabel.args,
-    ariaLabel: "Select box",
+    ariaLabel: "",
     inlineLabel: false,
     placeholder: "Select value from list",
     value: undefined,

--- a/packages/orbit-components/src/Select/__tests__/Select.test.tsx
+++ b/packages/orbit-components/src/Select/__tests__/Select.test.tsx
@@ -77,7 +77,7 @@ describe("Select", () => {
   it("should have passed width", () => {
     const width = "100px";
     render(<Select width={width} label="label" options={[{ value: "1", label: "One" }]} />);
-    expect(document.querySelector("label")).toHaveStyle({ width });
+    expect(document.querySelector(".orbit-select-label-container")).toHaveStyle({ width });
   });
 
   it("should have error message", async () => {

--- a/packages/orbit-components/src/Select/index.tsx
+++ b/packages/orbit-components/src/Select/index.tsx
@@ -13,7 +13,7 @@ import ErrorFormTooltip from "../ErrorFormTooltip";
 import useErrorTooltip from "../ErrorFormTooltip/hooks/useErrorTooltip";
 import useRandomId from "../hooks/useRandomId";
 import type { Props } from "./types";
-import { spaceAfterClasses } from "../common/tailwind/spaceAfter";
+import { spaceAfterClasses } from "../common/tailwind";
 
 const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
   const {
@@ -41,6 +41,7 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
     insideInputGroup,
     dataAttrs,
     ariaLabel,
+    ariaLabelledby,
   } = props;
   const filled = !(value == null || value === "");
 
@@ -182,6 +183,7 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
               aria-describedby={shown ? `${selectId}-feedback` : undefined}
               aria-invalid={error ? true : undefined}
               aria-label={ariaLabel}
+              aria-labelledby={ariaLabelledby}
               {...dataAttrs}
             >
               {placeholder && (

--- a/packages/orbit-components/src/Select/index.tsx
+++ b/packages/orbit-components/src/Select/index.tsx
@@ -64,146 +64,155 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
   const shown = tooltipShown || tooltipShownHover;
 
   return (
-    <label
-      className={cx("relative block", spaceAfter && spaceAfterClasses[spaceAfter])}
-      ref={inputRef}
+    <div
+      className={cx(
+        "orbit-select-label-container relative block",
+        spaceAfter && spaceAfterClasses[spaceAfter],
+      )}
       style={{ width }}
     >
-      {label && !inlineLabel && (
-        <FormLabel
-          error={!!error}
-          help={!!help}
-          labelRef={labelRef}
-          iconRef={iconRef}
-          onMouseEnter={() => setTooltipShownHover(true)}
-          onMouseLeave={() => setTooltipShownHover(false)}
-          required={required}
-        >
-          {label}
-        </FormLabel>
-      )}
-      <div
-        ref={label ? null : labelRef}
-        className={cx(
-          "orbit-select-container",
-          "relative flex flex-row items-center justify-between",
-          "h-form-box-normal box-border w-full",
-          disabled
-            ? "text-form-element-disabled-foreground cursor-not-allowed"
-            : "text-form-element-filled-foreground cursor-pointer",
-          !disabled &&
-            (error
-              ? "[&_.orbit-input-field-fake-input]:hover:shadow-form-element-error-hover"
-              : "[&_.orbit-input-field-fake-input]:hover:shadow-form-element-hover"),
-          "focus-within:outline-none",
-          "[&_.orbit-input-field-fake-input]:focus-within:outline-blue-normal [&_.orbit-input-field-fake-input]:focus-within:outline [&_.orbit-input-field-fake-input]:focus-within:outline-2",
-        )}
-      >
-        {label && inlineLabel && (
-          <div
-            className={cx(
-              "pointer-events-none z-[3] flex h-full items-center justify-center",
-              error || help ? "ps-100" : "ps-300",
-              "[&_.orbit-form-label]:text-normal [&_.orbit-form-label]:mb-0 [&_.orbit-form-label]:inline-block [&_.orbit-form-label]:max-w-[20ch] [&_.orbit-form-label]:truncate [&_.orbit-form-label]:leading-normal",
-            )}
-            ref={labelRef}
+      <label ref={inputRef}>
+        {label && !inlineLabel && (
+          <FormLabel
+            error={!!error}
+            help={!!help}
+            labelRef={labelRef}
+            iconRef={iconRef}
+            onMouseEnter={() => setTooltipShownHover(true)}
+            onMouseLeave={() => setTooltipShownHover(false)}
+            required={required}
           >
-            {help && !error && (
-              <span className="flex" ref={iconRef}>
-                <InformationCircle color="info" size="small" />
-              </span>
-            )}
-            {error && (
-              <span className="flex" ref={iconRef}>
-                <AlertCircle color="critical" size="small" />
-              </span>
-            )}
-            <FormLabel required={required} error={!!error} help={!!help} inlineLabel={inlineLabel}>
-              {label}
-            </FormLabel>
-          </div>
+            {label}
+          </FormLabel>
         )}
-
-        <div className="relative z-[3] size-full">
-          {prefix && (
-            <div className="px-300 pointer-events-none absolute top-0 z-[3] flex h-full items-center">
-              {prefix}
-            </div>
+        <div
+          ref={label ? null : labelRef}
+          className={cx(
+            "orbit-select-container",
+            "relative flex flex-row items-center justify-between",
+            "h-form-box-normal box-border w-full",
+            disabled
+              ? "text-form-element-disabled-foreground cursor-not-allowed"
+              : "text-form-element-filled-foreground cursor-pointer",
+            !disabled &&
+              (error
+                ? "[&_.orbit-input-field-fake-input]:hover:shadow-form-element-error-hover"
+                : "[&_.orbit-input-field-fake-input]:hover:shadow-form-element-hover"),
+            "focus-within:outline-none",
+            "[&_.orbit-input-field-fake-input]:focus-within:outline-blue-normal [&_.orbit-input-field-fake-input]:focus-within:outline [&_.orbit-input-field-fake-input]:focus-within:outline-2",
           )}
-          {customValueText && (
+        >
+          {label && inlineLabel && (
             <div
               className={cx(
-                (disabled && "text-form-element-disabled-foreground") || filled
-                  ? "text-form-element-filled-foreground"
-                  : "text-form-element-foreground",
-                "text-form-element-normal font-base pointer-events-none absolute inset-y-0 z-[3] flex items-center",
-                prefix ? "ps-1200" : "ps-300",
+                "pointer-events-none z-[3] flex h-full items-center justify-center",
+                error || help ? "ps-100" : "ps-300",
+                "[&_.orbit-form-label]:text-normal [&_.orbit-form-label]:mb-0 [&_.orbit-form-label]:inline-block [&_.orbit-form-label]:max-w-[20ch] [&_.orbit-form-label]:truncate [&_.orbit-form-label]:leading-normal",
               )}
+              ref={labelRef}
             >
-              {customValueText}
+              {help && !error && (
+                <span className="flex" ref={iconRef}>
+                  <InformationCircle color="info" size="small" />
+                </span>
+              )}
+              {error && (
+                <span className="flex" ref={iconRef}>
+                  <AlertCircle color="critical" size="small" />
+                </span>
+              )}
+              <FormLabel
+                required={required}
+                error={!!error}
+                help={!!help}
+                inlineLabel={inlineLabel}
+              >
+                {label}
+              </FormLabel>
             </div>
           )}
-          <select
-            className={cx(
-              "cursor-pointer appearance-none bg-transparent outline-none",
-              filled ? "text-form-element-filled-foreground" : "text-form-element-foreground",
-              "font-base text-form-element-normal",
-              "pe-1000",
-              prefix ? "ps-1200" : "ps-300",
-              "shrink grow basis-1/5",
-              "size-full",
-              "border-0",
-              customValueText && "!text-transparent",
-              "duration-fast transition-shadow ease-in-out",
-              "rounded-150 tb:rounded-100",
-              "[&>option]:text-form-element-filled-foreground",
-              "disabled:text-form-element-disabled-foreground disabled:cursor-not-allowed",
+
+          <div className="relative z-[3] size-full">
+            {prefix && (
+              <div className="px-300 pointer-events-none absolute top-0 z-[3] flex h-full items-center">
+                {prefix}
+              </div>
             )}
-            id={selectId}
-            data-test={dataTest}
-            data-state={getFieldDataState(!!error)}
-            disabled={disabled}
-            value={value == null ? "" : value}
-            name={name}
-            onFocus={handleFocus}
-            onBlur={onBlur}
-            onChange={onChange}
-            tabIndex={tabIndex ? Number(tabIndex) : undefined}
-            required={required}
-            ref={ref}
-            aria-describedby={shown ? `${selectId}-feedback` : undefined}
-            aria-invalid={error ? true : undefined}
-            aria-label={ariaLabel}
-            {...dataAttrs}
-          >
-            {placeholder && (
-              <option label={placeholder.toString()} value="">
-                {placeholder}
-              </option>
-            )}
-            {options.map(option => (
-              <option
-                key={`option-${option.key || option.value}`}
-                value={option.value}
-                disabled={option.disabled}
+            {customValueText && (
+              <div
+                className={cx(
+                  (disabled && "text-form-element-disabled-foreground") || filled
+                    ? "text-form-element-filled-foreground"
+                    : "text-form-element-foreground",
+                  "text-form-element-normal font-base pointer-events-none absolute inset-y-0 z-[3] flex items-center",
+                  prefix ? "ps-1200" : "ps-300",
+                )}
               >
-                {option.label}
-              </option>
-            ))}
-          </select>
+                {customValueText}
+              </div>
+            )}
+            <select
+              className={cx(
+                "cursor-pointer appearance-none bg-transparent outline-none",
+                filled ? "text-form-element-filled-foreground" : "text-form-element-foreground",
+                "font-base text-form-element-normal",
+                "pe-1000",
+                prefix ? "ps-1200" : "ps-300",
+                "shrink grow basis-1/5",
+                "size-full",
+                "border-0",
+                customValueText && "!text-transparent",
+                "duration-fast transition-shadow ease-in-out",
+                "rounded-150 tb:rounded-100",
+                "[&>option]:text-form-element-filled-foreground",
+                "disabled:text-form-element-disabled-foreground disabled:cursor-not-allowed",
+              )}
+              id={selectId}
+              data-test={dataTest}
+              data-state={getFieldDataState(!!error)}
+              disabled={disabled}
+              value={value == null ? "" : value}
+              name={name}
+              onFocus={handleFocus}
+              onBlur={onBlur}
+              onChange={onChange}
+              tabIndex={tabIndex ? Number(tabIndex) : undefined}
+              required={required}
+              ref={ref}
+              aria-describedby={shown ? `${selectId}-feedback` : undefined}
+              aria-invalid={error ? true : undefined}
+              aria-label={ariaLabel}
+              {...dataAttrs}
+            >
+              {placeholder && (
+                <option label={placeholder.toString()} value="">
+                  {placeholder}
+                </option>
+              )}
+              {options.map(option => (
+                <option
+                  key={`option-${option.key || option.value}`}
+                  value={option.value}
+                  disabled={option.disabled}
+                >
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div
+            className={cx(
+              "end-200 pointer-events-none absolute top-0 z-[3] flex h-full items-center justify-center",
+              disabled
+                ? "text-form-element-disabled-foreground"
+                : "text-form-element-filled-foreground",
+            )}
+          >
+            <ChevronDown color="secondary" />
+          </div>
+          <FakeInput disabled={disabled} error={error} />
         </div>
-        <div
-          className={cx(
-            "end-200 pointer-events-none absolute top-0 z-[3] flex h-full items-center justify-center",
-            disabled
-              ? "text-form-element-disabled-foreground"
-              : "text-form-element-filled-foreground",
-          )}
-        >
-          <ChevronDown color="secondary" />
-        </div>
-        <FakeInput disabled={disabled} error={error} />
-      </div>
+      </label>
       {!insideInputGroup && hasTooltip && (
         <ErrorFormTooltip
           id={`${selectId}-feedback`}
@@ -216,7 +225,7 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
           referenceElement={inlineLabel ? iconRef : inputRef}
         />
       )}
-    </label>
+    </div>
   );
 });
 

--- a/packages/orbit-components/src/Select/types.d.ts
+++ b/packages/orbit-components/src/Select/types.d.ts
@@ -36,4 +36,5 @@ export interface Props extends Common.Globals, Common.SpaceAfter, Common.DataAtt
   readonly inlineLabel?: boolean;
   readonly customValueText?: Common.Translation;
   readonly ariaLabel?: string;
+  readonly ariaLabelledby?: string;
 }


### PR DESCRIPTION
Closes: https://kiwicom.atlassian.net/browse/FEPLT-2252

Adjusted stories to remove violations, added aria-labelledby, added Accessibility tab.

I also made adjustment to the component to solve the issue with Tooltip content (when error/help are displayed) being part of the label instead of just being part of `aria-describedby`:

Before:
![Snímek obrazovky 2025-02-05 v 14 17 56](https://github.com/user-attachments/assets/b04845dd-e252-4307-9e4d-8696ea64f0c7)

After:
![Snímek obrazovky 2025-02-05 v 14 28 28](https://github.com/user-attachments/assets/e5795be5-62db-4f98-9a76-6488c8a24c40)


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR improves accessibility for the Select component by adding `aria-labelledby` and `aria-label` properties, and adjusting the Tooltip content handling.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Select
    participant ScreenReader
    participant AriaAttributes

    User->>Select: Interacts with Select component
    
    alt Has Label
        Select->>ScreenReader: Announce label text
    else Has AriaLabel
        Select->>AriaAttributes: Set aria-label
        AriaAttributes->>ScreenReader: Announce aria-label text
    else Has AriaLabelledby
        Select->>AriaAttributes: Set aria-labelledby
        AriaAttributes->>ScreenReader: Announce referenced element text
    end

    alt Has Error/Help
        Select->>AriaAttributes: Set aria-describedby
        AriaAttributes->>ScreenReader: Announce error/help message
    end

    alt Has CustomValueText
        Select->>ScreenReader: Announce custom text alternative
    end

    User->>Select: Makes selection
    Select->>ScreenReader: Announce selected value
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4613/files#diff-dabc7c7accf066fd10c57cb9eb8c4a311fb66a0b333287aed98b13f143a67d77>docs/src/documentation/03-components/05-input/select/03-accessibility.mdx</a></td><td>Added documentation for accessibility features of the Select component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4613/files#diff-20126b7c9184dcfd6338647a40e574b48fc234a828dbd6397344997bf60d1917>packages/orbit-components/src/Select/README.md</a></td><td>Updated README to reference the new accessibility features.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4613/files#diff-1f21894712c926281435ff477b2a430b2b176f700ded969438dad0170cf591c0>packages/orbit-components/src/Select/Select.stories.tsx</a></td><td>Updated stories to demonstrate the new accessibility props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4613/files#diff-b78acf68c19f2cb436b4c59630a6f193dc24bf58163c5a59b6277d895c7c0225>packages/orbit-components/src/Select/__tests__/Select.test.tsx</a></td><td>No changes related to accessibility were made in tests.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4613/files#diff-61824b9b2a0a9e5ee91f1145d6f2fda89d4bf4351b49ec38337904222f02eb91>packages/orbit-components/src/Select/index.tsx</a></td><td>Modified Select component to handle <code>aria-labelledby</code> and <code>aria-label</code>.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4613/files#diff-b56db16ebe93360040cfef9b74d42626645cee113d9ea698befa428226e7506c>packages/orbit-components/src/Select/types.d.ts</a></td><td>Added type definitions for new accessibility props.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->
















