### PR TITLE
Button primitive a11y + Loading ariaHidden prop

### DIFF
--- a/docs/src/documentation/03-components/01-action/button/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/01-action/button/03-accessibility.mdx
@@ -42,6 +42,8 @@ Also, the component offers flexibility in terms of the HTML element used for the
 
 - Use `role` and `tabIndex` when you are rendering `Button` to non-actionable HTML element as `div` or `span`. However, this should be done only in edge-cases as it is anti-pattern behavior.
 
+- When a `Button` is loading, the loading indicator is hidden from screen readers. For this reason, you should use the `title` prop (or any alternative available) to provide additional information about the button and its loading state.
+
 ## Example
 
 ### Example 1:

--- a/packages/orbit-components/src/Loading/index.tsx
+++ b/packages/orbit-components/src/Loading/index.tsx
@@ -89,6 +89,7 @@ const Loading = ({
   customSize,
   title,
   id,
+  ariaHidden,
 }: Props) => {
   const Element = text ? "div" : asComponent;
 
@@ -113,6 +114,7 @@ const Loading = ({
           style={{ height: customSize }}
           data-test={dataTest}
           id={id}
+          aria-hidden={ariaHidden}
         >
           <Loader title={title} type={type} customSize={customSize} />
           {type !== TYPE_OPTIONS.BUTTON_LOADER && Boolean(text) && (

--- a/packages/orbit-components/src/Loading/types.d.ts
+++ b/packages/orbit-components/src/Loading/types.d.ts
@@ -15,4 +15,5 @@ export interface Props extends Common.Globals {
   readonly title?: string;
   readonly text?: Common.Translation;
   readonly asComponent?: Common.Component;
+  readonly ariaHidden?: boolean;
 }

--- a/packages/orbit-components/src/primitives/ButtonPrimitive/index.tsx
+++ b/packages/orbit-components/src/primitives/ButtonPrimitive/index.tsx
@@ -221,7 +221,7 @@ const ButtonPrimitive = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, 
         )}
         style={varsButton}
       >
-        {loading && <Loading type="buttonLoader" />}
+        {loading && <Loading ariaHidden type="buttonLoader" />}
 
         {iconLeft != null && (
           <div

--- a/packages/orbit-components/src/primitives/Primitives.stories.tsx
+++ b/packages/orbit-components/src/primitives/Primitives.stories.tsx
@@ -153,7 +153,7 @@ export const ButtonPrimitive: Story = {
     role: "",
     spaceAfter: SPACINGS_AFTER.SMALL,
     submit: false,
-    title: "",
+    title: "Button title",
     tabIndex: 0,
     width: "",
     contentAlign: "center",


### PR DESCRIPTION
This includes:

- Addition of `ariaHidden` to `Loading` component. This allows the glyph to be ignored by screen readers.
- The ButtonPrimitive in loading state will make use of this. The button is responsible for announcing its state.
- Update the Button a11y docs, because it's a one sentence only.

FEPLT-2270

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds the `ariaHidden` prop to the `Loading` component to improve accessibility by allowing the loading indicator to be ignored by screen readers. The `ButtonPrimitive` component is updated to utilize this new prop when in a loading state. Additionally, the accessibility documentation for the Button has been updated.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant User
    participant Button
    participant Loading
    participant ScreenReader

    User->>Button: Clicks button (loading state)
    Button->>Loading: Renders with ariaHidden=true
    Note over Loading: Loading indicator shown visually
    Button-->>ScreenReader: Announces button title
    Note over ScreenReader: Loading indicator hidden from screen readers
    Loading-->>User: Visual feedback only

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4672/files#diff-f7984dc6f3191d3e7805b69db2341d3164bf117b6ef2f79b8a83ff6df203536c>docs/src/documentation/03-components/01-action/button/03-accessibility.mdx</a></td><td>Updated accessibility documentation to include information about the loading state of the Button.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4672/files#diff-c01d8e419781bc3faf3937760c711e99fdc5cd8637624bad193c9f8ac52eb4ce>packages/orbit-components/src/Loading/index.tsx</a></td><td>Added <code>ariaHidden</code> prop to the <code>Loading</code> component to control screen reader visibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4672/files#diff-2c271f47eeb5fa76e78f068449d6c992eac86607f9aff3298d9a90414b20729f>packages/orbit-components/src/Loading/types.d.ts</a></td><td>Extended <code>Props</code> interface to include the new <code>ariaHidden</code> prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4672/files#diff-f7cf66cb8809621c8c5505307aa0981e4ca0031b448214b0fe009841e76a6298>packages/orbit-components/src/primitives/ButtonPrimitive/index.tsx</a></td><td>Updated <code>ButtonPrimitive</code> to pass the <code>ariaHidden</code> prop to the <code>Loading</code> component when loading.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4672/files#diff-3c3127d3c4bd8b4a460ab0c42eafe3f7c515517399a3b45d82ca4017efbba5c0>packages/orbit-components/src/primitives/Primitives.stories.tsx</a></td><td>Updated story for <code>ButtonPrimitive</code> to include a title for better demonstration.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






