### PR TITLE
Make Table accessible

### DIFF
--- a/docs/src/documentation/03-components/02-structure/table/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/02-structure/table/03-accessibility.mdx
@@ -1,0 +1,28 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/table/accessibility/
+---
+
+# Accessibility
+
+## Table
+
+The Table component has been designed with accessibility in mind, and it can be used with keyboard navigation.
+
+### Scope attribute in the TableCell component
+
+If the `as` prop is set to `"th"`, it's possible to set the `scope` prop to identify whether a table header is a column header or a row header.
+You can find more information about the usage in the [official documentation of the scope property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableCellElement/scope).
+
+```jsx
+<TableRow>
+  <TableCell as="th" scope="row">
+    Freja Møller
+  </TableCell>
+  <TableCell>39</TableCell>
+  <TableCell>freja21@example.com</TableCell>
+</TableRow>
+```
+
+Screen readers will recognize markup structured like this, and allow their users to read out the entire column or row at once, for example.

--- a/docs/src/documentation/05-development/04-migration-guides/01-v20.mdx
+++ b/docs/src/documentation/05-development/04-migration-guides/01-v20.mdx
@@ -137,6 +137,14 @@ intl.formatMessage({
 
 Feel free to customize the translations according to your needs, by eventually providing more context to the modal it refers to.
 
+## Fixes
+
+### `scope` prop in the `TableCell` can now be set only for the `th` element (from version 20.1.0)
+
+Previously, it was possible to set the `scope` prop on the `TableCell` component when rendered as `td` element, but this was incorrect.
+
+As a result, the `scope` prop can now only be set when the `TableCell` is rendered as a `th` element.
+
 ## Codemod
 
 A codemod is available to help with the migration. It should target the new props that require (translated) strings.

--- a/packages/orbit-components/src/Table/README.md
+++ b/packages/orbit-components/src/Table/README.md
@@ -40,10 +40,10 @@ Table below contains all types of the props available in the Table component.
 
 | Name         | Type            | Default     | Description                                                                                |
 | :----------- | :-------------- | :---------- | :----------------------------------------------------------------------------------------- |
-| **children** | `React.Node`    |             | The content of the Table, normally [`TableHead`](#tablehead) or [`TableHead`](#TableHead). |
+| **children** | `React.Node`    |             | The content of the Table, normally [`TableHead`](#tablehead) or [`TableBody`](#tablebody). |
 | compact      | `boolean`       | `false`     | If `true`, the Table will have more compact styles.                                        |
 | dataTest     | `string`        |             | Optional prop for testing purposes.                                                        |
-| id           | `string`        |             | Set `id` for `Table`                                                                       |
+| id           | `string`        |             | Set `id` for Table.                                                                        |
 | striped      | `boolean`       | `true`      | Functionality of table where every second line is grey                                     |
 | type         | [`enum`](#enum) | `"primary"` | The type of Table.                                                                         |
 
@@ -113,15 +113,15 @@ import TableCell from "@kiwicom/orbit-components/lib/Table/TableCell";
 
 Table below contains all types of the props in TableCell component.
 
-| Name          | Type            | Default  | Description                                                                                                                                                         |
-| :------------ | :-------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| align         | [`enum`](#enum) | `"left"` | The align of text in the TableCell.                                                                                                                                 |
-| as            | [`enum`](#enum) | `"td"`   | possibility to render TableCell in different HTML                                                                                                                   |
-| children      | `React.Node`    |          | The content of the TableCell.                                                                                                                                       |
-| dataTest      | `string`        |          | Optional prop for testing purposes.                                                                                                                                 |
-| scope         | [`enum`](#enum) |          | The scope attribute identifies whether a table header is a column header or a row header. More about a11y reasons [here](https://webaim.org/techniques/tables/data) |
-| verticalAlign | [`enum`](#enum) |          | The vertical align of the content in the TableCell.                                                                                                                 |
-| whiteSpace    | [`enum`](#enum) |          | The white-space setting of text in the TableCell.                                                                                                                   |
+| Name          | Type            | Default  | Description                                                                                                                      |
+| :------------ | :-------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| align         | [`enum`](#enum) | `"left"` | The align of text in the TableCell.                                                                                              |
+| as            | [`enum`](#enum) | `"td"`   | Possibility to render TableCell in different HTML.                                                                               |
+| children      | `React.Node`    |          | The content of the TableCell.                                                                                                    |
+| dataTest      | `string`        |          | Optional prop for testing purposes.                                                                                              |
+| scope         | [`enum`](#enum) |          | Can be set only when `as="th"`. Identifies whether a table header is a column header or a row header. See the Accessibility tab. |
+| verticalAlign | [`enum`](#enum) |          | The vertical align of the content in the TableCell.                                                                              |
+| whiteSpace    | [`enum`](#enum) |          | The white-space setting of text in the TableCell.                                                                                |
 
 #### enum
 

--- a/packages/orbit-components/src/Table/Table.stories.tsx
+++ b/packages/orbit-components/src/Table/Table.stories.tsx
@@ -2,8 +2,9 @@ import * as React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { ALIGN_OPTIONS, WHITE_SPACE } from "./TableCell/consts";
-import { TYPE_OPTIONS, TYPE_AS } from "./consts";
+import { TYPE_OPTIONS } from "./consts";
 import RenderInRtl from "../utils/rtl/RenderInRtl";
+import type { Props } from "./TableCell/types";
 
 import Table, { TableFooter, TableHead, TableBody, TableRow, TableCell } from ".";
 
@@ -15,8 +16,7 @@ const tableRow = (
   </TableRow>
 );
 
-type TablePropsAndCustomArgs = React.ComponentProps<typeof Table> &
-  React.ComponentProps<typeof TableCell>;
+type TablePropsAndCustomArgs = React.ComponentProps<typeof Table> & Omit<Props, "as" | "scope">;
 
 const meta: Meta<TablePropsAndCustomArgs> = {
   title: "Table",
@@ -50,7 +50,7 @@ export const Playground: Story = {
         <TableHead>
           <TableRow>
             {Array.from({ length: 4 }, (_, idx) => (
-              <TableCell key={idx} {...args}>
+              <TableCell as="th" scope="col" key={idx} {...args}>
                 {children}
               </TableCell>
             ))}
@@ -93,8 +93,6 @@ export const Playground: Story = {
     verticalAlign: "middle",
     whiteSpace: WHITE_SPACE.NOWRAP,
     children: "Lorem ipsum dolor sit amet",
-    as: TYPE_AS.TD,
-    scope: "col",
   },
 
   argTypes: {
@@ -111,13 +109,6 @@ export const Playground: Story = {
     },
     // TableCell category
     children: { table: { category: "TableCell" } },
-    scope: {
-      options: ["col", "row", "colgroup", "rowgroup"],
-      control: {
-        type: "select",
-      },
-      table: { category: "TableCell" },
-    },
     align: {
       options: Object.values(ALIGN_OPTIONS),
       control: {
@@ -134,13 +125,6 @@ export const Playground: Story = {
     },
     whiteSpace: {
       options: Object.values(WHITE_SPACE),
-      control: {
-        type: "select",
-      },
-      table: { category: "TableCell" },
-    },
-    as: {
-      options: Object.values(TYPE_AS),
       control: {
         type: "select",
       },

--- a/packages/orbit-components/src/Table/TableCell/index.tsx
+++ b/packages/orbit-components/src/Table/TableCell/index.tsx
@@ -20,15 +20,16 @@ const whitespaceStyles: Record<WhiteSpace, string> = {
   "pre-wrap": "whitespace-pre-wrap",
 };
 
-const TableCell = ({
-  align = ALIGN_OPTIONS.LEFT,
-  scope,
-  as: Component = TYPE_AS.TD,
-  verticalAlign,
-  whiteSpace,
-  dataTest,
-  children,
-}: Props) => {
+const TableCell = (props: Props) => {
+  const {
+    align = ALIGN_OPTIONS.LEFT,
+    as: Component = TYPE_AS.TD,
+    verticalAlign,
+    whiteSpace,
+    dataTest,
+    children,
+  } = props;
+
   return (
     <Component
       className={cx(
@@ -40,7 +41,7 @@ const TableCell = ({
         (align === ALIGN_OPTIONS.END || align === ALIGN_OPTIONS.RIGHT) && "text-end",
       )}
       data-test={dataTest}
-      scope={scope}
+      scope={props.as === TYPE_AS.TH ? props.scope : undefined}
     >
       {children}
     </Component>

--- a/packages/orbit-components/src/Table/TableCell/types.d.ts
+++ b/packages/orbit-components/src/Table/TableCell/types.d.ts
@@ -3,15 +3,20 @@
 import type { SharedProps } from "../types";
 
 export type Align = "start" | "end" | "left" | "center" | "right";
-export type As = "th" | "td";
 export type Scope = "col" | "row" | "colgroup" | "rowgroup";
 export type WhiteSpace = "normal" | "nowrap" | "pre" | "pre-line" | "pre-wrap";
 export type VerticalAlign = "baseline" | "middle" | "top" | "bottom";
 
-export interface Props extends SharedProps {
-  readonly as?: As;
-  readonly scope?: Scope;
+export type Props = SharedProps & {
   readonly align?: Align;
   readonly whiteSpace?: WhiteSpace;
   readonly verticalAlign?: VerticalAlign;
-}
+} & (
+    | {
+        readonly as?: "th";
+        readonly scope?: Scope;
+      }
+    | {
+        readonly as?: "td";
+      }
+  );

--- a/packages/orbit-components/src/Table/index.tsx
+++ b/packages/orbit-components/src/Table/index.tsx
@@ -64,6 +64,8 @@ const Table = ({
         className={cx("w-full", shadows && "overflow-x-auto")}
         onScroll={handleScroll}
         ref={inner}
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex={shadows ? 0 : undefined}
       >
         <table
           className={cx(


### PR DESCRIPTION
I didn't find any wrong usage of `scope` in the repositories so the problem was most likely only in our stories. But to prevent wrong usage in the future, I changed the types to allow `scope` only for `th` element. I added it to migration guide as a note for the users to be aware of it as advised by Marco.

Closes https://kiwicom.atlassian.net/browse/FEPLT-2243

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR enhances the accessibility of the Table component by restricting the usage of the `scope` prop to only the `th` element. It also updates the documentation and migration guide accordingly.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant User
    participant TableCell
    participant ScreenReader

    Note over TableCell: Component can be rendered as "th" or "td"

    User->>TableCell: Render as TableHeader ("th")
    alt as="th"
        TableCell->>TableCell: Allow scope prop
        TableCell->>ScreenReader: Provide scope context (col/row)
        ScreenReader->>User: Read column/row context
    else as="td"
        TableCell->>TableCell: Scope prop not allowed
    end

    Note over User,ScreenReader: Improved accessibility for screen readers

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4629/files#diff-7e86fe007addf89bf247ae075dcfff9aa0250466a3116a08e5bfe5251cafb730>docs/src/documentation/03-components/02-structure/table/03-accessibility.mdx</a></td><td>Added documentation on accessibility features of the Table component, specifically regarding the <code>scope</code> attribute.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4629/files#diff-5d645f7065bef0ecf41fea1c146e96361f55ddf23af40dc185ce32a0ad4fd7da>docs/src/documentation/05-development/04-migration-guides/01-v20.mdx</a></td><td>Updated migration guide to inform users about the restriction of the <code>scope</code> prop to the <code>th</code> element.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4629/files#diff-5ef5ce9369be207d5a1f04b96fd5eddbd815f3c892ea1f4c72729370636120c6>packages/orbit-components/src/Table/README.md</a></td><td>Corrected the description of the <code>children</code> prop in the Table component documentation.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4629/files#diff-c426880355a7857ad1d99c88c3d7450dee6990a69103fef3004329e584494a99>packages/orbit-components/src/Table/TableCell/index.tsx</a></td><td>Modified the <code>TableCell</code> component to conditionally apply the <code>scope</code> prop based on the <code>as</code> prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4629/files#diff-719db48d090a6c87f0caa0111cceb00ebfa42da0ace8d11fe569a7b69f5bf6bd>packages/orbit-components/src/Table/TableCell/types.d.ts</a></td><td>Updated the <code>Props</code> type to restrict the <code>scope</code> prop to only be used with the <code>th</code> element.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->














