### PR TITLE
ButtonMobileStore: add title prop and make alt required

### DIFF
--- a/docs/src/__examples__/ButtonMobileStore/DEFAULT.tsx
+++ b/docs/src/__examples__/ButtonMobileStore/DEFAULT.tsx
@@ -4,9 +4,9 @@ import { ButtonMobileStore } from "@kiwicom/orbit-components";
 export default {
   Example: () => (
     <ButtonMobileStore
-      alt="Get it on Google Play"
       href="https://play.google.com/store/apps/details?id=com.skypicker.main"
       type="googlePlay"
+      alt="Get it on Google Play"
     />
   ),
   exampleKnobs: [

--- a/docs/src/__examples__/ButtonMobileStore/TYPES.tsx
+++ b/docs/src/__examples__/ButtonMobileStore/TYPES.tsx
@@ -2,15 +2,15 @@ import React from "react";
 import { ButtonMobileStore } from "@kiwicom/orbit-components";
 
 export default {
-  Example: () => <ButtonMobileStore type="appStore" />,
+  Example: () => <ButtonMobileStore alt="Download on the App Store" type="appStore" />,
   exampleVariants: [
     {
       name: "appStore",
-      code: `() => <ButtonMobileStore type="appStore">appStore</ButtonMobileStore>`,
+      code: `() => <ButtonMobileStore alt="Download on the App Store" type="appStore">appStore</ButtonMobileStore>`,
     },
     {
       name: "googlePlay",
-      code: `() => <ButtonMobileStore type="googlePlay">googlePlay</ButtonMobileStore>`,
+      code: `() => <ButtonMobileStore alt="Download on the Google Play" type="googlePlay">googlePlay</ButtonMobileStore>`,
     },
   ],
 };

--- a/docs/src/documentation/05-development/04-migration-guides/01-v21.mdx
+++ b/docs/src/documentation/05-development/04-migration-guides/01-v21.mdx
@@ -126,6 +126,48 @@ intl.formatMessage({
 
 Feel free to customize the translations according to your needs, by eventually providing more context.
 
+### Required prop in ButtonMobileStore component
+
+The `ButtonMobileStore` component now requires the prop `alt`.
+
+This prop provides the alt text for the image that is displayed in the `ButtonMobileStore` component.
+
+This allows assistive technologies to announce the button correctly, given that it renders an image.
+
+**Before:**
+
+```jsx
+<ButtonMobileStore type="appStore" />
+<ButtonMobileStore type="googlePlay" />
+```
+
+**After:**
+
+```jsx
+<ButtonMobileStore type="appStore" alt="Download on the App Store" />
+<ButtonMobileStore type="googlePlay" alt="Get it on Google Play" />
+```
+
+Make sure to provide translated strings for the `alt` prop.
+
+To ease the migration, we provide a codemod to help you out, with some default generic translations.
+The codemod will inject `intl.formatMessage` calls with the default translations, in this case:
+
+```jsx
+intl.formatMessage({
+  id: "common.screenreader.google_play_button",
+  defaultMessage: "Get it on Google Play",
+});
+intl.formatMessage({
+  id: "common.screenreader.app_store_button",
+  defaultMessage: "Download on the App Store",
+});
+```
+
+Remember that the component also expects a `lang` prop, which is used to determine the language version of the image.
+
+Feel free to customize the translations according to your needs, by eventually providing more context.
+
 ## Codemod
 
 A codemod is available to help with the migration. It should target the new props that require (translated) strings.

--- a/packages/orbit-components/src/ButtonMobileStore/README.md
+++ b/packages/orbit-components/src/ButtonMobileStore/README.md
@@ -9,7 +9,7 @@ import ButtonMobileStore from "@kiwicom/orbit-components/lib/ButtonMobileStore";
 After adding import into your project you can use it simply like:
 
 ```jsx
-<ButtonMobileStore type="appStore" />
+<ButtonMobileStore alt="Download on the App Store" type="appStore" />
 ```
 
 ## Props
@@ -18,7 +18,7 @@ Table below contains all types of the props available in the ButtonMobileStore c
 
 | Name            | Type                       | Default      | Description                                                                   |
 | :-------------- | :------------------------- | :----------- | :---------------------------------------------------------------------------- |
-| alt             | `string`                   |              | Optional property for passing own `alt` attribute to the DOM image element.   |
+| **alt**         | `string`                   |              | Required property for passing `alt` attribute to the DOM image element.       |
 | title           | `string`                   |              | Optional property for passing own `title` attribute to the DOM image element. |
 | dataTest        | `string`                   |              | Optional prop for testing purposes.                                           |
 | id              | `string`                   |              | Set `id` for `ButtonMobileStore`.                                             |

--- a/packages/orbit-components/src/ButtonMobileStore/README.md
+++ b/packages/orbit-components/src/ButtonMobileStore/README.md
@@ -16,16 +16,17 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the ButtonMobileStore component.
 
-| Name            | Type                       | Default | Description                                                                                                     |
-| :-------------- | :------------------------- | :------ | :-------------------------------------------------------------------------------------------------------------- |
-| alt             | `string`                   |         | Optional property for passing own `alt` attribute to the DOM image element.                                     |
-| dataTest        | `string`                   |         | Optional prop for testing purposes.                                                                             |
-| id              | `string`                   |         | Set `id` for `ButtonMobileStore`                                                                                |
-| href            | `string`                   |         | The URL to link when the ButtonMobileStore is clicked.                                                          |
-| onClick         | `event => void \| Promise` |         | Function for handling onClick event.                                                                            |
-| stopPropagation | `boolean`                  |         | If `true` the click event won't bubble. Useful when you use ButtonMobileStore inside another clickable element. |
-| **type**        | [`enum`](#enum)            |         | The type of the ButtonMobileStore.                                                                              |
-| lang            | [`enum`](#enum)            | `EN`    | The language of button                                                                                          |
+| Name            | Type                       | Default      | Description                                                                   |
+| :-------------- | :------------------------- | :----------- | :---------------------------------------------------------------------------- |
+| alt             | `string`                   |              | Optional property for passing own `alt` attribute to the DOM image element.   |
+| title           | `string`                   |              | Optional property for passing own `title` attribute to the DOM image element. |
+| dataTest        | `string`                   |              | Optional prop for testing purposes.                                           |
+| id              | `string`                   |              | Set `id` for `ButtonMobileStore`.                                             |
+| href            | `string`                   |              | The URL to link when the ButtonMobileStore is clicked.                        |
+| onClick         | `event => void \| Promise` |              | Function for handling onClick event.                                          |
+| stopPropagation | `boolean`                  |              | If `true` the click event won't bubble.                                       |
+| type            | [`enum`](#enum)            | `"appStore"` | The type of the ButtonMobileStore.                                            |
+| lang            | [`enum`](#enum)            | `EN`         | The language of the image displayed on the button.                            |
 
 ### enum
 

--- a/packages/orbit-components/src/ButtonMobileStore/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/ButtonMobileStore/__tests__/index.test.tsx
@@ -11,7 +11,13 @@ describe("ButtonMobileStore", () => {
   it("default", async () => {
     const onClick = jest.fn();
     render(
-      <ButtonMobileStore onClick={onClick} dataTest="test" type={TYPE_OPTIONS.APPSTORE} href="#" />,
+      <ButtonMobileStore
+        onClick={onClick}
+        dataTest="test"
+        type={TYPE_OPTIONS.APPSTORE}
+        href="#"
+        alt="Download on the App Store"
+      />,
     );
     expect(screen.getByTestId("test")).toBeInTheDocument();
     const link = screen.getByRole("link");

--- a/packages/orbit-components/src/ButtonMobileStore/index.tsx
+++ b/packages/orbit-components/src/ButtonMobileStore/index.tsx
@@ -18,7 +18,8 @@ const ButtonMobileStore = ({
   onClick,
   dataTest,
   id,
-  alt = "",
+  alt,
+  title,
   stopPropagation = false,
 }: Props) => {
   const onClickHandler = (ev: React.MouseEvent<HTMLAnchorElement>) => {
@@ -39,7 +40,7 @@ const ButtonMobileStore = ({
       data-test={dataTest}
       id={id}
     >
-      <img srcSet={getSrc(type, lang)} height="40px" alt={alt} />
+      <img srcSet={getSrc(type, lang)} height="40px" alt={alt} title={title} />
     </a>
   );
 };

--- a/packages/orbit-components/src/ButtonMobileStore/types.d.ts
+++ b/packages/orbit-components/src/ButtonMobileStore/types.d.ts
@@ -11,6 +11,7 @@ export interface Props extends Common.Globals {
   readonly stopPropagation?: boolean;
   readonly href?: string;
   readonly alt?: string;
+  readonly title?: string;
   readonly lang?: string;
   readonly onClick?: (ev: React.MouseEvent<HTMLAnchorElement>) => void;
 }

--- a/packages/orbit-components/src/ButtonMobileStore/types.d.ts
+++ b/packages/orbit-components/src/ButtonMobileStore/types.d.ts
@@ -10,7 +10,7 @@ export interface Props extends Common.Globals {
   readonly type?: Type;
   readonly stopPropagation?: boolean;
   readonly href?: string;
-  readonly alt?: string;
+  readonly alt: string;
   readonly title?: string;
   readonly lang?: string;
   readonly onClick?: (ev: React.MouseEvent<HTMLAnchorElement>) => void;

--- a/packages/orbit-components/transforms/aria-labels-v21.js
+++ b/packages/orbit-components/transforms/aria-labels-v21.js
@@ -56,7 +56,6 @@ export default function transformer(file, api) {
       if (name.name === "Alert") {
         const hasClosable = attributes.some(isClosableAttribute);
         const hasLabelClose = hasAttribute(attributes, "labelClose");
-
         if (hasClosable && !hasLabelClose) {
           attributes.push(
             j.jsxAttribute(
@@ -75,7 +74,6 @@ export default function transformer(file, api) {
             ),
           );
         }
-
         const hasCollapseButtonLabel = hasAttribute(attributes, "collapseButtonLabel");
         if (!hasCollapseButtonLabel) {
           attributes.push(
@@ -84,6 +82,28 @@ export default function transformer(file, api) {
               createIntlMessageContainer(j, "orbit.collapse_collapse", "Collapse"),
             ),
           );
+        }
+      } else if (name.name === "ButtonMobileStore") {
+        const hasAlt = hasAttribute(attributes, "alt");
+
+        if (!hasAlt) {
+          const typeAttr = attributes.find(
+            attr => attr.type === "JSXAttribute" && attr.name.name === "type",
+          );
+          const altText =
+            typeAttr.value.value === "googlePlay"
+              ? createIntlMessageContainer(
+                  j,
+                  "common.screenreader.google_play_button",
+                  "Get it on Google Play",
+                )
+              : createIntlMessageContainer(
+                  j,
+                  "common.screenreader.app_store_button",
+                  "Download on the App Store",
+                );
+
+          attributes.push(j.jsxAttribute(j.jsxIdentifier("alt"), altText));
         }
       }
     });


### PR DESCRIPTION
Prop to be used as title for the image, enhancing accessibility.

The accessibility documentation will be done on a separate task.

FEPLT-2279

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds a required `alt` prop to the `ButtonMobileStore` component for improved accessibility, along with updates to examples and documentation to reflect this change.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant User
    participant ButtonMobileStore
    participant Screen Reader

    Note over ButtonMobileStore: New required 'alt' prop added
    
    User->>ButtonMobileStore: Renders component with type="appStore"
    alt Without alt text (Before)
        ButtonMobileStore-->>Screen Reader: No accessibility description
    else With alt text (After)
        ButtonMobileStore->>Screen Reader: "Download on the App Store"
    end

    User->>ButtonMobileStore: Renders component with type="googlePlay"
    alt Without alt text (Before)
        ButtonMobileStore-->>Screen Reader: No accessibility description
    else With alt text (After)
        ButtonMobileStore->>Screen Reader: "Get it on Google Play"
    end

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4651/files#diff-cfd89a60da02a17f91d79c46176be7fbce55aee13ef98945d459593cb8c89f60>docs/src/__examples__/ButtonMobileStore/DEFAULT.tsx</a></td><td>Updated example to include the <code>alt</code> prop for accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4651/files#diff-26db64699538abda2ba04c8f6459ce0779cb2b9c723e5ebeca3d533ab2a1482e>docs/src/__examples__/ButtonMobileStore/TYPES.tsx</a></td><td>Modified example to include the <code>alt</code> prop for the <code>ButtonMobileStore</code> component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4651/files#diff-a8007b1fbccfbc88f4866726d94ff1318324230aaa02c826df2eb4ff628b6743>docs/src/documentation/05-development/04-migration-guides/01-v21.mdx</a></td><td>Added migration guide for the new required <code>alt</code> prop in <code>ButtonMobileStore</code>.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4651/files#diff-ecbb232a18106c28fea5e8d5a6ea1e37ea57e7ec3aa6e53e023a92cb3fa14b46>packages/orbit-components/src/ButtonMobileStore/README.md</a></td><td>Updated documentation to indicate that the <code>alt</code> prop is now required.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4651/files#diff-902e9d12f38d67b85e5738b0ca263836b068ba563cf919c5ad14092abeb6971b>packages/orbit-components/src/ButtonMobileStore/__tests__/index.test.tsx</a></td><td>Updated test to include the <code>alt</code> prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4651/files#diff-28b0308a8f2a2d65174f825c5eecceb9f9a9c89a919dd1b07e69633f83a6b4ec>packages/orbit-components/src/ButtonMobileStore/index.tsx</a></td><td>Modified component to require the <code>alt</code> prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4651/files#diff-217dd2e5e31929000b0b9cb3f3d0021852c15c6d567fcdc52ca0c4a2398fc4a1>packages/orbit-components/src/ButtonMobileStore/types.d.ts</a></td><td>Updated type definition to make the <code>alt</code> prop required.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4651/files#diff-8564c3f5e69a73a0e636de90f5a3aeb380f02c2493c4b766468cf182d8eac7f1>packages/orbit-components/transforms/aria-labels-v21.js</a></td><td>Added logic to ensure <code>alt</code> prop is set based on the <code>type</code> attribute.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






