### PR TITLE
dataTest was not applied on Drawer

### DIFF
--- a/packages/orbit-components/src/Drawer/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/Drawer/__tests__/index.test.tsx
@@ -42,16 +42,20 @@ describe("Drawer", () => {
     await user.click(screen.getByRole("button", { name: "Hide" }));
     expect(onClose).toHaveBeenCalled();
   });
-  it("should trigger close handler when clicked on backdrop", async () => {
+  it("should trigger close handler when clicked outside", async () => {
     const onClose = jest.fn();
     render(
-      <Drawer dataTest="container" onClose={onClose} shown>
-        <div data-test="content" />
-      </Drawer>,
+      <div data-test="outside">
+        <Drawer dataTest="container" onClose={onClose} shown>
+          <div data-test="content" />
+        </Drawer>
+      </div>,
     );
     await user.click(screen.getByTestId("content"));
     expect(onClose).not.toHaveBeenCalled();
     await user.click(screen.getByTestId("container"));
+    expect(onClose).not.toHaveBeenCalled();
+    await user.click(screen.getByTestId("outside"));
     expect(onClose).toHaveBeenCalled();
   });
   it("should trigger close when pressed escape key", async () => {

--- a/packages/orbit-components/src/Drawer/index.tsx
+++ b/packages/orbit-components/src/Drawer/index.tsx
@@ -99,7 +99,6 @@ const Drawer = ({
           overlayShown ? "visible" : "invisible",
           shown ? "bg-drawer-overlay-background" : "bg-transparent",
         )}
-        data-test={dataTest}
         id={id}
         ref={overlayRef}
       />
@@ -122,6 +121,7 @@ const Drawer = ({
         style={vars as React.CSSProperties}
         ref={drawerRef}
         aria-label={ariaLabel || title}
+        data-test={dataTest}
       >
         {(title || actions || onClose) && (
           <div


### PR DESCRIPTION
The dataTest was being applied on the overlay area. In the past, the overlay area was a wrapper for the drawer. But now, it is not.

It is more relevant to have the dataTest applied on the drawer itself. So we change this here.