### PR TITLE
Collapse Accessibility

### DIFF
--- a/docs/src/__examples__/Collapse/DEFAULT.tsx
+++ b/docs/src/__examples__/Collapse/DEFAULT.tsx
@@ -4,7 +4,11 @@ import { Collapse, OrbitProvider, Text, TextLink, defaultTheme } from "@kiwicom/
 export default {
   Example: () => (
     <OrbitProvider theme={defaultTheme} useId={React.useId}>
-      <Collapse label="Principle for collapses">
+      <Collapse
+        label="Principle for collapses"
+        expandButtonLabel="Expand"
+        collapseButtonLabel="Collapse"
+      >
         <Text>
           Collapse components help with{" "}
           <TextLink external href="https://orbit.kiwi/guides/progressive-disclosure/">

--- a/docs/src/components/DocLayout/index.tsx
+++ b/docs/src/components/DocLayout/index.tsx
@@ -179,7 +179,11 @@ export default function DocLayout({
                       {tocHasItems && (
                         <StyledMobileTocWrapper>
                           <Hide on={["tablet", "desktop", "largeDesktop"]}>
-                            <Collapse label="Table of contents">
+                            <Collapse
+                              label="Table of contents"
+                              expandButtonLabel="Expand"
+                              collapseButtonLabel="Collapse"
+                            >
                               <TableOfContents />
                             </Collapse>
                           </Hide>

--- a/docs/src/components/DocNavigation/Collapse.tsx
+++ b/docs/src/components/DocNavigation/Collapse.tsx
@@ -16,8 +16,10 @@ export default function Collapse({ expanded, label, hasCategories, children, onC
     <StyledCollapseWrapper>
       <OrbitCollapse
         expanded={expanded}
-        label={<StyledCollapseLabel>{label}</StyledCollapseLabel>}
+        customLabel={<StyledCollapseLabel>{label}</StyledCollapseLabel>}
         onClick={onClick}
+        expandButtonLabel="Expand"
+        collapseButtonLabel="Collapse"
       >
         <StyledCollapseContent hasCategories={hasCategories}>{children}</StyledCollapseContent>
       </OrbitCollapse>

--- a/docs/src/components/DocNavigation/DocNavigationItem.tsx
+++ b/docs/src/components/DocNavigation/DocNavigationItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Stack, Badge } from "@kiwicom/orbit-components";
+import { Stack, Badge, Heading } from "@kiwicom/orbit-components";
 import useTheme from "@kiwicom/orbit-components/lib/hooks/useTheme";
 
 import Category from "./Category";
@@ -48,7 +48,7 @@ export default function DocNavigationItem({ devMode, currentUrl, level, item, on
       <Badge type={getBadgeType(item.status)}>{item.status.toUpperCase()}</Badge>
     </Stack>
   ) : (
-    item.name
+    <Heading type="title4">{item.name}</Heading>
   );
 
   React.useEffect(() => {
@@ -80,10 +80,12 @@ export default function DocNavigationItem({ devMode, currentUrl, level, item, on
     if (level === 1) {
       return (
         <Collapse
-          label={itemName}
+          customLabel={itemName}
           expanded={expanded}
           hasCategories={hasCategories}
           onClick={() => setExpanded(prev => !prev)}
+          expandButtonLabel="Expand"
+          collapseButtonLabel="Collapse"
         >
           {navigationItems}
         </Collapse>

--- a/docs/src/documentation/05-development/04-migration-guides/01-v21.mdx
+++ b/docs/src/documentation/05-development/04-migration-guides/01-v21.mdx
@@ -44,6 +44,12 @@ It used to accept a React node for translations, but this could lead to some une
 
 This change also allows for the `aria-label` attribute to have the same value as the `title` prop, if `ariaLabel` is not provided.
 
+### Label prop in Collapse component
+
+The `label` prop in the `Collapse` component now only accepts a string.
+
+It used to accept a React node for translations, but this could lead to some unexpected or wrong HTML structure.
+
 ### Required prop in Alert component when is `closable`
 
 The `Alert` component now requires the prop `labelClose` when `closable` is `true`.
@@ -79,6 +85,46 @@ intl.formatMessage({
 ```
 
 Feel free to customize the translations according to your needs, by eventually providing more context to the alert it refers to.
+
+### Required props in Collapse component
+
+The `Collapse` component now requires the props `expandButtonLabel` and `collapseButtonLabel`.
+
+They are used to provide accessible labels to the button that toggles the collapse state.
+
+**Before:**
+
+```jsx
+<Collapse label="Collapse">
+  <Text>Collapse content</Text>
+</Collapse>
+```
+
+**After:**
+
+```jsx
+<Collapse label="Collapse" expandButtonLabel="Expand" collapseButtonLabel="Collapse">
+  <Text>Collapse content</Text>
+</Collapse>
+```
+
+Make sure to provide translated strings for the `expandButtonLabel` and `collapseButtonLabel` props.
+
+To ease the migration, we provide a codemod to help you out, with some default generic translations.
+The codemod will inject `intl.formatMessage` calls with the default translations, in this case:
+
+```jsx
+intl.formatMessage({
+  id: "orbit.collapse_expand",
+  defaultMessage: "Expand",
+});
+intl.formatMessage({
+  id: "orbit.collapse_collapse",
+  defaultMessage: "Collapse",
+});
+```
+
+Feel free to customize the translations according to your needs, by eventually providing more context.
 
 ## Codemod
 

--- a/packages/orbit-components/playroom/snippets/BasicComponents.ts
+++ b/packages/orbit-components/playroom/snippets/BasicComponents.ts
@@ -42,7 +42,7 @@ const choiceGroup = `
   <Radio label="Option three" value="three" />
 </ChoiceGroup>`;
 
-const collapse = `<Collapse label="Title"><Text>Collapsed content</Text></Collapse>`;
+const collapse = `<Collapse label="Title" expandButtonLabel="Expand" collapseButtonLabel="Collapse"><Text>Collapsed content</Text></Collapse>`;
 
 const coupon = `<Coupon>CODE</Coupon>`;
 

--- a/packages/orbit-components/playroom/snippets/Layouts.ts
+++ b/packages/orbit-components/playroom/snippets/Layouts.ts
@@ -18,7 +18,7 @@ const calloutBanner = `
 
 const drawer = `
 <Drawer title="Drawer title" position="right" width="320px">
-  <Collapse label="Links list" initialExpanded>
+  <Collapse label="Links list" initialExpanded expandButtonLabel="Expand" collapseButtonLabel="Collapse">
     <LinkList indent>
       <TextLink type="secondary">
         Link 1

--- a/packages/orbit-components/src/ChoiceGroup/index.tsx
+++ b/packages/orbit-components/src/ChoiceGroup/index.tsx
@@ -74,7 +74,7 @@ const ChoiceGroup = React.forwardRef<HTMLDivElement, Props>(
         ref={ref}
         data-test={dataTest}
         role="group"
-        aria-labelledby={groupID}
+        aria-labelledby={label ? groupID : undefined}
         id={id}
         className={cx(
           "flex w-full flex-col",

--- a/packages/orbit-components/src/Collapse/Collapse.ct-story.tsx
+++ b/packages/orbit-components/src/Collapse/Collapse.ct-story.tsx
@@ -16,10 +16,17 @@ export default function CollapseStory() {
             Action
           </TextLink>
         }
+        expandButtonLabel="Expand"
+        collapseButtonLabel="Collapse"
       >
         <p>Collapsed content</p>
       </Collapse>
-      <Collapse label="Expanded" initialExpanded>
+      <Collapse
+        label="Expanded"
+        initialExpanded
+        expandButtonLabel="Expand"
+        collapseButtonLabel="Collapse"
+      >
         <p>Expanded content</p>
       </Collapse>
     </>

--- a/packages/orbit-components/src/Collapse/Collapse.stories.tsx
+++ b/packages/orbit-components/src/Collapse/Collapse.stories.tsx
@@ -22,6 +22,8 @@ const meta: Meta<typeof Collapse> = {
     customLabel: "",
     expanded: false,
     initialExpanded: false,
+    expandButtonLabel: "Expand",
+    collapseButtonLabel: "Collapse",
   },
 
   parameters: {
@@ -35,6 +37,7 @@ type Story = StoryObj<typeof Collapse>;
 const SliderHistogramData = () => (
   <Slider
     label="Max travel time"
+    ariaLabel={["Adjust min", "Adjust max"]}
     valueDescription="00:00 - 24:00"
     defaultValue={[1, 12]}
     histogramData={[
@@ -53,7 +56,12 @@ export const Default: Story = {
     };
 
     return (
-      <Collapse {...args} onClick={onClick}>
+      <Collapse
+        {...args}
+        onClick={onClick}
+        expandButtonLabel="Expand"
+        collapseButtonLabel="Collapse"
+      >
         <SliderHistogramData />
       </Collapse>
     );
@@ -61,7 +69,7 @@ export const Default: Story = {
 
   parameters: {
     controls: {
-      exclude: ["customLabel"],
+      exclude: ["customLabel", "expandButtonLabel", "collapseButtonLabel"],
     },
   },
 };
@@ -77,6 +85,8 @@ export const WithCustomLabel: Story = {
           <Badge>Custom label </Badge>
         </Stack>
       }
+      expandButtonLabel="Expand"
+      collapseButtonLabel="Collapse"
     >
       <SliderHistogramData />
     </Collapse>
@@ -97,7 +107,12 @@ export const OpenedByDefault: Story = {
     };
 
     return (
-      <Collapse {...args} onClick={onClick}>
+      <Collapse
+        {...args}
+        onClick={onClick}
+        expandButtonLabel="Expand"
+        collapseButtonLabel="Collapse"
+      >
         <SliderHistogramData />
       </Collapse>
     );
@@ -125,12 +140,10 @@ export const WithActions: Story = {
             Clear
           </TextLink>
         }
+        expandButtonLabel="Expand"
+        collapseButtonLabel="Collapse"
       >
-        <ChoiceGroup
-          filter
-          onChange={action("onChange")}
-          onOnlySelection={action("onOnlySelection")}
-        >
+        <ChoiceGroup onChange={action("onChange")} onOnlySelection={action("onOnlySelection")}>
           <Checkbox label="Flight" value="one" />
           <Checkbox label="Bus" value="two" />
           <Checkbox label="Train" value="three" />
@@ -148,34 +161,22 @@ export const MultipleCollapses: Story = {
   render: args => {
     return (
       <Stack spacing="none">
-        <Collapse {...args}>
-          <ChoiceGroup
-            filter
-            onChange={action("onChange")}
-            onOnlySelection={action("onOnlySelection")}
-          >
+        <Collapse {...args} expandButtonLabel="Expand" collapseButtonLabel="Collapse">
+          <ChoiceGroup onChange={action("onChange")} onOnlySelection={action("onOnlySelection")}>
             <Checkbox label="Flight" value="one" />
             <Checkbox label="Bus" value="two" />
             <Checkbox label="Train" value="three" />
           </ChoiceGroup>
         </Collapse>
-        <Collapse {...args}>
-          <ChoiceGroup
-            filter
-            onChange={action("onChange")}
-            onOnlySelection={action("onOnlySelection")}
-          >
+        <Collapse {...args} expandButtonLabel="Expand" collapseButtonLabel="Collapse">
+          <ChoiceGroup onChange={action("onChange")} onOnlySelection={action("onOnlySelection")}>
             <Checkbox label="Flight" value="one" />
             <Checkbox label="Bus" value="two" />
             <Checkbox label="Train" value="three" />
           </ChoiceGroup>
         </Collapse>
-        <Collapse {...args}>
-          <ChoiceGroup
-            filter
-            onChange={action("onChange")}
-            onOnlySelection={action("onOnlySelection")}
-          >
+        <Collapse {...args} expandButtonLabel="Expand" collapseButtonLabel="Collapse">
+          <ChoiceGroup onChange={action("onChange")} onOnlySelection={action("onOnlySelection")}>
             <Checkbox label="Flight" value="one" />
             <Checkbox label="Bus" value="two" />
             <Checkbox label="Train" value="three" />
@@ -187,7 +188,7 @@ export const MultipleCollapses: Story = {
 
   parameters: {
     controls: {
-      exclude: ["expanded", "initialExpanded"],
+      exclude: ["expanded", "initialExpanded", "expandButtonLabel", "collapseButtonLabel"],
     },
   },
 
@@ -199,7 +200,12 @@ export const MultipleCollapses: Story = {
 
 export const Uncontrolled: Story = {
   render: args => (
-    <Collapse {...args} onClick={action("onClick")}>
+    <Collapse
+      {...args}
+      onClick={action("onClick")}
+      expandButtonLabel="Expand"
+      collapseButtonLabel="Collapse"
+    >
       <Slider
         label="Max travel time"
         valueDescription="00:00 - 24:00"
@@ -216,7 +222,7 @@ export const Uncontrolled: Story = {
 
   parameters: {
     controls: {
-      exclude: "expanded",
+      exclude: ["expanded", "expandButtonLabel", "collapseButtonLabel"],
     },
   },
 };
@@ -238,12 +244,10 @@ export const Rtl: Story = {
               Clear
             </TextLink>
           }
+          expandButtonLabel="Expand"
+          collapseButtonLabel="Collapse"
         >
-          <ChoiceGroup
-            filter
-            onChange={action("onChange")}
-            onOnlySelection={action("onOnlySelection")}
-          >
+          <ChoiceGroup onChange={action("onChange")} onOnlySelection={action("onOnlySelection")}>
             <Checkbox label="Flight" value="one" />
             <Checkbox label="Bus" value="two" />
             <Checkbox label="Train" value="three" />
@@ -266,7 +270,12 @@ export const Playground: Story = {
     };
 
     return (
-      <Collapse {...args} onClick={onClick}>
+      <Collapse
+        {...args}
+        onClick={onClick}
+        expandButtonLabel="Expand"
+        collapseButtonLabel="Collapse"
+      >
         <SliderHistogramData />
       </Collapse>
     );

--- a/packages/orbit-components/src/Collapse/README.md
+++ b/packages/orbit-components/src/Collapse/README.md
@@ -18,16 +18,16 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the Collapse component.
 
-| Name                | Type                                | Default | Description                                                                                                                                |
-| :------------------ | :---------------------------------- | :------ | :----------------------------------------------------------------------------------------------------------------------------------------- |
-| actions             | `React.Node`                        |         | Actions which will be render next to arrow.                                                                                                |
-| **children**        | `React.Node`                        |         | The children that should be collapsed.                                                                                                     |
-| id                  | `string`                            |         | Set `id` for `Collapse`.                                                                                                                   |
-| dataTest            | `string`                            |         | Optional prop for testing purposes.                                                                                                        |
-| expanded            | `boolean`                           |         | If you pass either `true` or `false` the Collapse component will controlled component and you will have to manage the state via `onClick`. |
-| initialExpanded     | `boolean`                           | `false` | If `true` the Collapse component will be expanded on the initial render.                                                                   |
-| **label**           | `Translation`                       |         | The rendered label of the Collapse.                                                                                                        |
-| **customLabel**     | `React.Node`                        |         | The rendered custom label of the Collapse.                                                                                                 |
-| onClick             | `(event, state) => void \| Promise` |         | Callback for handling onClick event.                                                                                                       |
-| expandButtonLabel   | `string`                            |         | The accessible label of the button when the content is collapsed.                                                                          |
-| collapseButtonLabel | `string`                            |         | The accessible label of the button when the content is expanded.                                                                           |
+| Name                | Type                                | Default | Description                                                                                                             |
+| :------------------ | :---------------------------------- | :------ | :---------------------------------------------------------------------------------------------------------------------- |
+| actions             | `React.Node`                        |         | Actions which will be render next to arrow.                                                                             |
+| **children**        | `React.Node`                        |         | The children that should be collapsed.                                                                                  |
+| id                  | `string`                            |         | Set `id` for `Collapse`.                                                                                                |
+| dataTest            | `string`                            |         | Optional prop for testing purposes.                                                                                     |
+| expanded            | `boolean`                           |         | Passing `true` or `false` makes Collapse a controlled component, requiring you to manage its state via `onClick`.       |
+| initialExpanded     | `boolean`                           | `false` | If `true` the Collapse component will be expanded on the initial render. To be used when the component is uncontrolled. |
+| label               | `string`                            |         | The rendered label of the Collapse.                                                                                     |
+| customLabel         | `React.Node`                        |         | Allows for rendering any component as a label.                                                                          |
+| onClick             | `(event, state) => void \| Promise` |         | Callback for handling onClick event.                                                                                    |
+| expandButtonLabel   | `string`                            |         | The accessible label of the button when the content is collapsed.                                                       |
+| collapseButtonLabel | `string`                            |         | The accessible label of the button when the content is expanded.                                                        |

--- a/packages/orbit-components/src/Collapse/README.md
+++ b/packages/orbit-components/src/Collapse/README.md
@@ -18,14 +18,16 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the Collapse component.
 
-| Name            | Type                                | Default | Description                                                                                                                                |
-| :-------------- | :---------------------------------- | :------ | :----------------------------------------------------------------------------------------------------------------------------------------- |
-| actions         | `React.Node`                        |         | Actions which will be render next to arrow.                                                                                                |
-| **children**    | `React.Node`                        |         | The children that should be collapsed.                                                                                                     |
-| id              | `string`                            |         | Set `id` for `Collapse`                                                                                                                    |
-| dataTest        | `string`                            |         | Optional prop for testing purposes.                                                                                                        |
-| expanded        | `boolean`                           |         | If you pass either `true` or `false` the Collapse component will controlled component and you will have to manage the state via `onClick`. |
-| initialExpanded | `boolean`                           | `false` | If `true` the Collapse component will be expanded on the initial render.                                                                   |
-| **label**       | `Translation`                       |         | The rendered label of the Collapse.                                                                                                        |
-| **customLabel** | `React.Node`                        |         | The rendered custom label of the Collapse.                                                                                                 |
-| onClick         | `(event, state) => void \| Promise` |         | Callback for handling onClick event.                                                                                                       |
+| Name                | Type                                | Default | Description                                                                                                                                |
+| :------------------ | :---------------------------------- | :------ | :----------------------------------------------------------------------------------------------------------------------------------------- |
+| actions             | `React.Node`                        |         | Actions which will be render next to arrow.                                                                                                |
+| **children**        | `React.Node`                        |         | The children that should be collapsed.                                                                                                     |
+| id                  | `string`                            |         | Set `id` for `Collapse`.                                                                                                                   |
+| dataTest            | `string`                            |         | Optional prop for testing purposes.                                                                                                        |
+| expanded            | `boolean`                           |         | If you pass either `true` or `false` the Collapse component will controlled component and you will have to manage the state via `onClick`. |
+| initialExpanded     | `boolean`                           | `false` | If `true` the Collapse component will be expanded on the initial render.                                                                   |
+| **label**           | `Translation`                       |         | The rendered label of the Collapse.                                                                                                        |
+| **customLabel**     | `React.Node`                        |         | The rendered custom label of the Collapse.                                                                                                 |
+| onClick             | `(event, state) => void \| Promise` |         | Callback for handling onClick event.                                                                                                       |
+| expandButtonLabel   | `string`                            |         | The accessible label of the button when the content is collapsed.                                                                          |
+| collapseButtonLabel | `string`                            |         | The accessible label of the button when the content is expanded.                                                                           |

--- a/packages/orbit-components/src/Collapse/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Collapse/__tests__/index.test.tsx
@@ -22,6 +22,16 @@ describe("Collapse", () => {
     );
     expect(screen.getByTestId("test")).toBeInTheDocument();
     expect(screen.getByText("Collapse")).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+  });
+
+  it("should not render a div with role button if label is not provided", () => {
+    render(
+      <Collapse expandButtonLabel="Expand" collapseButtonLabel="Collapse">
+        <div>children</div>
+      </Collapse>,
+    );
+    expect(screen.getAllByRole("button")).toHaveLength(1);
   });
 
   it("should have customLabel", () => {
@@ -39,7 +49,7 @@ describe("Collapse", () => {
       const onClick = jest.fn();
       render(
         <Collapse
-          label="Collapse"
+          label="Label"
           onClick={onClick}
           expandButtonLabel="Expand"
           collapseButtonLabel="Collapse"
@@ -50,8 +60,8 @@ describe("Collapse", () => {
 
       const toggleButton =
         triggerButton === "label"
-          ? screen.getByText("Collapse")
-          : screen.getByRole("button", { expanded: false });
+          ? screen.getByText("Label")
+          : screen.getByRole("button", { name: "Expand" });
 
       await user.click(toggleButton);
       expect(onClick).toHaveBeenCalled();

--- a/packages/orbit-components/src/Collapse/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Collapse/__tests__/index.test.tsx
@@ -11,7 +11,12 @@ describe("Collapse", () => {
 
   it("should have expected parts of DOM output", () => {
     render(
-      <Collapse dataTest="test" label="Collapse">
+      <Collapse
+        dataTest="test"
+        label="Collapse"
+        expandButtonLabel="Expand"
+        collapseButtonLabel="Collapse"
+      >
         <div>children</div>
       </Collapse>,
     );
@@ -21,7 +26,7 @@ describe("Collapse", () => {
 
   it("should have customLabel", () => {
     render(
-      <Collapse customLabel="customLabel">
+      <Collapse customLabel="customLabel" expandButtonLabel="Expand" collapseButtonLabel="Collapse">
         <div>children</div>
       </Collapse>,
     );
@@ -33,7 +38,12 @@ describe("Collapse", () => {
     async triggerButton => {
       const onClick = jest.fn();
       render(
-        <Collapse label="Collapse" onClick={onClick}>
+        <Collapse
+          label="Collapse"
+          onClick={onClick}
+          expandButtonLabel="Expand"
+          collapseButtonLabel="Collapse"
+        >
           <div>children</div>
         </Collapse>,
       );
@@ -51,7 +61,7 @@ describe("Collapse", () => {
   describe("uncontrolled", () => {
     it("should expand/collapse when clicking on button", async () => {
       render(
-        <Collapse label="Collapse">
+        <Collapse label="Collapse" expandButtonLabel="Expand" collapseButtonLabel="Collapse">
           <article>children</article>
         </Collapse>,
       );
@@ -69,13 +79,23 @@ describe("Collapse", () => {
   describe("controlled", () => {
     it("should expand/collapse with prop", () => {
       const { rerender } = render(
-        <Collapse label="Collapse" expanded={false}>
+        <Collapse
+          label="Collapse"
+          expanded={false}
+          expandButtonLabel="Expand"
+          collapseButtonLabel="Collapse"
+        >
           <article>children</article>
         </Collapse>,
       );
       expect(screen.queryByRole("article")).not.toBeInTheDocument();
       rerender(
-        <Collapse label="Collapse" expanded>
+        <Collapse
+          label="Collapse"
+          expanded
+          expandButtonLabel="Expand"
+          collapseButtonLabel="Collapse"
+        >
           <article>children</article>
         </Collapse>,
       );

--- a/packages/orbit-components/src/Collapse/index.tsx
+++ b/packages/orbit-components/src/Collapse/index.tsx
@@ -68,25 +68,29 @@ const Collapse = ({
       id={id}
     >
       <div className="flex items-center justify-between">
-        <div
-          className="flex w-full self-stretch"
-          id={labelID}
-          role="button"
-          tabIndex={0}
-          aria-expanded={expanded}
-          aria-controls={slideID}
-          onClick={handleClick}
-          onKeyDown={e => {
-            if (e.key === "Enter" || e.key === " ") {
-              handleClick(e);
-            }
-          }}
-        >
-          <Stack justify="between" align="center">
-            {label && !customLabel && <Heading type="title4">{label}</Heading>}
-            {customLabel}
-          </Stack>
-        </div>
+        {label || customLabel ? (
+          <div
+            className="flex w-full self-stretch"
+            id={labelID}
+            role="button"
+            tabIndex={0}
+            aria-expanded={expanded}
+            aria-controls={slideID}
+            onClick={handleClick}
+            onKeyDown={e => {
+              if (e.key === "Enter" || e.key === " ") {
+                handleClick(e);
+              }
+            }}
+          >
+            <Stack justify="between" align="center">
+              {label && !customLabel && <Heading type="title4">{label}</Heading>}
+              {customLabel}
+            </Stack>
+          </div>
+        ) : (
+          <div className="flex w-full self-stretch" />
+        )}
         <Stack inline grow={false} align="center" spacing="none">
           {actions && <div className="mx-300 flex items-center">{actions}</div>}
           <ButtonLink
@@ -96,6 +100,7 @@ const Collapse = ({
             title={expanded ? collapseButtonLabel : expandButtonLabel}
             onClick={handleClick}
             ariaControls={slideID}
+            ariaExpanded={expanded}
           />
         </Stack>
       </div>

--- a/packages/orbit-components/src/Collapse/index.tsx
+++ b/packages/orbit-components/src/Collapse/index.tsx
@@ -17,6 +17,7 @@ const AnimatedIcon = ({ expanded }: { expanded?: boolean }) => {
     <ChevronDown
       className={cx("duration-fast transition-transform ease-in-out", expanded && "rotate-180	")}
       color="secondary"
+      ariaHidden
     />
   );
 };
@@ -31,6 +32,8 @@ const Collapse = ({
   id,
   onClick,
   actions,
+  expandButtonLabel,
+  collapseButtonLabel,
 }: Props) => {
   const isControlledComponent = expandedProp != null;
   const [expandedState, setExpandedState] = React.useState(
@@ -70,6 +73,8 @@ const Collapse = ({
           id={labelID}
           role="button"
           tabIndex={0}
+          aria-expanded={expanded}
+          aria-controls={slideID}
           onClick={handleClick}
           onKeyDown={e => {
             if (e.key === "Enter" || e.key === " ") {
@@ -88,14 +93,13 @@ const Collapse = ({
             iconLeft={<AnimatedIcon expanded={expanded} />}
             size="small"
             type="secondary"
+            title={expanded ? collapseButtonLabel : expandButtonLabel}
             onClick={handleClick}
-            ariaLabelledby={labelID}
-            ariaExpanded={expanded}
             ariaControls={slideID}
           />
         </Stack>
       </div>
-      <Slide maxHeight={height} expanded={expanded} id={slideID} ariaLabelledBy={labelID}>
+      <Slide maxHeight={height} expanded={expanded} id={slideID}>
         <div className="my-300 mx-0" ref={node}>
           {children}
         </div>

--- a/packages/orbit-components/src/Collapse/types.d.ts
+++ b/packages/orbit-components/src/Collapse/types.d.ts
@@ -12,6 +12,8 @@ export interface Props extends Common.Globals {
   readonly children: React.ReactNode;
   readonly actions?: React.ReactNode;
   readonly customLabel?: React.ReactNode;
+  readonly expandButtonLabel: string;
+  readonly collapseButtonLabel: string;
   readonly onClick?: (
     e: React.SyntheticEvent<HTMLDivElement>,
     state: boolean,

--- a/packages/orbit-components/src/Collapse/types.d.ts
+++ b/packages/orbit-components/src/Collapse/types.d.ts
@@ -8,7 +8,7 @@ import type * as Common from "../common/types";
 export interface Props extends Common.Globals {
   readonly initialExpanded?: boolean;
   readonly expanded?: boolean;
-  readonly label?: Common.Translation;
+  readonly label?: string;
   readonly children: React.ReactNode;
   readonly actions?: React.ReactNode;
   readonly customLabel?: React.ReactNode;

--- a/packages/orbit-components/src/Drawer/Drawer.stories.tsx
+++ b/packages/orbit-components/src/Drawer/Drawer.stories.tsx
@@ -70,14 +70,19 @@ export const SideNavigation: Story = {
         </Stack>
       }
     >
-      <Collapse label="Discover" initialExpanded>
+      <Collapse
+        label="Discover"
+        initialExpanded
+        expandButtonLabel="Expand"
+        collapseButtonLabel="Collapse"
+      >
         <LinkList indent>
           <TextLink type="secondary">Refer a Friend</TextLink>
           <TextLink type="secondary">Subscribe to newsletter</TextLink>
           <TextLink type="secondary">Kiwi.com Stories</TextLink>
         </LinkList>
       </Collapse>
-      <Collapse label="Guidelines">
+      <Collapse label="Guidelines" expandButtonLabel="Expand" collapseButtonLabel="Collapse">
         <LinkList indent>
           <TextLink type="secondary">Terms & Conditions</TextLink>
           <TextLink type="secondary">Terms of Use</TextLink>
@@ -86,7 +91,7 @@ export const SideNavigation: Story = {
           <TextLink type="secondary">Cookies settings</TextLink>
         </LinkList>
       </Collapse>
-      <Collapse label="Company">
+      <Collapse label="Company" expandButtonLabel="Expand" collapseButtonLabel="Collapse">
         <LinkList indent>
           <TextLink type="secondary">About Kiwi.com</TextLink>
           <TextLink type="secondary">Careers</TextLink>
@@ -183,14 +188,19 @@ export const Suppressed: Story = {
 export const WithTitle: Story = {
   render: args => (
     <Drawer {...args}>
-      <Collapse label="Discover" initialExpanded>
+      <Collapse
+        label="Discover"
+        initialExpanded
+        expandButtonLabel="Expand"
+        collapseButtonLabel="Collapse"
+      >
         <LinkList indent>
           <TextLink type="secondary">Refer a Friend</TextLink>
           <TextLink type="secondary">Subscribe to newsletter</TextLink>
           <TextLink type="secondary">Kiwi.com Stories</TextLink>
         </LinkList>
       </Collapse>
-      <Collapse label="Guidelines">
+      <Collapse label="Guidelines" expandButtonLabel="Expand" collapseButtonLabel="Collapse">
         <LinkList indent>
           <TextLink type="secondary">Terms & Conditions</TextLink>
           <TextLink type="secondary">Terms of Use</TextLink>
@@ -199,7 +209,7 @@ export const WithTitle: Story = {
           <TextLink type="secondary">Cookies settings</TextLink>
         </LinkList>
       </Collapse>
-      <Collapse label="Company">
+      <Collapse label="Company" expandButtonLabel="Expand" collapseButtonLabel="Collapse">
         <LinkList indent>
           <TextLink type="secondary">About Kiwi.com</TextLink>
           <TextLink type="secondary">Careers</TextLink>
@@ -280,14 +290,19 @@ export const SideNavigationInRtl: Story = {
           </Stack>
         }
       >
-        <Collapse label="Discover" initialExpanded>
+        <Collapse
+          label="Discover"
+          initialExpanded
+          expandButtonLabel="Expand"
+          collapseButtonLabel="Collapse"
+        >
           <LinkList>
             <TextLink type="secondary">Refer a Friend</TextLink>
             <TextLink type="secondary">Subscribe to newsletter</TextLink>
             <TextLink type="secondary">Kiwi.com Stories</TextLink>
           </LinkList>
         </Collapse>
-        <Collapse label="Guidelines">
+        <Collapse label="Guidelines" expandButtonLabel="Expand" collapseButtonLabel="Collapse">
           <LinkList>
             <TextLink type="secondary">Terms & Conditions</TextLink>
             <TextLink type="secondary">Terms of Use</TextLink>
@@ -296,7 +311,7 @@ export const SideNavigationInRtl: Story = {
             <TextLink type="secondary">Cookies settings</TextLink>
           </LinkList>
         </Collapse>
-        <Collapse label="Company">
+        <Collapse label="Company" expandButtonLabel="Expand" collapseButtonLabel="Collapse">
           <LinkList>
             <TextLink type="secondary">About Kiwi.com</TextLink>
             <TextLink type="secondary">Careers</TextLink>

--- a/packages/orbit-components/transforms/aria-labels-v21.js
+++ b/packages/orbit-components/transforms/aria-labels-v21.js
@@ -43,26 +43,48 @@ export default function transformer(file, api) {
     .filter(path => {
       const { openingElement } = path.node;
       // Combine conditions for more efficient filtering
-      return openingElement.name.type === "JSXIdentifier" && openingElement.name.name === "Alert";
+      return openingElement.name.type === "JSXIdentifier";
     })
     .forEach(path => {
-      const { attributes } = path.node.openingElement;
+      const { attributes, name } = path.node.openingElement;
 
       if (!Array.isArray(attributes)) {
         // Handle malformed JSX
         return;
       }
 
-      const hasClosable = attributes.some(isClosableAttribute);
-      const hasLabelClose = hasAttribute(attributes, "labelClose");
+      if (name.name === "Alert") {
+        const hasClosable = attributes.some(isClosableAttribute);
+        const hasLabelClose = hasAttribute(attributes, "labelClose");
 
-      if (hasClosable && !hasLabelClose) {
-        attributes.push(
-          j.jsxAttribute(
-            j.jsxIdentifier("labelClose"),
-            createIntlMessageContainer(j, "orbit.button_close", "Close"),
-          ),
-        );
+        if (hasClosable && !hasLabelClose) {
+          attributes.push(
+            j.jsxAttribute(
+              j.jsxIdentifier("labelClose"),
+              createIntlMessageContainer(j, "orbit.button_close", "Close"),
+            ),
+          );
+        }
+      } else if (name.name === "Collapse") {
+        const hasExpandButtonLabel = hasAttribute(attributes, "expandButtonLabel");
+        if (!hasExpandButtonLabel) {
+          attributes.push(
+            j.jsxAttribute(
+              j.jsxIdentifier("expandButtonLabel"),
+              createIntlMessageContainer(j, "orbit.collapse_expand", "Expand"),
+            ),
+          );
+        }
+
+        const hasCollapseButtonLabel = hasAttribute(attributes, "collapseButtonLabel");
+        if (!hasCollapseButtonLabel) {
+          attributes.push(
+            j.jsxAttribute(
+              j.jsxIdentifier("collapseButtonLabel"),
+              createIntlMessageContainer(j, "orbit.collapse_collapse", "Collapse"),
+            ),
+          );
+        }
       }
     });
 


### PR DESCRIPTION
Added two new required props, for the labels to the Button that toggles the collapsed space.

Added codemod and migration guide for this breaking change.

Also added a small fix to ChoiceGroup, as it was adding `aria-labelledby` id of an element that would not be rendered (if `label` was not defined).

The accessibility documentation of Collapse will be done on a separate task.

FEPLT-2255

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces new required props for the `Collapse` component to enhance accessibility by providing labels for the expand and collapse buttons. It also includes a migration guide and a fix for the `ChoiceGroup` component regarding the `aria-labelledby` attribute.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Collapse
    participant Button
    participant Content

    Note over Collapse: New required props:<br/>expandButtonLabel<br/>collapseButtonLabel

    User->>Collapse: Click label/button
    alt Content is Collapsed
        Collapse->>Button: Update aria-expanded=false
        Button->>Button: Show expandButtonLabel
        Collapse->>Content: Hide content
    else Content is Expanded
        Collapse->>Button: Update aria-expanded=true
        Button->>Button: Show collapseButtonLabel
        Collapse->>Content: Show content
    end

    Note over Collapse: Improved accessibility:<br/>- aria-expanded state<br/>- aria-controls<br/>- Keyboard support
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-6ad623620129896f5ce51572b72bcac72829fcce4b8a74feb00ef7885b832839>docs/src/__examples__/Collapse/DEFAULT.tsx</a></td><td>Updated example to include new props for the <code>Collapse</code> component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-842d02bc6da462cebf6d30d904288c591a76c1aadc65a7f8d88ec65d8fa14977>docs/src/components/DocLayout/index.tsx</a></td><td>Modified <code>Collapse</code> component usage to include new required props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-4854a2daa76ac1c489ba55dbba3ceb45d14ee765bb12a4177b25f6606f4102fb>docs/src/components/DocNavigation/Collapse.tsx</a></td><td>Updated <code>Collapse</code> component to use new props for accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-964fc0dbe9d5f8a2c74ad4f737b3e0c668c43a8a5e0fce651f91e90f17d58735>docs/src/components/DocNavigation/DocNavigationItem.tsx</a></td><td>Adjusted <code>Collapse</code> component to include new required props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-a8007b1fbccfbc88f4866726d94ff1318324230aaa02c826df2eb4ff628b6743>docs/src/documentation/05-development/04-migration-guides/01-v21.mdx</a></td><td>Added migration guide for the breaking change regarding <code>Collapse</code> component props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-84b705555cf849a1d73e48965ee180aa078d61d5a9e7078ad070b003fe59e2b3>packages/orbit-components/playroom/snippets/BasicComponents.ts</a></td><td>Updated playroom snippet for <code>Collapse</code> to include new props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-bf57e41059744af88d82550c6eb9a06badbc4358f0efa081c996216f834337ec>packages/orbit-components/playroom/snippets/Layouts.ts</a></td><td>Modified layout snippet for <code>Collapse</code> to include new props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-7616b26166b41921709548bbe9c788c7f98fcd7621d79a1621e71ac199bd7d39>packages/orbit-components/src/ChoiceGroup/index.tsx</a></td><td>Fixed <code>ChoiceGroup</code> to conditionally set <code>aria-labelledby</code> based on the presence of <code>label</code>.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-48cf4b059d0833b5b03de07538d13c0cc7c6afa9aa3de177ec09d0fda313af45>packages/orbit-components/src/Collapse/Collapse.ct-story.tsx</a></td><td>Updated story for <code>Collapse</code> to include new props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-48429084200f269c10d3ad7773176ecf7d51b14abf7f650000c9c3e35d49b6f1>packages/orbit-components/src/Collapse/Collapse.stories.tsx</a></td><td>Modified stories for <code>Collapse</code> to reflect new required props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-2f6cc33d95212addda62ad2d66b9739f6029dea17ea502341b6fe27504cc6f2a>packages/orbit-components/src/Collapse/__tests__/index.test.tsx</a></td><td>Added tests to ensure new props are handled correctly in <code>Collapse</code>.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-b3b6aae52e21bdcedcc41f3be8f2f10f5b00a348c26e9ee1a08e8baff3cbe046>packages/orbit-components/src/Collapse/index.tsx</a></td><td>Updated <code>Collapse</code> component to accept new props for accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-600e764402c848fb48fd66e7fa6949efba1114773dfde5044da352a56cb60a1c>packages/orbit-components/src/Collapse/types.d.ts</a></td><td>Updated type definitions to include new required props for <code>Collapse</code>.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4645/files#diff-8564c3f5e69a73a0e636de90f5a3aeb380f02c2493c4b766468cf182d8eac7f1>packages/orbit-components/transforms/aria-labels-v21.js</a></td><td>Added logic to transform for new <code>Collapse</code> props.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->










