### PR TITLE
Toast accessibility

### DIFF
--- a/packages/orbit-components/src/Toast/README.md
+++ b/packages/orbit-components/src/Toast/README.md
@@ -6,15 +6,21 @@ The Toast component consists of `ToastRoot` and `createToast`/`createToastPromis
 import { ToastRoot, createToast } from "@kiwicom/orbit-components/lib/Toast";
 ```
 
-It's better to use ToastRoot once at the root of your application with your other context providers and you can use `createToast` from anywhere after. The `createToast` function accepts two arguments. The first is required and is the message to be displayed on the toast. The second is an object with an `icon` key that receives the icon to be rendered on the toast.
+It's better to use ToastRoot once at the root of your application with your other context providers and you can use `createToast` from anywhere after. The `createToast` function accepts two arguments. The first is required and is the message to be displayed on the toast. The second is an object. This object contains the `icon` key that receives the icon to be rendered on the toast as well as the `ariaProps` key that receives another object, with the `role` and `aria-live` keys and corresponding attributes as values.
 
 ```jsx
 import React from "react";
 import { ToastRoot, createToast } from "@kiwicom/orbit-components/lib/Toast";
 import Notification from "@kiwicom/orbit-components/lib/icons/Notification";
 
-const notify = () => createToast("Here is your toast", { icon: <Notification /> });
-
+const notify = () =>
+  createToast("Here is your toast", {
+    icon: <Notification />,
+    ariaProps: {
+      role: "alert",
+      "aria-live": "assertive",
+    },
+  });
 const App = () => {
   return (
     <div>

--- a/packages/orbit-components/src/Toast/Toast.stories.tsx
+++ b/packages/orbit-components/src/Toast/Toast.stories.tsx
@@ -30,7 +30,14 @@ type Story = StoryObj<ToastPropsAndCustomArgs>;
 
 export const Default: Story = {
   render: ({ message }) => {
-    const toast = () => createToast(message, { icon: <Notification /> });
+    const toast = () =>
+      createToast(message, {
+        icon: <Notification />,
+        ariaProps: {
+          role: "alert",
+          "aria-live": "assertive",
+        },
+      });
 
     return (
       <>

--- a/packages/orbit-components/src/Toast/ToastMessage.tsx
+++ b/packages/orbit-components/src/Toast/ToastMessage.tsx
@@ -27,6 +27,7 @@ const ToastMessage = ({
   children,
   offset,
   ariaLive,
+  role,
 }: Props) => {
   const theme = useTheme();
   const ref = React.useRef(null);
@@ -41,7 +42,7 @@ const ToastMessage = ({
   return (
     <div
       aria-live={ariaLive}
-      role="status"
+      role={role}
       className={cx(
         "z-onTop duration-normal absolute inset-x-0 flex cursor-grab transition-all ease-in-out will-change-transform",
         "translate-x-[var(--toast-message-offset-x)] translate-y-[var(--toast-message-offset-y)] opacity-[var(--toast-message-opacity)]",

--- a/packages/orbit-components/src/Toast/ToastRoot.tsx
+++ b/packages/orbit-components/src/Toast/ToastRoot.tsx
@@ -61,6 +61,7 @@ const ToastRoot = ({
             placement={placement}
             onDismiss={notify.dismiss}
             ariaLive={ariaProps["aria-live"]}
+            role={ariaProps.role}
           >
             {message as React.ReactNode}
           </ToastMessage>

--- a/packages/orbit-components/src/Toast/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Toast/__tests__/index.test.tsx
@@ -35,6 +35,7 @@ describe("Toast", () => {
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         ariaLive="polite"
+        role="status"
         visible
         onDismiss={onDismiss}
         placement="bottom-center"

--- a/packages/orbit-components/src/Toast/types.d.ts
+++ b/packages/orbit-components/src/Toast/types.d.ts
@@ -41,6 +41,7 @@ interface ToastProps {
   readonly placement: Placement;
   readonly offset?: number;
   readonly ariaLive: "polite" | "assertive" | "off";
+  readonly role: "status" | "alert";
 }
 
 export interface Options<T> {
@@ -49,14 +50,17 @@ export interface Options<T> {
   readonly error: ValueOrFunction<Renderable, any>;
 }
 
-export type IconType = Pick<DefaultToastOptions, "icon">;
+export type ToastOptions = Pick<DefaultToastOptions, "icon" | "ariaProps">;
 
-export type createToast = (message: ValueOrFunction<Renderable, Toast>, options?: IconType) => void;
+export type createToast = (
+  message: ValueOrFunction<Renderable, Toast>,
+  options?: ToastOptions,
+) => void;
 
 export type createToastPromise = <T>(
   promise: Promise<T>,
   messages: Options<T>,
-  options?: IconType & Partial<Record<ToastType, IconType>>,
+  options?: ToastOptions & Partial<Record<ToastType, ToastOptions>>,
 ) => Promise<T>;
 
 export { ToastProps as Toast };


### PR DESCRIPTION
The `createToast` function now accepts `ariaProps` as part of the `options` argument object.

This allows for better accessibility configuration on the toasts displayed.

The accessibility documentation will be done on a separate task.

FEPLT-2310

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR enhances the `createToast` function to accept `ariaProps` for improved accessibility, allowing configuration of ARIA attributes for toast notifications.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant App
    participant createToast
    participant ToastRoot
    participant ToastMessage

    App->>ToastRoot: Initialize with ToastRoot
    Note over App: Application wants to show toast
    App->>createToast: createToast(message, options)
    Note over createToast: Options include:<br/>- icon<br/>- ariaProps (role, aria-live)
    createToast->>ToastRoot: Trigger toast display
    ToastRoot->>ToastMessage: Render with:<br/>- message<br/>- icon<br/>- role (status/alert)<br/>- aria-live (polite/assertive)
    ToastMessage-->>App: Display toast notification

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4638/files#diff-4b786588fe54bd442ee9aca0550d90c72d2df154ad7084214cd2907a66fcb004>packages/orbit-components/src/Toast/README.md</a></td><td>Updated documentation to include <code>ariaProps</code> in the <code>createToast</code> function options.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4638/files#diff-d185cb9f16142057c648512b47016ea3737d58d9efd58bea84f04e15126b4c45>packages/orbit-components/src/Toast/Toast.stories.tsx</a></td><td>Modified the toast creation in stories to include <code>ariaProps</code>.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4638/files#diff-7159ca47640f9f56a1c5cead5e4ad3c6e573a6a2c2d0fe0fb32c8aab8f19e836>packages/orbit-components/src/Toast/ToastMessage.tsx</a></td><td>Updated <code>ToastMessage</code> component to accept <code>role</code> as a prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4638/files#diff-76b9a56bdf07f544ac025acd828163df8d8f69a8cdcafcbedb1269ea76b64062>packages/orbit-components/src/Toast/ToastRoot.tsx</a></td><td>Passed <code>role</code> from <code>ariaProps</code> to <code>ToastMessage</code>.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4638/files#diff-0064a8f579a5615cd6b56855f438304d2c05d16267b1db22753a835a90272227>packages/orbit-components/src/Toast/__tests__/index.test.tsx</a></td><td>Updated test to include <code>role</code> in the toast component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4638/files#diff-7e4f78a25e51ab3ae8b04a1d93dfaf670d93e8659ef011b7ce9b1a1a5608bba5>packages/orbit-components/src/Toast/types.d.ts</a></td><td>Updated type definitions to include <code>role</code> in <code>ToastProps</code> and <code>Options</code>.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




