### PR TITLE
InputField accessibility improvements

### DIFF
--- a/docs/src/documentation/03-components/05-input/inputfield/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/05-input/inputfield/03-accessibility.mdx
@@ -1,0 +1,19 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/inputfield/accessibility/
+---
+
+### Accessibility
+
+- For special cases you can use your own, detached `label`. Simply like this:
+
+```jsx
+<label for="NICEID">Content</label>
+<InputField
+  id="NICEID"
+/>
+```
+
+- The `ariaLabel` prop allows you to specify an `aria-label` attribute for the InputField component. This attribute provides additional information to screen readers, enhancing the accessibility of the component. By using `ariaLabel`, you can ensure that users who rely on assistive technologies receive the necessary context and information about the component's purpose and functionality.
+- If the `label` prop is not provided, the `ariaLabel` prop must be specified to ensure component accessibility.

--- a/packages/orbit-components/src/InputField/InputField.stories.tsx
+++ b/packages/orbit-components/src/InputField/InputField.stories.tsx
@@ -316,7 +316,13 @@ export const WithButtonLinkSuffix: Story = {
       <InputField
         suffix={
           Suffix && (
-            <ButtonLink type="primary" compact iconLeft={<Suffix />} onClick={action("clicked")} />
+            <ButtonLink
+              aria-label="Show text"
+              type="primary"
+              compact
+              iconLeft={<Suffix />}
+              onClick={action("clicked")}
+            />
           )
         }
         {...args}
@@ -393,6 +399,7 @@ export const WithError: Story = {
               compact
               size="normal"
               onClick={action("clicked")}
+              aria-label="Show text"
               disabled={disabled}
             />
           )
@@ -427,6 +434,7 @@ export const WithHelp: Story = {
               size="normal"
               onClick={action("clicked")}
               disabled={disabled}
+              aria-label="Show text"
             />
           )
         }
@@ -460,6 +468,7 @@ export const Playground: Story = {
               onClick={action("clicked")}
               disabled={disabled}
               compact
+              aria-label="Show text"
             />
           )
         }
@@ -522,7 +531,10 @@ export const Rtl: Story = {
 
     return (
       <RenderInRtl>
-        <InputField suffix={<ButtonLink iconLeft={<Suffix />} compact />} {...args} />
+        <InputField
+          suffix={<ButtonLink iconLeft={<Suffix />} aria-label="Show text" compact />}
+          {...args}
+        />
       </RenderInRtl>
     );
   },

--- a/packages/orbit-components/src/InputField/README.md
+++ b/packages/orbit-components/src/InputField/README.md
@@ -16,54 +16,54 @@ After adding import to your project you can use it simply like:
 
 The table below contains all types of props available in the InputField component.
 
-| Name                 | Type                               | Default   | Description                                                                                                                                                                      |
-| :------------------- | :--------------------------------- | :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| autoComplete         | `string`                           |           | The autocomplete attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).                                             |
-| autoFocus            | `boolean`                          |           | The autofocus attribute of the input, see [this docs](https://www.w3schools.com/tags/att_autofocus.asp). Keep in mind that autofocus works only when Input is initially rendered |
-| defaultValue         | `string \| number`                 |           | Specifies the default value of the InputField. To be used with uncontrolled usage.                                                                                               |
-| disabled             | `boolean`                          |           | If `true`, the InputField will be disabled.                                                                                                                                      |
-| dataAttrs            | `Object`                           |           | Optional prop for passing `data-*` attributes to the `input` DOM element.                                                                                                        |
-| dataTest             | `string`                           |           | Optional prop for testing purposes.                                                                                                                                              |
-| error                | `React.Node`                       |           | The error to display beneath the InputField. [See Functional specs](#functional-specs)                                                                                           |
-| tags                 | `React.Node`                       |           | Here you can pass <Tag /> component for render tags [See Functional specs](#functional-specs)                                                                                    |
-| help                 | `React.Node`                       |           | The help to display beneath the InputField.                                                                                                                                      |
-| label                | `Translation`                      |           | The label for the InputField. [See Functional specs](#functional-specs)                                                                                                          |
-| id                   | `string`                           |           | HTML `id` attribute for input.[See Accessibility specs](#accessibility)                                                                                                          |
-| inlineLabel          | `boolean`                          |           | If true the label renders on the left side of input                                                                                                                              |
-| inputMode            | [`enum`](#enum)                    |           | The type of data that might be entered by the user. [See more here](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).                              |
-| maxLength            | `number`                           |           | Specifies the maximum number of characters allowed.                                                                                                                              |
-| maxValue             | `number`                           |           | Specifies the maximum value for the InputField.                                                                                                                                  |
-| minLength            | `number`                           |           | Specifies the minimum number of characters allowed.                                                                                                                              |
-| width                | `string`                           | `100%`    | Specifies the width of InputField.                                                                                                                                               |
-| minValue             | `number`                           |           | Specifies the minimum value for the InputField.                                                                                                                                  |
-| required             | `boolean`                          |           | If true, the label is displayed as required.                                                                                                                                     |
-| name                 | `string`                           |           | The name for the InputField.                                                                                                                                                     |
-| onBlur               | `event => void \| Promise`         |           | Function for handling onBlur event.                                                                                                                                              |
-| onChange             | `event => void \| Promise`         |           | Function for handling onChange event.                                                                                                                                            |
-| onFocus              | `event => void \| Promise`         |           | Function for handling onFocus event.                                                                                                                                             |
-| onKeyDown            | `event => void \| Promise`         |           | Function for handling onKeyDown event.                                                                                                                                           |
-| onKeyUp              | `event => void \| Promise`         |           | Function for handling onKeyUp event.                                                                                                                                             |
-| onMouseDown          | `event => void \| Promise`         |           | Function for handling onMouseDown event.                                                                                                                                         |
-| onMouseUp            | `event => void \| Promise`         |           | Function for handling onMouseUp event.                                                                                                                                           |
-| onSelect             | `event => void \| Promise`         |           | Function for handling onSelect event.                                                                                                                                            |
-| placeholder          | `string \| (() => string))`        |           | The placeholder of the InputField.                                                                                                                                               |
-| **prefix**           | `React.Node`                       |           | The prefix component for the InputField.                                                                                                                                         |
-| readOnly             | `boolean`                          | `"false"` | If `true`, the InputField be readOnly.                                                                                                                                           |
-| ref                  | `func`                             |           | Prop for forwarded ref of the InputField. [See Functional specs](#functional-specs)                                                                                              |
-| spaceAfter           | `enum`                             |           | Additional `margin-bottom` after component.                                                                                                                                      |
-| suffix               | `React.Node`                       |           | The suffix component for the InputField. [See Functional specs](#functional-specs)                                                                                               |
-| tabIndex             | `string \| number`                 |           | Specifies the tab order of an element                                                                                                                                            |
-| **type**             | [`enum`](#enum)                    | `"text"`  | The type of the InputField.                                                                                                                                                      |
-| value                | `string \| number`                 |           | Specifies the value of the InputField. To be used with controlled usage.                                                                                                         |
-| helpClosable         | `boolean`                          | `true`    | Whether to display help as a closable tooltip, or have it open only while the field is focused, same as error.                                                                   |
-| list                 | `string`                           |           | The id of the datalist element.                                                                                                                                                  |
-| ariaAutocomplete     | `inline \| list \| both`           |           | The aria-autocomplete attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete).                     |
-| role                 | `textbox \| combobox \| searchbox` | `textbox` | The role attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role).                                            |
-| ariaActiveDescendant | `string`                           |           | The aria-activedescendant attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant).             |
-| ariaHasPopup         | `boolean`                          |           | The aria-haspopup attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup).                             |
-| ariaExpanded         | `boolean`                          |           | The aria-expanded attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded).                             |
-| ariaControls         | `string`                           |           | The aria-controls attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls).                             |
-| ariaLabel            | `string`                           |           | Optional prop for `aria-label` value. [See Accessibility](#accessibility).                                                                                                       |
+| Name                 | Type                               | Default   | Description                                                                                                                                                                       |
+| :------------------- | :--------------------------------- | :-------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| autoComplete         | `string`                           |           | The autocomplete attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).                                              |
+| autoFocus            | `boolean`                          |           | The autofocus attribute of the input, see [this docs](https://www.w3schools.com/tags/att_autofocus.asp). Keep in mind that autofocus works only when Input is initially rendered. |
+| defaultValue         | `string \| number`                 |           | Specifies the default value of the InputField. To be used with uncontrolled usage.                                                                                                |
+| disabled             | `boolean`                          |           | If `true`, the InputField will be disabled.                                                                                                                                       |
+| dataAttrs            | `Object`                           |           | Optional prop for passing `data-*` attributes to the `input` DOM element.                                                                                                         |
+| dataTest             | `string`                           |           | Optional prop for testing purposes.                                                                                                                                               |
+| error                | `React.Node`                       |           | The error to display beneath the InputField. [See Functional specs](#functional-specs)                                                                                            |
+| tags                 | `React.Node`                       |           | Optional prop to display rendered Tag component. [See Functional specs](#functional-specs)                                                                                        |
+| help                 | `React.Node`                       |           | The help to display beneath the InputField.                                                                                                                                       |
+| label                | `Translation`                      |           | The label for the InputField. [See Functional specs](#functional-specs)                                                                                                           |
+| id                   | `string`                           |           | Set `id` attribute for input.                                                                                                                                                     |
+| inlineLabel          | `boolean`                          |           | If `true`, the label renders on the left side of input.                                                                                                                           |
+| inputMode            | [`enum`](#enum)                    |           | The type of data that might be entered by the user. [See more here](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).                               |
+| minValue             | `number`                           |           | Specifies the minimum value for the InputField.                                                                                                                                   |
+| maxValue             | `number`                           |           | Specifies the maximum value for the InputField.                                                                                                                                   |
+| maxLength            | `number`                           |           | Specifies the maximum number of characters allowed.                                                                                                                               |
+| minLength            | `number`                           |           | Specifies the minimum number of characters allowed.                                                                                                                               |
+| width                | `string`                           | `"100%"`  | Specifies the width of the InputField.                                                                                                                                            |
+| required             | `boolean`                          |           | If `true`, the label is displayed as required.                                                                                                                                    |
+| name                 | `string`                           |           | The name for the InputField.                                                                                                                                                      |
+| onBlur               | `event => void \| Promise`         |           | Function for handling onBlur event.                                                                                                                                               |
+| onChange             | `event => void \| Promise`         |           | Function for handling onChange event.                                                                                                                                             |
+| onFocus              | `event => void \| Promise`         |           | Function for handling onFocus event.                                                                                                                                              |
+| onKeyDown            | `event => void \| Promise`         |           | Function for handling onKeyDown event.                                                                                                                                            |
+| onKeyUp              | `event => void \| Promise`         |           | Function for handling onKeyUp event.                                                                                                                                              |
+| onMouseDown          | `event => void \| Promise`         |           | Function for handling onMouseDown event.                                                                                                                                          |
+| onMouseUp            | `event => void \| Promise`         |           | Function for handling onMouseUp event.                                                                                                                                            |
+| onSelect             | `event => void \| Promise`         |           | Function for handling onSelect event.                                                                                                                                             |
+| placeholder          | `string \| (() => string))`        |           | The placeholder of the InputField.                                                                                                                                                |
+| **prefix**           | `React.Node`                       |           | The prefix component for the InputField.                                                                                                                                          |
+| readOnly             | `boolean`                          | `false`   | If `true`, the InputField is readOnly.                                                                                                                                            |
+| ref                  | `func`                             |           | Prop for forwarded ref of the InputField. [See Functional specs](#functional-specs)                                                                                               |
+| spaceAfter           | `enum`                             |           | Additional `margin-bottom` after component.                                                                                                                                       |
+| suffix               | `React.Node`                       |           | The suffix component for the InputField.                                                                                                                                          |
+| tabIndex             | `string \| number`                 |           | Specifies the tab order of an element.                                                                                                                                            |
+| **type**             | [`enum`](#enum)                    | `"text"`  | The type of the InputField.                                                                                                                                                       |
+| value                | `string \| number`                 |           | Specifies the value of the InputField. To be used with controlled usage.                                                                                                          |
+| helpClosable         | `boolean`                          | `true`    | Whether to display help as a closable tooltip, or have it open only while the field is focused.                                                                                   |
+| list                 | `string`                           |           | The id of the datalist element.                                                                                                                                                   |
+| ariaAutocomplete     | `inline \| list \| both`           |           | The aria-autocomplete attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete).                      |
+| role                 | `textbox \| combobox \| searchbox` | `textbox` | The role attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role).                                             |
+| ariaActiveDescendant | `string`                           |           | The aria-activedescendant attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant).              |
+| ariaHasPopup         | `boolean`                          |           | The aria-haspopup attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup).                              |
+| ariaExpanded         | `boolean`                          |           | The aria-expanded attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded).                              |
+| ariaControls         | `string`                           |           | The aria-controls attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls).                              |
+| ariaLabel            | `string`                           |           | Optional prop for `aria-label` value. See `Accessibility` tab.                                                                                                                    |
 
 ### enum
 
@@ -82,16 +82,9 @@ The table below contains all types of props available in the InputField componen
 
 - The `error` prop overwrites the `help` prop, due to higher priority.
 
-- You can use `string` for currency InputField, or `React.Node` for InputField with icon.
+- The `help` and `error` icons overwrite the prefix when `inlineLabel` is `true`.
 
-- If you want to use `ButtonLink` as suffix for the `InputField`, use `transparent` prop for the `ButtonLink`, e.g.:
-
-```jsx
-<InputField
-  placeholder="My placeholder"
-  suffix={<ButtonLink transparent icon={<Visibility />} />}
-/>
-```
+### Examples
 
 - Usage of `Tag` in `InputField`
 
@@ -108,33 +101,3 @@ import Tag from "@kiwicom/orbit-components/lib/Tag";
   }
 />;
 ```
-
-- `ref` can be used for example auto-focus the elements immediately after render.
-
-```jsx
-class Component extends React.PureComponent<Props> {
-  componentDidMount() {
-    this.ref.current && this.ref.current.focus();
-  }
-
-  ref: { current: React.ElementRef<*> | null } = React.createRef();
-
-  render() {
-    return <InputField ref={this.ref} />;
-  }
-}
-```
-
-## Accessibility
-
-- For special cases you can use your own, detached `label`. Simply like this:
-
-```jsx
-<label for="NICEID">Content</label>
-<InputField
-  id="NICEID"
-/>
-```
-
-- The `ariaLabel` prop allows you to specify an `aria-label` attribute for the InputField component. This attribute provides additional information to screen readers, enhancing the accessibility of the component. By using `ariaLabel`, you can ensure that users who rely on assistive technologies receive the necessary context and information about the component's purpose and functionality.
-- If the `label` prop is not provided, the `ariaLabel` prop must be specified to ensure component accessibility.

--- a/packages/orbit-components/src/InputField/README.md
+++ b/packages/orbit-components/src/InputField/README.md
@@ -64,6 +64,7 @@ The table below contains all types of props available in the InputField componen
 | ariaExpanded         | `boolean`                          |           | The aria-expanded attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded).                              |
 | ariaControls         | `string`                           |           | The aria-controls attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls).                              |
 | ariaLabel            | `string`                           |           | Optional prop for `aria-label` value. See `Accessibility` tab.                                                                                                                    |
+| ariaLabelledby       | `string`                           |           | Optional prop for `aria-labelledby` value. See `Accessibility` tab.                                                                                                               |
 
 ### enum
 

--- a/packages/orbit-components/src/InputField/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/InputField/__tests__/index.test.tsx
@@ -107,7 +107,7 @@ describe("InputField", () => {
   it("should have passed width", () => {
     const width = "100px";
     render(<InputField width={width} label="label" />);
-    expect(document.querySelector("label")).toHaveStyle({ width });
+    expect(document.querySelector(".orbit-input-field-field")).toHaveStyle({ width });
   });
 
   describe("compact", () => {

--- a/packages/orbit-components/src/InputField/index.tsx
+++ b/packages/orbit-components/src/InputField/index.tsx
@@ -111,6 +111,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
     list,
     autoComplete,
     ariaLabel,
+    ariaLabelledby,
     ariaAutocomplete,
     ariaActiveDescendant,
     ariaHasPopup,
@@ -276,6 +277,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
           tabIndex={tabIndex !== undefined ? Number(tabIndex) : undefined}
           list={list}
           aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledby}
           aria-describedby={shown ? `${inputId}-feedback` : undefined}
           aria-invalid={error ? true : undefined}
           aria-autocomplete={ariaAutocomplete}

--- a/packages/orbit-components/src/InputField/index.tsx
+++ b/packages/orbit-components/src/InputField/index.tsx
@@ -43,7 +43,7 @@ export const FakeInput = ({ error, disabled }: Pick<Props, "error" | "disabled">
 );
 
 const Prefix = ({ children }: { children: React.ReactNode }) => (
-  <div
+  <span
     className={cx(
       "text-form-element-prefix-foreground",
       "ps-300 pointer-events-none z-[3] flex h-full items-center justify-center",
@@ -53,7 +53,7 @@ const Prefix = ({ children }: { children: React.ReactNode }) => (
     )}
   >
     {children}
-  </div>
+  </span>
 );
 
 const Suffix = ({
@@ -143,33 +143,32 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
 
   const shown = tooltipShown || tooltipShownHover;
   const fieldRef = React.useRef(null);
-  const Component = label ? "label" : "div";
 
   return (
-    <Component
+    <div
       className={cx(
         "orbit-input-field-field font-base relative block flex-1 basis-full",
         spaceAfter && spaceAfterClasses[spaceAfter],
       )}
-      style={{ width }}
       ref={fieldRef}
-      htmlFor={label ? inputId : undefined}
+      style={{ width }}
       onMouseEnter={() => (disabled && inlineLabel ? setTooltipShownHover(true) : undefined)}
       onMouseLeave={() => (disabled && inlineLabel ? setTooltipShownHover(false) : undefined)}
     >
-      {label && !inlineLabel && (
-        <FormLabel
-          inlineLabel={inlineLabel}
-          required={required}
-          error={!!error}
-          help={!!help}
-          labelRef={labelRef}
-          iconRef={iconRef}
-          onMouseEnter={() => setTooltipShownHover(true)}
-          onMouseLeave={() => setTooltipShownHover(false)}
-        >
-          {label}
-        </FormLabel>
+      {!inlineLabel && label && (
+        <label className="block" ref={fieldRef} htmlFor={inputId}>
+          <FormLabel
+            required={required}
+            error={!!error}
+            help={!!help}
+            labelRef={labelRef}
+            iconRef={iconRef}
+            onMouseEnter={() => setTooltipShownHover(true)}
+            onMouseLeave={() => setTooltipShownHover(false)}
+          >
+            {label}
+          </FormLabel>
+        </label>
       )}
       <div
         className={cx(
@@ -182,41 +181,47 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             ? "text-form-element-disabled-foreground"
             : "text-form-element-filled-foreground",
         )}
-        ref={label ? null : labelRef}
       >
-        {inlineLabel && !tags && (error || help) ? (
-          <Prefix>
-            {help && !error && (
-              <div className="flex" ref={iconRef}>
-                <InformationCircle color="info" size="small" />
-              </div>
-            )}
-            {error && (
-              <div className="flex" ref={iconRef}>
-                <AlertCircle color="critical" size="small" />
-              </div>
-            )}
-          </Prefix>
-        ) : (
-          prefix && <Prefix>{prefix}</Prefix>
-        )}
-        {label && inlineLabel && (
-          <div
-            className={cx(
-              "flex items-center justify-center",
-              "pointer-events-none h-full",
-              "[&>.orbit-form-label]:mb-0",
-              "[&>.orbit-form-label]:text-form-element-normal [&>.orbit-form-label]:whitespace-nowrap [&>.orbit-form-label]:leading-normal",
-              "[&>.orbit-form-label]:z-[3]",
-              !tags && (error || help) ? "ps-100" : "ps-300",
-            )}
-            ref={labelRef}
-          >
-            <FormLabel required={required} error={!!error} help={!!help} inlineLabel={inlineLabel}>
-              {label}
-            </FormLabel>
-          </div>
-        )}
+        <label className="relative z-[2] flex items-center" ref={fieldRef} htmlFor={inputId}>
+          {inlineLabel && !tags && (error || help) ? (
+            <Prefix>
+              {help && !error && (
+                <span className="flex" ref={iconRef}>
+                  <InformationCircle color="info" size="small" />
+                </span>
+              )}
+              {error && (
+                <span className="flex" ref={iconRef}>
+                  <AlertCircle color="critical" size="small" />
+                </span>
+              )}
+            </Prefix>
+          ) : (
+            prefix && <Prefix>{prefix}</Prefix>
+          )}
+          {label && inlineLabel && (
+            <span
+              className={cx(
+                "flex items-center justify-center",
+                "pointer-events-none h-full",
+                "[&>.orbit-form-label]:mb-0",
+                "[&>.orbit-form-label]:text-form-element-normal [&>.orbit-form-label]:whitespace-nowrap [&>.orbit-form-label]:leading-normal",
+                "[&>.orbit-form-label]:z-[3]",
+                !tags && (error || help) ? "ps-100" : "ps-300",
+              )}
+            >
+              <FormLabel
+                required={required}
+                error={!!error}
+                help={!!help}
+                labelRef={labelRef}
+                inlineLabel
+              >
+                {label}
+              </FormLabel>
+            </span>
+          )}
+        </label>
         {tags && <InputTags>{tags}</InputTags>}
         {/* the rule is working weird, it passes only if the value is number, eg not even prop including number } */}
         {/* eslint-disable-next-line jsx-a11y/aria-activedescendant-has-tabindex */}
@@ -304,7 +309,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
           referenceElement={inlineLabel && !tags ? iconRef : fieldRef}
         />
       )}
-    </Component>
+    </div>
   );
 });
 

--- a/packages/orbit-components/src/InputField/types.d.ts
+++ b/packages/orbit-components/src/InputField/types.d.ts
@@ -51,6 +51,7 @@ export interface Props extends Common.Globals, Common.SpaceAfter, Common.DataAtt
   readonly onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
   readonly onKeyUp?: React.KeyboardEventHandler<HTMLInputElement>;
   readonly ariaLabel?: string;
+  readonly ariaLabelledby?: string;
   readonly ariaAutocomplete?: AriaAutoComplete;
   readonly ariaActiveDescendant?: string;
   readonly ariaHasPopup?: boolean;


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2248 

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces accessibility improvements for the `InputField` component, including the addition of `ariaLabelledby` prop and enhancements to the documentation regarding accessibility usage.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Screen Reader
    participant InputField
    participant Label
    participant ARIA

    User->>InputField: Interacts with input field
    
    alt Using Custom Label
        InputField->>Label: Connect using "for" attribute
        Label-->>Screen Reader: Announce label content
    end

    alt Using Built-in Label
        InputField->>ARIA: Set aria-label
        InputField->>ARIA: Set aria-labelledby
        ARIA-->>Screen Reader: Announce accessibility info
    end

    alt Using Suffix Button
        InputField->>ARIA: Add "Show text" aria-label
        ARIA-->>Screen Reader: Announce button purpose
    end

    Screen Reader-->>User: Provide accessible feedback
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4632/files#diff-2ad882504eac28fad21af9efb45f5506c134a3935b808531913e8f53914b7e09>docs/src/documentation/03-components/05-input/inputfield/03-accessibility.mdx</a></td><td>Added documentation for accessibility features of the InputField component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4632/files#diff-f2e9ecbe159fd887322916e9effec729d5358b645acabee377812acd394dc5da>packages/orbit-components/src/InputField/InputField.stories.tsx</a></td><td>Updated stories to include accessibility attributes for ButtonLink suffix.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4632/files#diff-b12bab43f299d4badaa7cc5aec122e2ea2ff4bd7302a9fa076c76b9ff89d0b06>packages/orbit-components/src/InputField/README.md</a></td><td>Updated the README to include new accessibility props and examples.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4632/files#diff-9fd267e09e00216cdee3fca9728eb90b5d44deccfe052972b5fe27e196af689b>packages/orbit-components/src/InputField/__tests__/index.test.tsx</a></td><td>Updated tests to check for correct width application.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4632/files#diff-a22047902ec5dad314f04706476107ebd04df90a6577b33c7fdf40c9887e6355>packages/orbit-components/src/InputField/index.tsx</a></td><td>Modified InputField component to support new accessibility props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4632/files#diff-3e385564e61dd8d7efdbcee542dd8b992a2c37ab1b2dfab626a6e522cfa6567a>packages/orbit-components/src/InputField/types.d.ts</a></td><td>Added <code>ariaLabelledby</code> prop to the InputField props type definition.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->
























