### PR TITLE
AirportIllustration accessibility

### DIFF
--- a/packages/orbit-components/src/AirportIllustration/AirportIllustration.stories.tsx
+++ b/packages/orbit-components/src/AirportIllustration/AirportIllustration.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<typeof AirportIllustration> = {
     size: SIZE_OPTIONS.MEDIUM,
     name: "BGYFastTrack",
     spaceAfter: SPACINGS_AFTER.SMALL,
+    alt: "Airport illustration",
   },
 
   argTypes: {

--- a/packages/orbit-components/src/AirportIllustration/README.md
+++ b/packages/orbit-components/src/AirportIllustration/README.md
@@ -16,14 +16,14 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in AirportIllustration component.
 
-| Name       | Type            | Default    | Description                                                                                                                  |
-| :--------- | :-------------- | :--------- | :--------------------------------------------------------------------------------------------------------------------------- |
-| alt        | `string`        |            | Optional property for passing own `alt` attribute to the DOM image element. Bby default, the `name` of illustration is used. |
-| dataTest   | `string`        |            | Optional prop for testing purposes.                                                                                          |
-| id         | `string`        |            | Set `id` for `Illustration`                                                                                                  |
-| **name**   | [`enum`](#enum) |            | Name for the displayed Airportillustration.                                                                                  |
-| size       | [`enum`](#enum) | `"medium"` | The size of the AirportIllustration.                                                                                         |
-| spaceAfter | `enum`          |            | Additional `margin-bottom` after component.                                                                                  |
+| Name       | Type            | Default    | Description                                                                                                      |
+| :--------- | :-------------- | :--------- | :--------------------------------------------------------------------------------------------------------------- |
+| alt        | `string`        | `""`       | Optional property for passing own `alt` attribute to the DOM image element. By default, an empty string is used. |
+| dataTest   | `string`        |            | Optional prop for testing purposes.                                                                              |
+| id         | `string`        |            | Set `id` for `Illustration`.                                                                                     |
+| **name**   | [`enum`](#enum) |            | Name for the displayed Airportillustration.                                                                      |
+| size       | [`enum`](#enum) | `"medium"` | The size of the AirportIllustration.                                                                             |
+| spaceAfter | `enum`          |            | Additional `margin-bottom` after component.                                                                      |
 
 ### enum
 

--- a/packages/orbit-components/src/AirportIllustration/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/AirportIllustration/__tests__/index.test.tsx
@@ -8,6 +8,7 @@ import defaultTheme from "../../defaultTheme";
 
 const name = "BGYFastTrack";
 const dataTest = "test";
+const alt = "Fast Track at Bergamo Airport";
 
 describe(`AirportIllustration of ${name}`, () => {
   beforeEach(() => {
@@ -15,14 +16,15 @@ describe(`AirportIllustration of ${name}`, () => {
       <AirportIllustration
         size={SIZE_OPTIONS.EXTRASMALL}
         name={name}
-        dataTest="test"
+        alt={alt}
+        dataTest={dataTest}
         spaceAfter={SPACINGS_AFTER.NORMAL}
       />,
     );
   });
 
   it("should have passed props", () => {
-    expect(screen.getByRole("img")).toHaveAttribute("alt", name);
+    expect(screen.getByRole("img")).toHaveAttribute("alt", alt);
     expect(screen.getByRole("img")).toHaveAttribute("data-test", dataTest);
   });
 

--- a/packages/orbit-components/src/AirportIllustration/index.tsx
+++ b/packages/orbit-components/src/AirportIllustration/index.tsx
@@ -5,8 +5,8 @@ import React from "react";
 import type { Props } from "./types";
 import IllustrationPrimitive, { SIZE_OPTIONS } from "../primitives/IllustrationPrimitive";
 
-const AirportIllustration = ({ size = SIZE_OPTIONS.MEDIUM, ...props }: Props) => (
-  <IllustrationPrimitive {...props} size={size} />
+const AirportIllustration = ({ size = SIZE_OPTIONS.MEDIUM, alt = "", ...props }: Props) => (
+  <IllustrationPrimitive {...props} alt={alt} size={size} />
 );
 
 export default AirportIllustration;


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2275 

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds an `alt` attribute to the `AirportIllustration` component for improved accessibility and updates the README to reflect this change.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant Client
    participant AirportIllustration
    participant IllustrationPrimitive
    participant DOM

    Client->>AirportIllustration: Render with props (name, size, alt)
    Note over AirportIllustration: Default alt="" if not provided
    AirportIllustration->>IllustrationPrimitive: Forward props with alt
    IllustrationPrimitive->>DOM: Render img element with alt attribute
    DOM-->>Client: Display illustration with alt text

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4664/files#diff-0c5187a0d8d33007403839e76aa6bc147d7a7cdff5cc75d84d48750f38cdfaf3>packages/orbit-components/src/AirportIllustration/AirportIllustration.stories.tsx</a></td><td>Added an <code>alt</code> attribute to the <code>AirportIllustration</code> story.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4664/files#diff-e7f8ffa331d8f4809a1f8ce87f7fee50111a4d91e53ab2c7465e3796f5a44cfc>packages/orbit-components/src/AirportIllustration/README.md</a></td><td>Updated the README to include the <code>alt</code> attribute in the props table.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4664/files#diff-cf9a6524586a6f6d3e4afa39987cef9180174643b9bcc831fc021049a5a6a184>packages/orbit-components/src/AirportIllustration/__tests__/index.test.tsx</a></td><td>Updated tests to check for the new <code>alt</code> attribute.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4664/files#diff-b327293c89c314df6e7afecb9955057a50fb02259c805b677fdf5b984f8756a0>packages/orbit-components/src/AirportIllustration/index.tsx</a></td><td>Modified the <code>AirportIllustration</code> component to accept and pass the <code>alt</code> prop.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




















