### PR TITLE
Tab: improve accessibility

### DIFF
--- a/packages/orbit-components/src/Tabs/components/Tab/index.tsx
+++ b/packages/orbit-components/src/Tabs/components/Tab/index.tsx
@@ -35,7 +35,7 @@ const Tab = ({
         "font-base font-medium",
         "rounded-t-100",
         "duration-fast transition-colors ease-in-out",
-        "px-400",
+        "px-400 focus:z-default",
         compact ? "text-normal py-[5px] leading-normal" : "text-large leading-large py-[9px]",
         disabled && "cursor-not-allowed opacity-50",
         !disabled && [
@@ -68,6 +68,7 @@ const Tab = ({
           onClick(ev);
         } else setSelected(index);
       }}
+      id={`tab-${index}`}
       type="button"
       disabled={disabled}
       role="tab"

--- a/packages/orbit-components/src/Tabs/components/TabPanel/index.tsx
+++ b/packages/orbit-components/src/Tabs/components/TabPanel/index.tsx
@@ -39,6 +39,8 @@ const TabPanel = ({ children, margin, padding, dataTest, active = false }: Props
       style={cssVars}
       id={`panel-${index}`}
       data-test={dataTest}
+      role="tabpanel"
+      aria-labelledby={`tab-${index}`}
     >
       {children}
     </div>


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2271 

I also added `role`, `aria-labelledby` attributes to the `TabPanel` file. Based on that, voice can read that respective content is connected to the active tab.

<img width="623" alt="image" src="https://github.com/user-attachments/assets/1c41eb7a-89b4-4169-9b9f-bdadc60ea382" />


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR improves accessibility for the Tab and TabPanel components by adding appropriate ARIA roles and attributes.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Tab
    participant TabPanel
    participant Screen Reader

    Note over Tab,TabPanel: Accessibility Enhancements
    
    Tab->>Tab: Add unique ID (tab-{index})
    Tab->>Tab: Add focus z-index
    Tab->>Tab: Add padding-x
    
    TabPanel->>TabPanel: Add role="tabpanel"
    TabPanel->>TabPanel: Link to Tab via aria-labelledby
    
    Screen Reader->>Tab: Reads tab identity
    Screen Reader->>TabPanel: Associates panel with tab
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4670/files#diff-f769f822dcbd259136a6bc34330cc5739176c0685b2e4df5e8960f790d155b08>packages/orbit-components/src/Tabs/components/Tab/index.tsx</a></td><td>Added <code>id</code> attribute to the Tab component for accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4670/files#diff-2579b97f86f2a6ff7b3a352aa29e5128476e2d047c095afddde4076857b75b91>packages/orbit-components/src/Tabs/components/TabPanel/index.tsx</a></td><td>Added <code>role</code> and <code>aria-labelledby</code> attributes to the TabPanel component for accessibility.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->




