### PR TITLE
A11y Seat

### DIFF
--- a/packages/orbit-components/src/Seat/Seat.stories.tsx
+++ b/packages/orbit-components/src/Seat/Seat.stories.tsx
@@ -71,7 +71,6 @@ export const Playground: Story = {
         true: action("onClick"),
         false: undefined,
       },
-      defaultValue: true,
     },
   },
 };

--- a/packages/orbit-components/src/Seat/Seat.stories.tsx
+++ b/packages/orbit-components/src/Seat/Seat.stories.tsx
@@ -14,13 +14,14 @@ const meta: Meta<typeof Seat> = {
   parameters: {
     info: "Seat components stories. Visit Orbit.Kiwi for more detailed guidelines.",
     controls: {
-      exclude: ["onClick", "aria-labelledby"],
+      exclude: ["aria-labelledby"],
     },
   },
 
   args: {
     label: "XY",
     type: TYPES.DEFAULT,
+    title: "25D",
   },
 
   argTypes: {
@@ -62,6 +63,15 @@ export const Playground: Story = {
       control: {
         type: "select",
       },
+    },
+    onClick: {
+      control: "boolean",
+      description: "Toggle onClick handler",
+      mapping: {
+        true: action("onClick"),
+        false: undefined,
+      },
+      defaultValue: true,
     },
   },
 };

--- a/packages/orbit-components/src/Seat/index.tsx
+++ b/packages/orbit-components/src/Seat/index.tsx
@@ -29,40 +29,52 @@ const Seat = ({
   const randomId = useRandomIdSeed();
   const titleId = title ? randomId("title") : "";
   const descrId = description ? randomId("descr") : "";
-  const clickable = type !== TYPES.UNAVAILABLE;
+  const isAvailable = type !== TYPES.UNAVAILABLE;
+  const clickable = isAvailable && onClick !== undefined;
+
+  const commonProps = {
+    className: cx(
+      "orbit-seat font-base group relative",
+      isAvailable && "cursor-pointer",
+      size === SIZE_OPTIONS.SMALL ? "w-800 h-[36px]" : "size-[46px]",
+    ),
+    id,
+    "data-test": dataTest,
+  };
+
+  const seatContent = (
+    <>
+      <svg
+        viewBox={size === SIZE_OPTIONS.SMALL ? "0 0 32 36" : "0 0 46 46"}
+        aria-labelledby={`${[ariaLabelledBy, titleId, descrId].join(" ").trim()}` || undefined}
+        fill="none"
+        role="img"
+      >
+        {title && <title id={titleId}>{title}</title>}
+        {description && <desc id={descrId}>{description}</desc>}
+
+        {size === SIZE_OPTIONS.SMALL ? (
+          <SeatSmall type={type} selected={selected} label={label} />
+        ) : (
+          <SeatNormal type={type} selected={selected} label={label} />
+        )}
+      </svg>
+      {selected && isAvailable && <SeatCircle size={size} type={type} />}
+    </>
+  );
 
   return (
     <Stack inline grow={false} spacing="50" direction="column" align="center">
-      <button
-        className={cx(
-          "orbit-seat font-base group relative",
-          size === SIZE_OPTIONS.SMALL ? "w-800 h-[36px]" : "size-[46px]",
-        )}
-        data-test={dataTest}
-        id={id}
-        disabled={!clickable}
-        onClick={clickable ? onClick : undefined}
-        tabIndex={clickable ? 0 : -1}
-        type="button"
-      >
-        <svg
-          viewBox={size === SIZE_OPTIONS.SMALL ? "0 0 32 36" : "0 0 46 46"}
-          aria-labelledby={`${[ariaLabelledBy, titleId, descrId].join(" ").trim()}` || undefined}
-          fill="none"
-          role="img"
-        >
-          {title && <title id={titleId}>{title}</title>}
-          {description && <desc id={descrId}>{description}</desc>}
-
-          {size === SIZE_OPTIONS.SMALL ? (
-            <SeatSmall type={type} selected={selected} label={label} />
-          ) : (
-            <SeatNormal type={type} selected={selected} label={label} />
-          )}
-        </svg>
-        {selected && clickable && <SeatCircle size={size} type={type} />}
-      </button>
-      {price && !(selected && type === TYPES.UNAVAILABLE) && (
+      {clickable ? (
+        <button {...commonProps} onClick={onClick} type="button" aria-pressed={selected}>
+          {seatContent}
+        </button>
+      ) : (
+        <div {...commonProps} role="button" aria-pressed={selected} aria-disabled="true">
+          {seatContent}
+        </div>
+      )}
+      {price && !(selected && !isAvailable) && (
         <Text size="small" type="secondary">
           {price}
         </Text>


### PR DESCRIPTION
- **chore(Seat): add onClick prop control to story**
  Useful to see how the component behaves both with and without the handler
  

- **fix(Seat): display as div when non-clickable**
  If the Seat is available and has onClick set, renders it as an
  interactive button, otherwise renders it as a non-interactive div
  
  Closes FEPLT-2265
  
---
  
It can be tested with yalc on booking. I used this diff:

<details><summary>Diff</summary>
<p>

```diff

diff --git a/package.json b/package.json
index 11f81b8aad..2663914f4a 100644
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@kiwicom/event": "0.0.6",
     "@kiwicom/event-schemas": "0.0.81",
     "@kiwicom/nitro": "75.1.0",
-    "@kiwicom/orbit-components": "20.1.0",
+    "@kiwicom/orbit-components": "file:.yalc/@kiwicom/orbit-components",
     "@kiwicom/smart-faq-sidebar": "18.0.0",
     "@kiwicom/translations": "4.0.30",
     "@kiwicom/useragent": "0.2.3",
diff --git a/src/ancillaries/flight/features/Seating/components/DesktopOptions/components/SeatMap/components/Seat.tsx b/src/ancillaries/flight/features/Seating/components/DesktopOptions/components/SeatMap/components/Seat.tsx
index 10bc0d54b4..7ae43b8812 100644
--- a/src/ancillaries/flight/features/Seating/components/DesktopOptions/components/SeatMap/components/Seat.tsx
+++ b/src/ancillaries/flight/features/Seating/components/DesktopOptions/components/SeatMap/components/Seat.tsx
@@ -85,7 +85,7 @@ const Seat = ({ seat, paxValues, activeSegmentCode }: SeatProps) => {
   const handleClosePopover = useCallback(() => setPopoverActive(false), [])
 
   if (seat.type === SEAT_FORMATED_TYPES.unavailable) {
-    return <NewSeatIcon type="unavailable" price="-" />
+    return <NewSeatIcon type="unavailable" price="-" title={seat.name} />
   }
 
   return (
@@ -121,6 +121,7 @@ const Seat = ({ seat, paxValues, activeSegmentCode }: SeatProps) => {
           isSeatOccupied ? initialsOfPapOnThisSeat : (seat.isEmergencyExit && "*") || undefined
         }
         selected={isSeatOccupied}
+        title={seat.name}
       />
     </Popover>
   )
diff --git a/yarn.lock b/yarn.lock
index d7831a6f77..cfa81e252f 100644
--- a/yarn.lock
+++ b/yarn.lock
@@ -1270,10 +1270,8 @@
     validator "^13.0.0"
     yargs "^17.0.0"
 
-"@kiwicom/orbit-components@20.1.0":
+"@kiwicom/orbit-components@file:.yalc/@kiwicom/orbit-components":
   version "20.1.0"
-  resolved "https://registry.yarnpkg.com/@kiwicom/orbit-components/-/orbit-components-20.1.0.tgz#a4f734edceafe1b76fcde716907d57ecc48c6a8d"
-  integrity sha512-lLOSScm5OCbCFeSELApn9UZBI10PMcJwa7OLeW5R5TU+izkB6kX5HGn6A/zpDBsoF+G/fxsBPdTOsdgmJggvbA==
   dependencies:
     "@floating-ui/react" "0.26.24"
     "@kiwicom/orbit-design-tokens" "^9.0.1"

```

</p>
</details>  

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces a new feature for the Seat component, allowing it to render as a clickable button when available and has an onClick handler. It also adds a title prop to enhance accessibility.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant S as Seat Component
    participant B as Button/Div Container
    participant SV as Seat SVG

    Note over S: Initialize with type, onClick, size
    S->>S: Check if seat is available
    S->>S: Check if clickable (available & onClick exists)
    
    alt Clickable Seat
        S->>B: Render as Button
    else Non-Clickable Seat
        S->>B: Render as Div
    end
    
    B->>SV: Render Seat SVG content
    
    alt Small Size
        SV->>SV: Render SeatSmall
    else Normal Size
        SV->>SV: Render SeatNormal
    end
    
    alt Selected & Available
        SV->>SV: Show SeatCircle
    end
    
    alt Has Price & Not (Selected & Unavailable)
        S->>S: Display Price Text
    end
    
    U->>B: Click Seat
    alt Is Clickable
        B->>S: Trigger onClick handler
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4653/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519>package.json</a></td><td>Updated dependency for @kiwicom/orbit-components to use local version.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4653/files#diff-5254fbb1cd7dfc213dad2dc0bdb6a82b8ce614f82ce555e992d109fcb2789875>src/ancillaries/flight/features/Seating/components/DesktopOptions/components/SeatMap/components/Seat.tsx</a></td><td>Added title prop to NewSeatIcon and Popover components for better accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4653/files#diff-7f1bf45b8616043f7bcf3f93c1d15c06b6e26612e1cb31c4ffd69136ca7048a1>packages/orbit-components/src/Seat/Seat.stories.tsx</a></td><td>Updated story controls to include onClick handler toggle.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4653/files#diff-d7278c1d88f86f9bac9c62077916c29f733ba1e4e0e09f6f5b8e4eef75f6f5f7>packages/orbit-components/src/Seat/index.tsx</a></td><td>Refactored Seat component to conditionally render as a button or div based on availability and onClick prop.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->
















