### PR TITLE
Timeline: improve component accessibility

### DIFF
--- a/packages/orbit-components/src/Timeline/Timeline.stories.tsx
+++ b/packages/orbit-components/src/Timeline/Timeline.stories.tsx
@@ -62,7 +62,7 @@ export const InsideModal: Story = {
 
     return (
       <Container>
-        <Modal onClose={onClose} labelClose="Close" lockScrolling={false}>
+        <Modal onClose={onClose} labelClose="Close" ariaLabel="Timeline" lockScrolling={false}>
           <ModalSection>
             <Timeline>
               <TimelineStep label="Requested" subLabel="3rd May 14:04" type="success">

--- a/packages/orbit-components/src/Timeline/TimelineStep/components/TextWrapper.tsx
+++ b/packages/orbit-components/src/Timeline/TimelineStep/components/TextWrapper.tsx
@@ -7,7 +7,10 @@ type Props = React.PropsWithChildren<{
 
 const TextWrapper = ({ active, children }: Props) => {
   return (
-    <div className={cx("de:min-h-400", active ? "[&>p]:text-ink-dark" : "[&>p]:text-ink-light")}>
+    <div
+      className={cx("de:min-h-400", active ? "[&>p]:text-ink-dark" : "[&>p]:text-ink-light")}
+      aria-current={active ? "step" : undefined}
+    >
       {children}
     </div>
   );

--- a/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepDesktop.tsx
+++ b/packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepDesktop.tsx
@@ -31,7 +31,10 @@ const TimelineStepDesktop = ({
 
   return (
     <Stack inline shrink direction="column" align="center">
-      <div className={cx("relative flex w-[calc(100%+theme(spacing.400))] items-center")}>
+      <div
+        className={cx("relative flex w-[calc(100%+theme(spacing.400))] items-center")}
+        aria-hidden
+      >
         <ProgressLine desktop status={type} prevStatus={prevType} nextStatus={nextType} />
         <TypeIcon type={type} active={!!active} />
         <ProgressLine

--- a/packages/orbit-components/src/Timeline/TimelineStep/components/TypeIcon.tsx
+++ b/packages/orbit-components/src/Timeline/TimelineStep/components/TypeIcon.tsx
@@ -55,6 +55,7 @@ const TypeIcon = ({ type, active, mobile }: Props) => {
         "z-default h-icon-medium relative flex items-center justify-center",
         mobile && "min-w-600",
       )}
+      aria-hidden
     >
       {getTypeIcon({ type, active })}
       <div


### PR DESCRIPTION
For now, it only adds `aria-current="step"` on the active step and silences the announcement of the icon used for the step.

Accessibility documentation will be done on a separate task.

Improvements on how to announce steps status are still TBD.

FEPLT-2256

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR improves the accessibility of the Timeline component by adding `aria-current="step"` to the active step and silencing the announcement of the icon used for the step.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Timeline
    participant TimelineStep
    participant TextWrapper
    participant TypeIcon

    User->>Timeline: Views Timeline in Modal
    Note over Timeline: Added Modal with aria-label="Timeline"

    Timeline->>TimelineStep: Renders step content
    TimelineStep->>TextWrapper: Displays step text
    Note over TextWrapper: Added aria-current="step" for active state

    TimelineStep->>TypeIcon: Shows step icon
    Note over TypeIcon: Added aria-hidden to decorative icons

    TypeIcon-->>TimelineStep: Returns with progress line
    Note over TimelineStep: Added aria-hidden to progress visuals

    TimelineStep-->>Timeline: Renders complete step
    Timeline-->>User: Displays accessible timeline
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4669/files#diff-2682ee7a412c6a387769ca18420121f1e0e86d744f8148b2ab5a7d8d4bb8519d>packages/orbit-components/src/Timeline/Timeline.stories.tsx</a></td><td>Added <code>ariaLabel</code> to the Modal component for better accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4669/files#diff-03b5edd5ce83df7f1ebccc3726a49df114be5d3e175294067414d884bc1950d7>packages/orbit-components/src/Timeline/TimelineStep/components/TextWrapper.tsx</a></td><td>Added <code>aria-current</code> attribute to indicate the active step.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4669/files#diff-7ae803bdb5700b78f0d4f51b6834a7f6b0e168af1557e21247293f28fce522dd>packages/orbit-components/src/Timeline/TimelineStep/components/TimelineStepDesktop.tsx</a></td><td>Added <code>aria-hidden</code> attribute to the wrapper div to improve accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4669/files#diff-80fb90a404f7dd7b21edfe9e4f4fdff38d28c9047c073ae1faa3515638c9bd27>packages/orbit-components/src/Timeline/TimelineStep/components/TypeIcon.tsx</a></td><td>Added <code>aria-hidden</code> attribute to the icon container to improve accessibility.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->






