### PR TITLE
Badge a11y

### DIFF
--- a/docs/src/documentation/03-components/03-information/badge/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/03-information/badge/01-guidelines.mdx
@@ -61,7 +61,7 @@ visual cues can help users understand the idea more quickly.
 Use icons to display more information in a smaller size,
 such as what form of transport is included.
 
-The badge can be only an icon. Just be sure to keep it [accessible](/foundation/accessibility/)
+The badge can be only an icon. Just be sure to keep it [accessible](./accessibility/)
 by giving it a label for people who don't see the icon.
 
 <Guideline type="do" title="Use icons only on left">

--- a/docs/src/documentation/03-components/03-information/badge/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/03-information/badge/03-accessibility.mdx
@@ -1,0 +1,36 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/badge/accessibility/
+---
+
+## Accessibility
+
+The Badge component has been designed with accessibility in mind.
+
+### Screen reader support
+
+The Badge component supports screen readers through the `ariaLabel` prop. This prop is especially important when:
+
+- The badge contains only an icon
+- The content is not sufficient to convey the full meaning
+- Additional context would help understand the badge's purpose
+
+For example:
+
+```jsx
+<Badge ariaLabel="4 passengers" icon={<Icons.Passenger />}>
+  4
+</Badge>
+```
+
+In this example, while sighted users see the number "4" with a passengers icon, screen reader users hear "4 passengers" which provides the complete context.
+
+As it is announced by screen readers, the content should have meaningful and translated text.
+
+### Icons
+
+When using icons in badges:
+
+- Provide an `ariaLabel` if the icon has a meaning by itself that is not obvious to screen readers, regardless of the existence of text
+- If the icon is decorative and the badge contains text, the icon should be marked as `aria-hidden="true"`

--- a/packages/orbit-components/src/primitives/BadgePrimitive/index.tsx
+++ b/packages/orbit-components/src/primitives/BadgePrimitive/index.tsx
@@ -31,6 +31,7 @@ const BadgePrimitive = ({
       id={id}
       data-test={dataTest}
       aria-label={ariaLabel}
+      role="status"
     >
       {carriers && <CarrierLogo carriers={carriers} rounded size="medium" />}
       {icon && (


### PR DESCRIPTION
closes FEPLT-2251


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces accessibility improvements for the Badge component, including guidelines for screen reader support and proper use of aria attributes.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant User as Screen Reader User
    participant Badge as Badge Component
    participant SR as Screen Reader

    Note over Badge: Added role="status"
    Note over Badge: Support for ariaLabel prop

    User->>Badge: Interacts with Badge
    alt Badge with Icon Only
        Badge->>SR: Announces ariaLabel
        SR->>User: Reads meaningful context<br/>(e.g. "4 passengers")
    else Badge with Decorative Icon + Text
        Badge->>SR: Icon marked as aria-hidden="true"
        SR->>User: Reads badge text only
    end

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4620/files#diff-ba7db54b8c002b69dca366c884d0784316508e87a7acd8cc010680bacafb16e4>docs/src/documentation/03-components/03-information/badge/01-guidelines.mdx</a></td><td>Updated the accessibility link to point to the correct path.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4620/files#diff-7692d1eeb67262221643fb27ecf3d3db714b12b6d0d54f0145aaf79e38bfdef6>docs/src/documentation/03-components/03-information/badge/03-accessibility.mdx</a></td><td>Added a new document outlining accessibility features and guidelines for the Badge component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4620/files#diff-68c4c6405a097428e4008897ebcf17cc663b53441885f257187da7c80d03ef1f>packages/orbit-components/src/primitives/BadgePrimitive/index.tsx</a></td><td>Added role='status' to the BadgePrimitive component for better accessibility.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




















