### PR TITLE
Fix collapse label on docs

### DIFF
--- a/docs/src/components/DocNavigation/Collapse.tsx
+++ b/docs/src/components/DocNavigation/Collapse.tsx
@@ -11,12 +11,18 @@ interface Props extends React.ComponentProps<typeof OrbitCollapse> {
   hasCategories: boolean;
 }
 
-export default function Collapse({ expanded, label, hasCategories, children, onClick }: Props) {
+export default function Collapse({
+  expanded,
+  customLabel,
+  hasCategories,
+  children,
+  onClick,
+}: Props) {
   return (
     <StyledCollapseWrapper>
       <OrbitCollapse
         expanded={expanded}
-        customLabel={<StyledCollapseLabel>{label}</StyledCollapseLabel>}
+        customLabel={<StyledCollapseLabel>{customLabel}</StyledCollapseLabel>}
         onClick={onClick}
         expandButtonLabel="Expand"
         collapseButtonLabel="Collapse"


### PR DESCRIPTION
With the change in Collapse, the docs broke because of misnaming of label props

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR fixes the label prop in the Collapse component to correctly use `customLabel` instead of `label`.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant User
    participant Collapse
    participant OrbitCollapse
    participant StyledCollapseLabel

    User->>Collapse: Renders with props (expanded, customLabel)
    Collapse->>OrbitCollapse: Initializes with expanded state
    Collapse->>StyledCollapseLabel: Wraps customLabel
    OrbitCollapse-->>User: Displays collapsible content
    User->>OrbitCollapse: Clicks expand/collapse
    OrbitCollapse-->>User: Toggles content visibility

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4662/files#diff-4854a2daa76ac1c489ba55dbba3ceb45d14ee765bb12a4177b25f6606f4102fb>docs/src/components/DocNavigation/Collapse.tsx</a></td><td>Updated the Collapse component to use customLabel prop instead of label.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


