### PR TITLE
CarrierLogo Accessibility

### DIFF
--- a/docs/src/__examples__/CarrierLogo/ACCESSIBILITY.tsx
+++ b/docs/src/__examples__/CarrierLogo/ACCESSIBILITY.tsx
@@ -16,11 +16,12 @@ export default {
         />
         <Stack direction="row" spacing="100" align="center">
           <CarrierLogo
+            ariaHidden
             carriers={[
               {
                 code: "OK",
                 type: "airline",
-                name: "",
+                name: "Czech Airlines",
               },
             ]}
           />

--- a/docs/src/snippets/short-nonvisual.mdx
+++ b/docs/src/snippets/short-nonvisual.mdx
@@ -14,8 +14,7 @@
     <p>
       This can mean including the name of the {props.associated} with the {props.visual} so anyone
       who doesn't see the {props.visual} still gets the name. But if the {props.visual} is present
-      next to text with the name, don't include the name with the {props.visual} so it's not
-      repeated.
+      next to some text with its name, make sure to hide the {props.visual} from screen readers.
     </p>
   )}
 </>

--- a/packages/orbit-components/src/CarrierLogo/CarrierLogo.stories.tsx
+++ b/packages/orbit-components/src/CarrierLogo/CarrierLogo.stories.tsx
@@ -17,6 +17,7 @@ const meta: Meta<typeof CarrierLogo> = {
   args: {
     rounded: false,
     inlineStacked: false,
+    ariaHidden: false,
     size: SIZE_OPTIONS.LARGE,
     carriers: [
       { code: "FR", name: "Ryanair" },

--- a/packages/orbit-components/src/CarrierLogo/README.md
+++ b/packages/orbit-components/src/CarrierLogo/README.md
@@ -16,14 +16,15 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in CarrierLogo component.
 
-| Name          | Type                    | Default   | Description                                                            |
-| :------------ | :---------------------- | :-------- | :--------------------------------------------------------------------- |
-| **carriers**  | [`Carrier[]`](#carrier) |           | The content of the CarrierLogo, passed as array of objects.            |
-| dataTest      | `string`                |           | Optional prop for testing purposes.                                    |
-| id            | `string`                |           | Set `id` for `CarrierLogo`                                             |
-| size          | [`enum`](#enum)         | `"large"` | The size of the CarrierLogo. [See Functional specs](#functional-specs) |
-| rounded       | `boolean`               |           | Rounded carrier image                                                  |
-| inlineStacked | `boolean`               |           | Carrier logos are displayed inline, stacking on top of each other.     |
+| Name          | Type                    | Default   | Description                                                                                                        |
+| :------------ | :---------------------- | :-------- | :----------------------------------------------------------------------------------------------------------------- |
+| **carriers**  | [`Carrier[]`](#carrier) |           | The content of the CarrierLogo, passed as array of objects.                                                        |
+| dataTest      | `string`                |           | Optional prop for testing purposes.                                                                                |
+| id            | `string`                |           | Set `id` for `CarrierLogo`.                                                                                        |
+| size          | [`enum`](#enum)         | `"large"` | The size of the CarrierLogo. [See Functional specs](#functional-specs).                                            |
+| rounded       | `boolean`               |           | Rounded carrier image.                                                                                             |
+| inlineStacked | `boolean`               |           | Carrier logos are displayed inline, stacking on top of each other.                                                 |
+| ariaHidden    | `boolean`               | `false`   | Hide the CarrierLogo from screen readers. Can be used if the logo is used with the name of the Carrier next to it. |
 
 ### Carrier
 
@@ -32,7 +33,7 @@ Table below contains all types of the props available for object in Carrier arra
 | Name     | Type            | Description                                                                                   |
 | :------- | :-------------- | :-------------------------------------------------------------------------------------------- |
 | **code** | `string`        | The IATA code of the Carrier, defines which logo will be rendered.                            |
-| name     | `string`        | The name of the Carrier, mainly for information.                                              |
+| **name** | `string`        | The name of the Carrier, used for `alt` and `title` attributes.                               |
 | type     | [`enum`](#enum) | The preferred placeholder for non-existing carrier. [See Functional specs](#functional-specs) |
 
 ### enum

--- a/packages/orbit-components/src/CarrierLogo/index.tsx
+++ b/packages/orbit-components/src/CarrierLogo/index.tsx
@@ -92,7 +92,7 @@ export const CarrierLogoWrapper: React.FC<WrapperProps> = ({
     <div
       className={cx(
         "orbit-carrier-logo",
-        "flex content-between justify-between bg-transparent",
+        "flex place-content-between bg-transparent",
         inlineStacked
           ? "w-min"
           : [
@@ -116,6 +116,7 @@ const CarrierLogo = ({
   id,
   rounded,
   inlineStacked = false,
+  ariaHidden = false,
 }: Props) => {
   const randomId = useRandomIdSeed();
 
@@ -126,6 +127,7 @@ const CarrierLogo = ({
       data-test={dataTest}
       id={id}
       inlineStacked={inlineStacked}
+      aria-hidden={ariaHidden}
     >
       {carriers.slice(0, 4).map((carrierImage, idx) => (
         <img

--- a/packages/orbit-components/src/CarrierLogo/types.d.ts
+++ b/packages/orbit-components/src/CarrierLogo/types.d.ts
@@ -17,4 +17,5 @@ export interface Props extends Common.Globals {
   readonly rounded?: boolean;
   readonly carriers: Common.Carrier[];
   readonly inlineStacked?: boolean;
+  readonly ariaHidden?: boolean;
 }

--- a/packages/orbit-components/src/List/List.stories.tsx
+++ b/packages/orbit-components/src/List/List.stories.tsx
@@ -135,12 +135,12 @@ export const WithLabelAndIcon: Story = {
 export const WithCarrier: Story = {
   render: args => (
     <List {...args}>
-      <ListItem icon={<CarrierLogo carriers={[{ code: "FR", name: "Ryanair" }]} />}>
+      <ListItem icon={<CarrierLogo ariaHidden carriers={[{ code: "FR", name: "Ryanair" }]} />}>
         Airline: Ryanair
       </ListItem>
-      <ListItem icon={<Icons.InformationCircle />}>Flight no: FR 1337</ListItem>
-      <ListItem icon={<Icons.Trip />}>PNR: TEST0X0</ListItem>
-      <ListItem icon={<Icons.Airplane />}>Airbus A320 (320)</ListItem>
+      <ListItem icon={<Icons.InformationCircle ariaHidden />}>Flight no: FR 1337</ListItem>
+      <ListItem icon={<Icons.Trip ariaHidden />}>PNR: TEST0X0</ListItem>
+      <ListItem icon={<Icons.Airplane ariaHidden />}>Airbus A320 (320)</ListItem>
     </List>
   ),
 


### PR DESCRIPTION
The `ariaHidden` prop was added to allow the image to be hidden, if it is placed next to text that describes it.

Documentation was also slightly improved. But dedicated A11Y docs will be added on a separate task.

FEPLT-2280

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds the `ariaHidden` prop to the `CarrierLogo` component to improve accessibility by allowing the logo to be hidden from screen readers when it is accompanied by descriptive text.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant ScreenReader
    participant CarrierLogo
    participant Text

    Note over CarrierLogo: New ariaHidden prop added
    
    alt ariaHidden=true
        User->>+CarrierLogo: View carrier logo
        CarrierLogo->>+Text: Display next to carrier name
        ScreenReader-->>CarrierLogo: Skip logo
        ScreenReader->>Text: Read carrier name
    else ariaHidden=false
        User->>+CarrierLogo: View carrier logo
        ScreenReader->>CarrierLogo: Read carrier name
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4650/files#diff-7795419181f396a2c0aa6c7b0883a3f942a0fa795b5d03e8b5b05beba0e835c1>docs/src/__examples__/CarrierLogo/ACCESSIBILITY.tsx</a></td><td>Added <code>ariaHidden</code> prop to <code>CarrierLogo</code> component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4650/files#diff-391e66ae1cfd5b948fab79c1c399f0c53a6d16bb8b3d8339bb12333df1bbd5af>docs/src/snippets/short-nonvisual.mdx</a></td><td>Updated documentation to clarify usage of <code>ariaHidden</code>.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4650/files#diff-4650068f53c6332cc83e527295fe940e122180f374f34b3d26f908f7b92c02c7>packages/orbit-components/src/CarrierLogo/CarrierLogo.stories.tsx</a></td><td>Set default value for <code>ariaHidden</code> in story args.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4650/files#diff-68682aa45fd3fbbfdb15130437058f232826c0db6e26cf49ad103b0698f7f378>packages/orbit-components/src/CarrierLogo/README.md</a></td><td>Updated README to include <code>ariaHidden</code> prop in the documentation.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4650/files#diff-6a3065b057871ed808416e76b4e2a64d713a580c730531db18cee7ac6fc21bc9>packages/orbit-components/src/CarrierLogo/index.tsx</a></td><td>Updated class names for better styling.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4650/files#diff-4650068f53c6332cc83e527295fe940e122180f374f34b3d26f908f7b92c02c7>packages/orbit-components/src/CarrierLogo/CarrierLogo.stories.tsx</a></td><td>Updated story to demonstrate <code>ariaHidden</code> usage.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4650/files#diff-290ba735b113bd29a0967a0c4de0d4be6f826602106c4850dbf32060140688f0>packages/orbit-components/src/CarrierLogo/types.d.ts</a></td><td>Added <code>ariaHidden</code> to the props interface.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4650/files#diff-fbf2be6431d2d26f0a8d536baa4802fb553f03e9ba7141e4a911603842e6da1d>packages/orbit-components/src/List/List.stories.tsx</a></td><td>Updated list items to use <code>ariaHidden</code> prop.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->








