### PR TITLE
docs: add OrbitProvider to a Tag example

### DIFF
--- a/docs/src/__examples__/Tag/FILTERS.tsx
+++ b/docs/src/__examples__/Tag/FILTERS.tsx
@@ -20,6 +20,8 @@ import {
   StopoverArrow,
   Stack,
   Text,
+  OrbitProvider,
+  defaultTheme,
 } from "@kiwicom/orbit-components";
 
 export default {
@@ -34,174 +36,176 @@ export default {
     const isTransportFiltered =
       checked.plane === false || checked.train === false || checked.bus === false;
     return (
-      <Stack>
-        <Stack direction="row" spacing="300">
-          <Text>Amsterdam</Text>
-          <FlightDirect ariaLabel="to" />
-          <Text>Barcelona</Text>
-        </Stack>
-        <Stack direction="row" spacing="300">
-          <Badge>Fri May 17</Badge>
-          <Text>to</Text>
-          <Badge>No return</Badge>
-        </Stack>
-        <Stack direction="row" spacing="300">
-          <Popover
-            renderInPortal={false}
-            content={
-              <Stack>
-                <Stack justify="center" grow>
-                  <Stack>
-                    <Text>Cabin baggage</Text>
+      <OrbitProvider theme={defaultTheme} useId={React.useId}>
+        <Stack>
+          <Stack direction="row" spacing="300">
+            <Text>Amsterdam</Text>
+            <FlightDirect ariaLabel="to" />
+            <Text>Barcelona</Text>
+          </Stack>
+          <Stack direction="row" spacing="300">
+            <Badge>Fri May 17</Badge>
+            <Text>to</Text>
+            <Badge>No return</Badge>
+          </Stack>
+          <Stack direction="row" spacing="300">
+            <Popover
+              renderInPortal={false}
+              content={
+                <Stack>
+                  <Stack justify="center" grow>
+                    <Stack>
+                      <Text>Cabin baggage</Text>
+                    </Stack>
+                    <Stepper
+                      defaultValue={cabinBags}
+                      maxValue={1}
+                      minValue={0}
+                      onChange={value => setCabinBags(value)}
+                    />
                   </Stack>
-                  <Stepper
-                    defaultValue={cabinBags}
-                    maxValue={1}
-                    minValue={0}
-                    onChange={value => setCabinBags(value)}
-                  />
-                </Stack>
-                <Stack align="center">
-                  <Stack>
-                    <Text>Checked baggage</Text>
+                  <Stack align="center">
+                    <Stack>
+                      <Text>Checked baggage</Text>
+                    </Stack>
+                    <Stepper
+                      defaultValue={checkedBags}
+                      maxValue={2}
+                      minValue={0}
+                      onChange={value => setCheckedBags(value)}
+                    />
                   </Stack>
-                  <Stepper
-                    defaultValue={checkedBags}
-                    maxValue={2}
-                    minValue={0}
-                    onChange={value => setCheckedBags(value)}
-                  />
                 </Stack>
-              </Stack>
-            }
-          >
-            <Tag
-              selected={isBagsFiltered}
-              onRemove={
-                isBagsFiltered
-                  ? () => {
-                      setCabinBags(0);
-                      setCheckedBags(0);
-                    }
-                  : undefined
               }
             >
-              Bags
-            </Tag>
-          </Popover>
-          <Popover
-            renderInPortal={false}
-            content={
-              <ChoiceGroup label="Stops" onChange={event => setStops(event.currentTarget.name)}>
-                <Radio name="non" label="Any" checked={stops === "any" || false} />
-                <Radio name="non" label="Nonstop" checked={stops === "non" || false} />
-                <Radio name="1stop" label="Up to 1 stop" checked={stops === "1stop" || false} />
-                <Radio name="2stop" label="Up to 2 stops" checked={stops === "2stop" || false} />
-              </ChoiceGroup>
-            }
-          >
-            <Tag
-              selected={isStopsFiltered}
-              onRemove={
-                isStopsFiltered
-                  ? () => {
-                      setStops("any");
-                    }
-                  : undefined
-              }
-            >
-              Stops
-            </Tag>
-          </Popover>
-          <Popover
-            renderInPortal={false}
-            content={
-              <ChoiceGroup
-                label="Transport"
-                onChange={event => {
-                  const { name } = event.currentTarget;
-                  setChecked(prevState => ({ ...prevState, [name]: !checked[name] }));
-                }}
+              <Tag
+                selected={isBagsFiltered}
+                onRemove={
+                  isBagsFiltered
+                    ? () => {
+                        setCabinBags(0);
+                        setCheckedBags(0);
+                      }
+                    : undefined
+                }
               >
-                <Checkbox name="plane" label="Planes" checked={checked.plane} />
-                <Checkbox name="train" label="Trains" checked={checked.train} />
-                <Checkbox name="bus" label="Buses" checked={checked.bus} />
-              </ChoiceGroup>
-            }
-          >
-            <Tag
-              selected={isTransportFiltered}
-              onRemove={
-                isTransportFiltered
-                  ? () => {
-                      setChecked({ plane: true, train: true, bus: true });
-                    }
-                  : undefined
+                Bags
+              </Tag>
+            </Popover>
+            <Popover
+              renderInPortal={false}
+              content={
+                <ChoiceGroup label="Stops" onChange={event => setStops(event.currentTarget.name)}>
+                  <Radio name="non" label="Any" checked={stops === "any" || false} />
+                  <Radio name="non" label="Nonstop" checked={stops === "non" || false} />
+                  <Radio name="1stop" label="Up to 1 stop" checked={stops === "1stop" || false} />
+                  <Radio name="2stop" label="Up to 2 stops" checked={stops === "2stop" || false} />
+                </ChoiceGroup>
               }
             >
-              Transport
-            </Tag>
-          </Popover>
+              <Tag
+                selected={isStopsFiltered}
+                onRemove={
+                  isStopsFiltered
+                    ? () => {
+                        setStops("any");
+                      }
+                    : undefined
+                }
+              >
+                Stops
+              </Tag>
+            </Popover>
+            <Popover
+              renderInPortal={false}
+              content={
+                <ChoiceGroup
+                  label="Transport"
+                  onChange={event => {
+                    const { name } = event.currentTarget;
+                    setChecked(prevState => ({ ...prevState, [name]: !checked[name] }));
+                  }}
+                >
+                  <Checkbox name="plane" label="Planes" checked={checked.plane} />
+                  <Checkbox name="train" label="Trains" checked={checked.train} />
+                  <Checkbox name="bus" label="Buses" checked={checked.bus} />
+                </ChoiceGroup>
+              }
+            >
+              <Tag
+                selected={isTransportFiltered}
+                onRemove={
+                  isTransportFiltered
+                    ? () => {
+                        setChecked({ plane: true, train: true, bus: true });
+                      }
+                    : undefined
+                }
+              >
+                Transport
+              </Tag>
+            </Popover>
+          </Stack>
+          <Separator />
+          {checked.plane && (
+            <Card
+              title={
+                <Stack flex align="center">
+                  <Text>Excellent flight</Text>
+                  <StopoverArrow stops="0" />
+                  <Airplane ariaLabel="Plane" />
+                  <Stack inline>
+                    <Text>Up to 1</Text>
+                    <BaggageCabin ariaLabel="cabin bag" />
+                  </Stack>
+                  <Stack inline>
+                    <Text>Up to 2</Text>
+                    <BaggageChecked30 ariaLabel="checked bags" />
+                  </Stack>
+                </Stack>
+              }
+            />
+          )}
+          {checked.train && stops !== "direct" && checkedBags <= 1 && (
+            <Card
+              title={
+                <Stack flex align="center">
+                  <Text>Awesome train ride</Text>
+                  <StopoverArrow stops="1" />
+                  <Train ariaLabel="Train" />
+                  <Stack inline>
+                    <Text>Up to 1</Text>
+                    <BaggageCabin ariaLabel="cabin bag" />
+                  </Stack>
+                  <Stack inline>
+                    <Text>Up to 1</Text>
+                    <BaggageChecked30 ariaLabel="checked bag" />
+                  </Stack>
+                </Stack>
+              }
+            />
+          )}
+          {checked.bus && stops !== "direct" && stops !== "1stop" && checkedBags <= 1 && (
+            <Card
+              title={
+                <Stack flex align="center">
+                  <Text>Smooth bus ride</Text>
+                  <StopoverArrow stops="2" />
+                  <Bus ariaLabel="Bus" />
+                  <Stack inline>
+                    <Text>Up to 1</Text>
+                    <BaggageCabin ariaLabel="cabin bag" />
+                  </Stack>
+                  <Stack inline>
+                    <Text>Up to 1</Text>
+                    <BaggageChecked30 ariaLabel="checked bag" />
+                  </Stack>
+                </Stack>
+              }
+            />
+          )}
         </Stack>
-        <Separator />
-        {checked.plane && (
-          <Card
-            title={
-              <Stack flex align="center">
-                <Text>Excellent flight</Text>
-                <StopoverArrow stops="0" />
-                <Airplane ariaLabel="Plane" />
-                <Stack inline>
-                  <Text>Up to 1</Text>
-                  <BaggageCabin ariaLabel="cabin bag" />
-                </Stack>
-                <Stack inline>
-                  <Text>Up to 2</Text>
-                  <BaggageChecked30 ariaLabel="checked bags" />
-                </Stack>
-              </Stack>
-            }
-          />
-        )}
-        {checked.train && stops !== "direct" && checkedBags <= 1 && (
-          <Card
-            title={
-              <Stack flex align="center">
-                <Text>Awesome train ride</Text>
-                <StopoverArrow stops="1" />
-                <Train ariaLabel="Train" />
-                <Stack inline>
-                  <Text>Up to 1</Text>
-                  <BaggageCabin ariaLabel="cabin bag" />
-                </Stack>
-                <Stack inline>
-                  <Text>Up to 1</Text>
-                  <BaggageChecked30 ariaLabel="checked bag" />
-                </Stack>
-              </Stack>
-            }
-          />
-        )}
-        {checked.bus && stops !== "direct" && stops !== "1stop" && checkedBags <= 1 && (
-          <Card
-            title={
-              <Stack flex align="center">
-                <Text>Smooth bus ride</Text>
-                <StopoverArrow stops="2" />
-                <Bus ariaLabel="Bus" />
-                <Stack inline>
-                  <Text>Up to 1</Text>
-                  <BaggageCabin ariaLabel="cabin bag" />
-                </Stack>
-                <Stack inline>
-                  <Text>Up to 1</Text>
-                  <BaggageChecked30 ariaLabel="checked bag" />
-                </Stack>
-              </Stack>
-            }
-          />
-        )}
-      </Stack>
+      </OrbitProvider>
     );
   },
 };


### PR DESCRIPTION
# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds the `OrbitProvider` and `defaultTheme` to the Tag example, enhancing the component's styling and theming capabilities.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant FilterInterface
    participant TransportFilter
    participant BagsFilter
    participant StopsFilter
    participant ResultsDisplay

    User->>FilterInterface: Views Amsterdam to Barcelona route
    
    User->>TransportFilter: Toggles transport options
    TransportFilter-->>ResultsDisplay: Updates visible transport cards
    
    User->>BagsFilter: Adjusts cabin/checked bags
    BagsFilter-->>ResultsDisplay: Filters based on baggage allowance
    
    User->>StopsFilter: Selects number of stops
    StopsFilter-->>ResultsDisplay: Filters routes by stop count
    
    ResultsDisplay-->>User: Shows filtered transport options
    Note over ResultsDisplay: Displays cards for:<br/>- Planes (0 stops)<br/>- Trains (1 stop)<br/>- Buses (2 stops)
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4623/files#diff-eca9f56eda9db6695ce5c2df30df730d6d47e6f97cfa55727be0982bbeb74117>docs/src/__examples__/Tag/FILTERS.tsx</a></td><td>Added <code>OrbitProvider</code> and <code>defaultTheme</code> to the Tag example for improved theming.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->




