### PR TITLE
fix(InputField): render label element once, show block tooltip icon

### DIFF
--- a/packages/orbit-components/src/InputField/index.tsx
+++ b/packages/orbit-components/src/InputField/index.tsx
@@ -145,6 +145,8 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   const shown = tooltipShown || tooltipShownHover;
   const fieldRef = React.useRef(null);
 
+  const InlineLabelElement = inlineLabel && (error || help || label) ? "label" : "div";
+
   return (
     <div
       className={cx(
@@ -156,7 +158,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
       onMouseEnter={() => (disabled && inlineLabel ? setTooltipShownHover(true) : undefined)}
       onMouseLeave={() => (disabled && inlineLabel ? setTooltipShownHover(false) : undefined)}
     >
-      {!inlineLabel && label && (
+      {!inlineLabel && (error || help || label) && (
         <label className="block" ref={fieldRef} htmlFor={inputId}>
           <FormLabel
             required={required}
@@ -183,7 +185,11 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             : "text-form-element-filled-foreground",
         )}
       >
-        <label className="relative z-[2] flex items-center" ref={fieldRef} htmlFor={inputId}>
+        <InlineLabelElement
+          className="relative z-[2] flex items-center"
+          ref={fieldRef}
+          htmlFor={InlineLabelElement === "label" ? inputId : undefined}
+        >
           {inlineLabel && !tags && (error || help) ? (
             <Prefix>
               {help && !error && (
@@ -222,7 +228,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
               </FormLabel>
             </span>
           )}
-        </label>
+        </InlineLabelElement>
         {tags && <InputTags>{tags}</InputTags>}
         {/* the rule is working weird, it passes only if the value is number, eg not even prop including number } */}
         {/* eslint-disable-next-line jsx-a11y/aria-activedescendant-has-tabindex */}


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2358

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR modifies the `InputField` component to render the label element conditionally based on the presence of error, help, or label props when inlineLabel is true. It also updates the rendering of the label element to use a variable for better flexibility.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant User
    participant InputField
    participant InlineLabelElement
    participant FormLabel

    User->>InputField: Render with props
    
    InputField->>InputField: Check inlineLabel condition
    
    alt inlineLabel true & (error || help || label)
        InputField->>InlineLabelElement: Render as "label"
    else
        InputField->>InlineLabelElement: Render as "div"
    end
    
    InlineLabelElement->>FormLabel: Render label content
    
    alt !inlineLabel & (error || help || label)
        InputField->>FormLabel: Render standard label
    end
    
    FormLabel-->>User: Display final input field

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4646/files#diff-a22047902ec5dad314f04706476107ebd04df90a6577b33c7fdf40c9887e6355>packages/orbit-components/src/InputField/index.tsx</a></td><td>Updated the InputField component to conditionally render the label element and show a block tooltip icon.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->














