### PR TITLE
CountryFlag: add generic orbit class

### DIFF
--- a/packages/orbit-components/src/CountryFlag/index.tsx
+++ b/packages/orbit-components/src/CountryFlag/index.tsx
@@ -26,10 +26,14 @@ const CountryFlag = ({ dataTest, size = SIZES.MEDIUM, id, role = "img", ...props
 
   return (
     <div
-      className={cx("rounded-50 bg-country-flag-background relative shrink-0 overflow-hidden", {
-        "h-country-flag-small w-country-flag-small": size === SIZES.SMALL,
-        "h-country-flag-medium w-country-flag-medium": size === SIZES.MEDIUM,
-      })}
+      className={cx(
+        "orbit-country-flag",
+        "rounded-50 bg-country-flag-background relative shrink-0 overflow-hidden",
+        {
+          "h-country-flag-small w-country-flag-small": size === SIZES.SMALL,
+          "h-country-flag-medium w-country-flag-medium": size === SIZES.MEDIUM,
+        },
+      )}
     >
       <img
         className="block size-full shrink-0"


### PR DESCRIPTION
FEPLT-2332

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces a generic orbit class to the CountryFlag component, enhancing its styling capabilities.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant App
    participant CountryFlag
    participant div
    participant img

    App->>CountryFlag: Render with size prop
    CountryFlag->>div: Create container
    Note over div: Add className with:<br/>- orbit-country-flag<br/>- rounded-50<br/>- bg-country-flag-background<br/>- size-specific classes
    div->>img: Render image
    Note over img: Apply full size and<br/>shrink-0 classes
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4624/files#diff-9cde0be138e7f708e07470a9cbf51bb74d6fe8d50ce4032cf7bf66c8bfca5092>packages/orbit-components/src/CountryFlag/index.tsx</a></td><td>Added a new class 'orbit-country-flag' to the CountryFlag component for improved styling.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


