### PR TITLE
fix(InputField): remove tooltip icon when label is null

### DIFF
--- a/packages/orbit-components/src/InputField/index.tsx
+++ b/packages/orbit-components/src/InputField/index.tsx
@@ -158,7 +158,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
       onMouseEnter={() => (disabled && inlineLabel ? setTooltipShownHover(true) : undefined)}
       onMouseLeave={() => (disabled && inlineLabel ? setTooltipShownHover(false) : undefined)}
     >
-      {!inlineLabel && (error || help || label) && (
+      {!inlineLabel && label && (
         <label className="block" ref={fieldRef} htmlFor={inputId}>
           <FormLabel
             required={required}


### PR DESCRIPTION
# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR modifies the `InputField` component to remove the tooltip icon when the `label` is null, ensuring that the label is displayed only when it has a value.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant InputField
    participant FormLabel

    User->>InputField: Render with label prop
    Note over InputField: Check if inlineLabel is false
    alt inlineLabel is false and label exists
        InputField->>FormLabel: Render label with required prop
    else inlineLabel is true
        InputField->>InputField: Skip label rendering
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4657/files#diff-a22047902ec5dad314f04706476107ebd04df90a6577b33c7fdf40c9887e6355>packages/orbit-components/src/InputField/index.tsx</a></td><td>Updated the condition for rendering the label to check only if the label is present.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


