### PR TITLE
InputGroup accessibility

### DIFF
--- a/docs/src/documentation/03-components/05-input/inputfield/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/05-input/inputfield/03-accessibility.mdx
@@ -16,4 +16,82 @@ redirect_from:
 ```
 
 - The `ariaLabel` prop allows you to specify an `aria-label` attribute for the InputField component. This attribute provides additional information to screen readers, enhancing the accessibility of the component. By using `ariaLabel`, you can ensure that users who rely on assistive technologies receive the necessary context and information about the component's purpose and functionality.
+
 - If the `label` prop is not provided, the `ariaLabel` prop must be specified to ensure component accessibility.
+
+- The `ariaDescribedby` prop allows you to specify an `aria-describedby` attribute for the InputField component. This attribute links the component to additional descriptive text, enhancing accessibility by providing supplementary information to screen readers.
+
+```jsx
+  <InputField label="Password" type="password" ariaDescribedby="password-requirements" />
+  <p id="password-requirements" style={{ display: "none", visibility: "hidden" }}>
+    Password must be at least 8 characters long and include at least one uppercase letter and one number.
+  </p>
+```
+
+When using the `error` or `help` props, the component automatically manages the `aria-describedby` attribute:
+
+```jsx
+<InputField label="Username" error="This username is already taken" />
+```
+
+In this example, the error message is automatically associated with the input field via `aria-describedby`.
+
+If you provide both an `ariaDescribedby` prop and use `error` or `help`, the component automatically combines them, ensuring that screen readers announce all descriptive content:
+
+```jsx
+  <p id="email-hint" style={{ display: "none", visibility: "hidden" }}>
+    We'll never share your email with anyone else.
+  </p>
+  <InputField label="Email" error="Invalid email format" ariaDescribedby="email-hint" />
+```
+
+In this example, both the "email-hint" text and the error message will be announced by screen readers. The text from `ariaDescribedby` will be announced first, followed by the text from `error`.
+
+### InputGroup Integration
+
+When using InputField within an InputGroup, the `aria-describedby` association follows these rules:
+
+#### Example 1
+
+If the InputGroup has `error`/`help` messages, these will be properly associated with all child components:
+
+```jsx
+<InputGroup label="Passenger details" error="Incomplete information">
+  <InputField label="First name" />
+  <InputField label="Last name" />
+</InputGroup>
+```
+
+In this example, all InputField components will have the InputGroup's error message "Incomplete information" announced by screen readers.
+
+#### Example 2
+
+If individual InputField components have their own `error`/`help` messages (and the InputGroup doesn't), only those specific components will have `aria-describedby` set:
+
+```jsx
+<InputGroup label="Passenger details">
+  <InputField label="First name" />
+  <InputField label="Last name" error="Last name is required" />
+</InputGroup>
+```
+
+In this example, only the second InputField will have its error message "Last name is required" announced.
+
+#### Example 3
+
+Avoid setting `ariaDescribedby` directly on InputField components when inside an InputGroup, as these values will be overwritten by the InputGroup's internal accessibility logic:
+
+```jsx
+<InputGroup label="Contact information">
+  <Select options={countryOptions} label="Country" />
+  <InputField
+    label="Phone number"
+    ariaDescribedby="phone-hint" // This will be overwritten
+  />
+  <p id="phone-hint" style={{ display: "none", visibility: "hidden" }}>
+    Enter your phone number
+  </p>
+</InputGroup>
+```
+
+In this example, the `ariaDescribedby` value "phone-hint" will be ignored because the InputGroup manages the accessibility associations internally. Instead, rely on the InputGroup's `error`/`help` props or the component's own `error`/`help` props.

--- a/docs/src/documentation/03-components/05-input/select/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/05-input/select/03-accessibility.mdx
@@ -10,10 +10,11 @@ The Select component has been designed with accessibility in mind.
 
 It supports keyboard navigation and includes the following properties that provide additional information to screen readers:
 
-| Name           | Type     | Description                                                            |
-| :------------- | :------- | :--------------------------------------------------------------------- |
-| ariaLabel      | `string` | Allows you to specify an `aria-label` attribute of the component.      |
-| ariaLabelledby | `string` | Allows you to specify an `aria-labelledby` attribute of the component. |
+| Name            | Type     | Description                                                             |
+| :-------------- | :------- | :---------------------------------------------------------------------- |
+| ariaLabel       | `string` | Allows you to specify an `aria-label` attribute of the component.       |
+| ariaLabelledby  | `string` | Allows you to specify an `aria-labelledby` attribute of the component.  |
+| ariaDescribedby | `string` | Allows you to specify an `aria-describedby` attribute of the component. |
 
 While these props are optional, we recommend including them to ensure proper accessibility of the component, especially if the `label` prop is not provided.
 
@@ -71,6 +72,21 @@ For better screen reader experience, you can always complement the `label` prop 
 
 For enhanced accessibility, it is recommended to have these label strings translated.
 
+The `ariaDescribedby` prop allows you to associate additional descriptive text with the Select component. This is useful for providing supplementary information that screen readers will announce after reading the component's label.
+
+```jsx
+  <Select
+    options={countryOptions}
+    value={countryValue}
+    onChange={onChange}
+    label="Country"
+    ariaDescribedby="country-info"
+  />
+  <p id="country-info" style={{ display: "none", visibility: "hidden" }}>
+    Select the country where you currently reside.
+  </p>
+```
+
 When using the `help` or `error` props, their content is set as `aria-describedby` on the element. Screen readers will announce this additional information after reading the component's label (whether provided via `label`, `ariaLabel`, or `ariaLabelledby` props).
 
 ```jsx
@@ -83,4 +99,72 @@ When using the `help` or `error` props, their content is set as `aria-describedb
 />
 ```
 
-It would have the screen reader announce: “Nationality. Required field.”.
+It would have the screen reader announce: "Nationality. Required field."
+
+If you provide both an `ariaDescribedby` prop and use `error` or `help`, the component automatically combines them, ensuring all descriptive content is properly announced:
+
+```jsx
+  <p id="terms-info" style={{ display: "none", visibility: "hidden" }}>
+    Please review our terms and conditions.
+  </p>
+  <Select
+    options={termsOptions}
+    value={termsValue}
+    onChange={onChange}
+    label="Accept Terms"
+    error="This field is required"
+    ariaDescribedby="terms-info"
+  />
+```
+
+In this example, both the "terms-info" text and the error message will be announced by screen readers. The text from `ariaDescribedby` will be announced first, followed by the text from `error`.
+
+### InputGroup Integration
+
+When using Select within an InputGroup, the `aria-describedby` association follows these rules:
+
+#### Example 1
+
+If the InputGroup has `error`/`help` messages, these will be properly associated with all child components:
+
+```jsx
+<InputGroup label="Travel preferences" error="Please complete all fields">
+  <Select options={countryOptions} label="Departure country" />
+  <Select options={countryOptions} label="Destination country" />
+</InputGroup>
+```
+
+In this example, all Select components will have the InputGroup's error message "Please complete all fields" announced by screen readers.
+
+#### Example 2
+
+If individual Select components have their own `error`/`help` messages (and the InputGroup doesn't), only those specific components will have `aria-describedby` set:
+
+```jsx
+<InputGroup label="Travel preferences">
+  <Select options={countryOptions} label="Departure country" />
+  <Select options={countryOptions} label="Destination country" error="This field is required" />
+</InputGroup>
+```
+
+In this example, only the second Select will have its error message "This field is required" announced.
+
+#### Example 3
+
+Avoid setting `ariaDescribedby` directly on Select components when inside an InputGroup, as these values will be overwritten by the InputGroup's internal accessibility logic:
+
+```jsx
+<InputGroup label="Contact information">
+  <Select
+    options={countryOptions}
+    label="Country"
+    ariaDescribedby="country-hint" // This will be overwritten
+  />
+  <InputField label="Phone number" />
+  <p id="country-hint" style={{ display: "none", visibility: "hidden" }}>
+    Select the country prefix of your phone number
+  </p>
+</InputGroup>
+```
+
+In this example, the `ariaDescribedby` value "country-hint" will be ignored because the InputGroup manages the accessibility associations internally. Instead, rely on the InputGroup's `error`/`help` props or the component's own `error`/`help` props.

--- a/packages/orbit-components/src/InputField/README.md
+++ b/packages/orbit-components/src/InputField/README.md
@@ -64,6 +64,7 @@ The table below contains all types of props available in the InputField componen
 | ariaControls         | `string`                           |           | The aria-controls attribute of the input, see [this docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls).                              |
 | ariaLabel            | `string`                           |           | Optional prop for `aria-label` value. See `Accessibility` tab.                                                                                                                    |
 | ariaLabelledby       | `string`                           |           | Optional prop for `aria-labelledby` value. See `Accessibility` tab.                                                                                                               |
+| ariaDescribedby      | `string`                           |           | Optional prop for `aria-describedby` value. See `Accessibility` tab.                                                                                                              |
 
 ### enum
 

--- a/packages/orbit-components/src/InputField/index.tsx
+++ b/packages/orbit-components/src/InputField/index.tsx
@@ -249,7 +249,10 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             "[&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
             "[&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:m-0",
             "[&[data-com-onepassword-filled]]:!bg-inherit",
-            "peer focus:outline-none",
+            "peer",
+            insideInputGroup
+              ? "focus:outline-blue-normal focus:rounded-150 focus:tb:rounded-100 duration-fast transition-all ease-in-out focus:outline-2 focus:-outline-offset-1"
+              : "focus:outline-none",
             "[&::placeholder]:opacity-100",
             "[&::placeholder]:text-form-element-foreground",
             "[&::-ms-input-placeholder]:text-form-element-foreground",

--- a/packages/orbit-components/src/InputField/index.tsx
+++ b/packages/orbit-components/src/InputField/index.tsx
@@ -116,6 +116,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
     ariaHasPopup,
     ariaExpanded,
     ariaControls,
+    ariaDescribedby,
     autoFocus,
     spaceAfter,
     id,
@@ -146,6 +147,12 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
 
   const InlineLabelElement = inlineLabel && (error || help || label) ? "label" : "div";
 
+  const tooltipId = shown ? `${inputId}-feedback` : undefined;
+
+  const ariaDescribedbyValue = insideInputGroup
+    ? ariaDescribedby
+    : [ariaDescribedby, tooltipId].filter(Boolean).join(" ") || undefined;
+
   return (
     <div
       className={cx(
@@ -165,8 +172,8 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             help={!!help}
             labelRef={labelRef}
             iconRef={iconRef}
-            onMouseEnter={() => setTooltipShownHover(true)}
-            onMouseLeave={() => setTooltipShownHover(false)}
+            onMouseEnter={() => (hasTooltip ? setTooltipShownHover(true) : undefined)}
+            onMouseLeave={() => (hasTooltip ? setTooltipShownHover(false) : undefined)}
           >
             {label}
           </FormLabel>
@@ -283,7 +290,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
           list={list}
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledby}
-          aria-describedby={shown ? `${inputId}-feedback` : undefined}
+          aria-describedby={ariaDescribedbyValue}
           aria-invalid={error ? true : undefined}
           aria-autocomplete={ariaAutocomplete}
           aria-haspopup={ariaHasPopup}
@@ -307,7 +314,7 @@ const InputField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
       {!insideInputGroup && hasTooltip && (
         <ErrorFormTooltip
           help={help}
-          id={`${inputId}-feedback`}
+          id={tooltipId}
           shown={shown}
           onShown={setTooltipShown}
           error={error}

--- a/packages/orbit-components/src/InputField/types.d.ts
+++ b/packages/orbit-components/src/InputField/types.d.ts
@@ -56,4 +56,5 @@ export interface Props extends Common.Globals, Common.SpaceAfter, Common.DataAtt
   readonly ariaHasPopup?: boolean;
   readonly ariaExpanded?: boolean;
   readonly ariaControls?: string;
+  readonly ariaDescribedby?: string;
 }

--- a/packages/orbit-components/src/InputGroup/InputGroup.stories.tsx
+++ b/packages/orbit-components/src/InputGroup/InputGroup.stories.tsx
@@ -78,6 +78,7 @@ export const DateOfBirth: Story = {
     return (
       <InputGroup {...args}>
         <InputField
+          label="Day of birth"
           placeholder="DD"
           error={error}
           help={help}
@@ -92,7 +93,7 @@ export const DateOfBirth: Story = {
           value={value}
           placeholder="Month"
         />
-        <InputField placeholder="YYYY" />
+        <InputField label="Year of birth" placeholder="YYYY" />
       </InputGroup>
     );
   },
@@ -128,19 +129,25 @@ export const PhoneNumber: Story = {
     return (
       <InputGroup {...args}>
         <Select
-          label="Country"
+          label="Country prefix"
           options={selectOptionsPhoneNumber}
           value={selectValue}
           prefix={<CountryFlag code={code} name={label} />}
           error={error}
           help={help}
         />
-        <InputField placeholder={placeholder} maxLength={11} value={inputValue} />
+        <InputField
+          label="Phone number"
+          placeholder={placeholder}
+          maxLength={11}
+          value={inputValue}
+        />
       </InputGroup>
     );
   },
 
   args: {
+    label: "Phone number",
     flex: ["0 0 250px", "1 1 100%"],
     selectValue: selectOptionsPhoneNumber[0].value,
     placeholder: "e.g. 123 456 789",
@@ -182,7 +189,7 @@ export const Error: Story = {
 
     return (
       <InputGroup {...args}>
-        <InputField placeholder="DD" error={error} />
+        <InputField placeholder="DD" label="Day of birth" error={error} />
         <Select
           label="Month of birth"
           options={selectOptionsError}
@@ -191,7 +198,7 @@ export const Error: Story = {
           error="Something went wrong on month field"
           onChange={e => setValue(e.target.value)}
         />
-        <InputField placeholder="YYYY" />
+        <InputField placeholder="YYYY" label="Year of birth" />
       </InputGroup>
     );
   },
@@ -203,7 +210,7 @@ export const Error: Story = {
   },
 
   args: {
-    label: "Label",
+    label: "Date of birth",
     flex: ["0 0 60px", "1 1 100%", "0 0 90px"],
     selectValue: selectOptionsError[0].value,
     error: "Something went wrong on day field",
@@ -234,7 +241,7 @@ export const ValidationApproaches: Story = {
         <InputField placeholder="b" maxLength={11} value={inputValue} />
       </InputGroup>
 
-      <InputGroup label="Events and states on children" error={errorGroup} help={helpGroup}>
+      <InputGroup label="Events and states on children">
         <InputField
           placeholder="c"
           maxLength={11}
@@ -405,7 +412,7 @@ export const Rtl: Story = {
     return (
       <RenderInRtl>
         <InputGroup {...args}>
-          <InputField placeholder="DD" help={help} error={error} />
+          <InputField label="Day of birth" placeholder="DD" help={help} error={error} />
           <Select
             options={selectOptionsMonths}
             onChange={e => setValue(e.target.value)}
@@ -413,7 +420,7 @@ export const Rtl: Story = {
             placeholder="Month"
             label="Month of birth"
           />
-          <InputField placeholder="YYYY" />
+          <InputField label="Year of birth" placeholder="YYYY" />
         </InputGroup>
       </RenderInRtl>
     );

--- a/packages/orbit-components/src/InputGroup/README.md
+++ b/packages/orbit-components/src/InputGroup/README.md
@@ -21,20 +21,22 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in InputGroup component.
 
-| Name         | Type                        | Default      | Description                                                                                                         |
-| :----------- | :-------------------------- | :----------- | :------------------------------------------------------------------------------------------------------------------ |
-| **children** | `React.Node`                |              | The content of the InputGroup, normally **InputField** or **Select**.                                               |
-| dataTest     | `string`                    |              | Optional prop for testing purposes.                                                                                 |
-| id           | `string`                    |              | Set `id` for `InputGroup`                                                                                           |
-| error        | `React.Node`                |              | The error to display beneath the InputGroup. [See Functional specs](#functional-specs)                              |
-| disabled     | `boolean`                   |              | Whether to disable all nested fields.                                                                               |
-| flex         | `string` or `Array<string>` | `"0 1 auto"` | The flex attribute(s) for children of the InputGroup. [See Functional specs](#functional-specs)                     |
-| label        | `Translation`               |              | The label for the InputGroup. [See Functional specs](#functional-specs)                                             |
-| onChange     | `event => void \| Promise`  |              | Function for handling onClick event. [See Functional specs](#functional-specs)                                      |
-| onFocus      | `event => void \| Promise`  |              | Function for handling onFocus event. [See Functional specs](#functional-specs)                                      |
-| onBlur       | `event => void \| Promise`  |              | Function for handling onBlur event between different InputGroup children. [See Functional specs](#functional-specs) |
-| onBlurGroup  | `event => void \| Promise`  |              | Function for handling onBlur event for the whole InputGroup. [See Functional specs](#functional-specs)              |
-| spaceAfter   | `enum`                      |              | Additional `margin-bottom` after component.                                                                         |
+| Name           | Type                        | Default      | Description                                                                                                         |
+| :------------- | :-------------------------- | :----------- | :------------------------------------------------------------------------------------------------------------------ |
+| **children**   | `React.Node`                |              | The content of the InputGroup, normally **InputField** or **Select**.                                               |
+| dataTest       | `string`                    |              | Optional prop for testing purposes.                                                                                 |
+| id             | `string`                    |              | Set `id` for `InputGroup`                                                                                           |
+| error          | `React.Node`                |              | The error to display beneath the InputGroup. [See Functional specs](#functional-specs)                              |
+| disabled       | `boolean`                   |              | Whether to disable all nested fields.                                                                               |
+| flex           | `string` or `Array<string>` | `"0 1 auto"` | The flex attribute(s) for children of the InputGroup. [See Functional specs](#functional-specs)                     |
+| label          | `Translation`               |              | The label for the InputGroup. [See Functional specs](#functional-specs)                                             |
+| onChange       | `event => void \| Promise`  |              | Function for handling onClick event. [See Functional specs](#functional-specs)                                      |
+| onFocus        | `event => void \| Promise`  |              | Function for handling onFocus event. [See Functional specs](#functional-specs)                                      |
+| onBlur         | `event => void \| Promise`  |              | Function for handling onBlur event between different InputGroup children. [See Functional specs](#functional-specs) |
+| onBlurGroup    | `event => void \| Promise`  |              | Function for handling onBlur event for the whole InputGroup. [See Functional specs](#functional-specs)              |
+| spaceAfter     | `enum`                      |              | Additional `margin-bottom` after component.                                                                         |
+| ariaLabel      | `string`                    |              | Optional prop for `aria-label` value.                                                                               |
+| ariaLabelledby | `string`                    |              | Optional prop for `aria-labelledby` value.                                                                          |
 
 ### enum
 

--- a/packages/orbit-components/src/InputGroup/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/InputGroup/__tests__/index.test.tsx
@@ -72,7 +72,7 @@ describe("InputGroup", () => {
   });
 
   it("should have ref", () => {
-    const ref = React.createRef<HTMLDivElement>();
+    const ref = React.createRef<HTMLFieldSetElement>();
 
     render(
       <InputGroup ref={ref}>

--- a/packages/orbit-components/src/InputGroup/index.tsx
+++ b/packages/orbit-components/src/InputGroup/index.tsx
@@ -129,7 +129,6 @@ const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
           <div
             className={cx(
               "text-normal h-form-box-normal duration-fast rounded-150 tb:rounded-100 z-default w-full transition-shadow ease-in-out",
-              active && "outline-blue-normal outline outline-2",
               disabled ? "bg-form-element-disabled-background" : "bg-form-element-background",
               !errorReal && "shadow-form-element",
               !errorReal && !disabled && "hover:shadow-form-element-hover",
@@ -142,9 +141,14 @@ const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
                 // TODO: next cleanup iteration just remove this whole `flex` prop thing
                 // and cloning elements, and make children take care of their sizing themselves
 
-                const childFlex = (
-                  Array.isArray(flex) && flex.length !== 1 ? flex[key] ?? flex[0] : flex
-                ) as string | undefined;
+                const childrenCount = React.Children.count(children);
+                const isLastChild = key === childrenCount - 1;
+                const flexArray = Array.isArray(flex) ? flex : [flex];
+
+                let childFlex = flex ? flexArray[key] || flexArray[0] : undefined;
+                if (isLastChild && flexArray.length !== childrenCount) {
+                  childFlex = "1 1 100%";
+                }
 
                 const item = child as React.ReactElement<InputFieldProps | SelectProps>;
 
@@ -152,7 +156,7 @@ const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
                   <div
                     key={randomId(String(key))}
                     className={cx(
-                      "orbit-input-group-child pe-200 last:p-0 [&_.orbit-input-field-fake-input]:hidden [&_.orbit-input-field-fake-input]:bg-transparent [&_.orbit-input-field-input~.orbit-input-field-fake-input]:shadow-none [&_.orbit-select-container_select]:bg-transparent [&_.orbit-select-container_select]:shadow-none [&_.orbit-select-container_select]:focus:outline-none",
+                      "orbit-input-group-child [&_.orbit-input-field-fake-input]:hidden [&_.orbit-input-field-fake-input]:bg-transparent [&_.orbit-input-field-input~.orbit-input-field-fake-input]:shadow-none [&_.orbit-select-container_select]:bg-transparent [&_.orbit-select-container_select]:shadow-none [&_.orbit-select-container_select]:focus:outline-none",
                       // InputField:after
                       "[&_.orbit-input-field-input-container]:after:duration-fast [&_.orbit-input-field-input-container]:after:z-default [&_.orbit-input-field-input-container]:after:h-600 [&_.orbit-input-field-input-container]:after:absolute [&_.orbit-input-field-input-container]:after:end-0 [&_.orbit-input-field-input-container]:after:top-1/2 [&_.orbit-input-field-input-container]:after:block [&_.orbit-input-field-input-container]:after:-translate-y-1/2 [&_.orbit-input-field-input-container]:after:border-r [&_.orbit-input-field-input-container]:after:transition-colors [&_.orbit-input-field-input-container]:after:ease-in-out [&_.orbit-input-field-input-container]:last-of-type:after:content-none",
                       // Select:after

--- a/packages/orbit-components/src/InputGroup/index.tsx
+++ b/packages/orbit-components/src/InputGroup/index.tsx
@@ -50,8 +50,10 @@ const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
     const errorReal = error || (foundErrors.length > 0 && foundErrors[0]);
     const helpReal = help || (foundHelp.length > 0 && foundHelp[0]);
     const randomId = useRandomIdSeed();
+    const feedbackId = useRandomId();
 
     const hasTooltip = errorReal || helpReal;
+    const shown = tooltipShown || tooltipShownHover;
 
     const handleFocus =
       callBack =>
@@ -166,6 +168,10 @@ const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
                       onFocus: handleFocus(item.props.onFocus),
                       ariaLabel: item.props.label as string,
                       insideInputGroup: true,
+                      ariaDescribedby:
+                        (error || help || item.props.error || item.props.help) && shown
+                          ? feedbackId
+                          : undefined,
                     })}
                   </div>
                 );
@@ -174,10 +180,11 @@ const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
           </div>
         </fieldset>
         <ErrorFormTooltip
+          id={feedbackId}
           help={helpReal}
           error={errorReal}
           onShown={setTooltipShown}
-          shown={tooltipShown || tooltipShownHover}
+          shown={shown}
           referenceElement={labelRef}
         />
       </div>

--- a/packages/orbit-components/src/InputGroup/index.tsx
+++ b/packages/orbit-components/src/InputGroup/index.tsx
@@ -34,6 +34,8 @@ const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
       onBlur,
       onChange,
       onBlurGroup,
+      ariaLabel,
+      ariaLabelledby,
     },
     ref,
   ) => {
@@ -105,6 +107,8 @@ const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
           id={id}
           data-test={dataTest}
           data-state={getFieldDataState(!!errorReal)}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledby}
         >
           {label && (
             <legend>

--- a/packages/orbit-components/src/InputGroup/index.tsx
+++ b/packages/orbit-components/src/InputGroup/index.tsx
@@ -18,7 +18,7 @@ const findPropInChild = (propToFind, children) =>
     return null;
   }).filter(el => el != null);
 
-const InputGroup = React.forwardRef<HTMLDivElement, Props>(
+const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
   (
     {
       children,
@@ -50,6 +50,8 @@ const InputGroup = React.forwardRef<HTMLDivElement, Props>(
     const errorReal = error || (foundErrors.length > 0 && foundErrors[0]);
     const helpReal = help || (foundHelp.length > 0 && foundHelp[0]);
     const randomId = useRandomIdSeed();
+
+    const hasTooltip = errorReal || helpReal;
 
     const handleFocus =
       callBack =>
@@ -91,83 +93,86 @@ const InputGroup = React.forwardRef<HTMLDivElement, Props>(
 
     return (
       <div
-        ref={ref}
-        id={id}
-        data-test={dataTest}
-        data-state={getFieldDataState(!!errorReal)}
-        aria-labelledby={label != null ? inputID : undefined}
-        role="group"
         className={cx(
           "relative flex w-full flex-col",
           spaceAfter != null && getSpaceAfterClasses(spaceAfter),
         )}
       >
-        {label && (
-          <FormLabel
-            id={inputID}
-            labelRef={labelRef}
-            error={!!errorReal}
-            help={!!helpReal}
-            iconRef={iconRef}
-            onMouseEnter={() => setTooltipShownHover(true)}
-            onMouseLeave={() => setTooltipShownHover(false)}
-          >
-            {label}
-          </FormLabel>
-        )}
-
-        <div
-          className={cx(
-            "text-normal h-form-box-normal duration-fast rounded-150 tb:rounded-100 z-default w-full transition-shadow ease-in-out",
-            active && "outline-blue-normal outline outline-2",
-            disabled ? "bg-form-element-disabled-background" : "bg-form-element-background",
-            !errorReal && "shadow-form-element",
-            !errorReal && !disabled && "hover:shadow-form-element-hover",
-            Boolean(errorReal) && "shadow-form-element-error",
-            Boolean(errorReal) && !disabled && "hover:shadow-form-element-error-hover",
-          )}
+        <fieldset
+          ref={ref}
+          id={id}
+          data-test={dataTest}
+          data-state={getFieldDataState(!!errorReal)}
         >
-          <div className="relative flex" onBlur={handleBlurGroup}>
-            {React.Children.toArray(children).map((child, key) => {
-              // TODO: next cleanup iteration just remove this whole `flex` prop thing
-              // and cloning elements, and make children take care of their sizing themselves
+          {label && (
+            <legend>
+              <FormLabel
+                id={inputID}
+                labelRef={labelRef}
+                error={!!errorReal}
+                help={!!helpReal}
+                iconRef={iconRef}
+                onMouseEnter={() => (hasTooltip ? setTooltipShownHover(true) : undefined)}
+                onMouseLeave={() => (hasTooltip ? setTooltipShownHover(false) : undefined)}
+              >
+                {label}
+              </FormLabel>
+            </legend>
+          )}
 
-              const childFlex = (
-                Array.isArray(flex) && flex.length !== 1 ? flex[key] ?? flex[0] : flex
-              ) as string | undefined;
+          <div
+            className={cx(
+              "text-normal h-form-box-normal duration-fast rounded-150 tb:rounded-100 z-default w-full transition-shadow ease-in-out",
+              active && "outline-blue-normal outline outline-2",
+              disabled ? "bg-form-element-disabled-background" : "bg-form-element-background",
+              !errorReal && "shadow-form-element",
+              !errorReal && !disabled && "hover:shadow-form-element-hover",
+              Boolean(errorReal) && "shadow-form-element-error",
+              Boolean(errorReal) && !disabled && "hover:shadow-form-element-error-hover",
+            )}
+          >
+            <div className="relative flex" onBlur={handleBlurGroup}>
+              {React.Children.toArray(children).map((child, key) => {
+                // TODO: next cleanup iteration just remove this whole `flex` prop thing
+                // and cloning elements, and make children take care of their sizing themselves
 
-              const item = child as React.ReactElement<InputFieldProps | SelectProps>;
+                const childFlex = (
+                  Array.isArray(flex) && flex.length !== 1 ? flex[key] ?? flex[0] : flex
+                ) as string | undefined;
 
-              return (
-                <div
-                  key={randomId(String(key))}
-                  className={cx(
-                    "orbit-input-group-child pe-200 last:p-0 [&_.orbit-input-field-fake-input]:hidden [&_.orbit-input-field-fake-input]:bg-transparent [&_.orbit-input-field-input~.orbit-input-field-fake-input]:shadow-none [&_.orbit-select-container_select]:bg-transparent [&_.orbit-select-container_select]:shadow-none [&_.orbit-select-container_select]:focus:outline-none",
-                    // InputField:after
-                    "[&_.orbit-input-field-input-container]:after:duration-fast [&_.orbit-input-field-input-container]:after:z-default [&_.orbit-input-field-input-container]:after:h-600 [&_.orbit-input-field-input-container]:after:absolute [&_.orbit-input-field-input-container]:after:end-0 [&_.orbit-input-field-input-container]:after:top-1/2 [&_.orbit-input-field-input-container]:after:block [&_.orbit-input-field-input-container]:after:-translate-y-1/2 [&_.orbit-input-field-input-container]:after:border-r [&_.orbit-input-field-input-container]:after:transition-colors [&_.orbit-input-field-input-container]:after:ease-in-out [&_.orbit-input-field-input-container]:last-of-type:after:content-none",
-                    // Select:after
-                    "[&_.orbit-select-container]:after:duration-fast [&_.orbit-select-container]:after:h-600 [&_.orbit-select-container]:bg-transparent [&_.orbit-select-container]:after:absolute [&_.orbit-select-container]:after:end-0 [&_.orbit-select-container]:after:top-1/2 [&_.orbit-select-container]:after:z-[2] [&_.orbit-select-container]:after:block [&_.orbit-select-container]:after:-translate-y-1/2 [&_.orbit-select-container]:after:border-r [&_.orbit-select-container]:after:transition-colors [&_.orbit-select-container]:after:ease-in-out [&_.orbit-select-container]:last-of-type:after:content-none",
-                    Boolean(errorReal) && !active
-                      ? "[&_.orbit-select-container]:after:border-form-element-error [&_.orbit-input-field-input-container]:after:border-form-element-error"
-                      : "[&_.orbit-select-container]:after:border-form-element [&_.orbit-input-field-input-container]:after:border-form-element",
-                    label != null && "[&_.orbit-form-label]:hidden",
-                  )}
-                  style={{ flex: childFlex }}
-                >
-                  {React.cloneElement(item, {
-                    disabled: item.props.disabled || disabled,
-                    label: undefined,
-                    onChange: handleChange(item.props.onChange),
-                    onBlur: handleBlur(item.props.onBlur),
-                    onFocus: handleFocus(item.props.onFocus),
-                    ariaLabel: item.props.label as string,
-                    insideInputGroup: true,
-                  })}
-                </div>
-              );
-            })}
+                const item = child as React.ReactElement<InputFieldProps | SelectProps>;
+
+                return (
+                  <div
+                    key={randomId(String(key))}
+                    className={cx(
+                      "orbit-input-group-child pe-200 last:p-0 [&_.orbit-input-field-fake-input]:hidden [&_.orbit-input-field-fake-input]:bg-transparent [&_.orbit-input-field-input~.orbit-input-field-fake-input]:shadow-none [&_.orbit-select-container_select]:bg-transparent [&_.orbit-select-container_select]:shadow-none [&_.orbit-select-container_select]:focus:outline-none",
+                      // InputField:after
+                      "[&_.orbit-input-field-input-container]:after:duration-fast [&_.orbit-input-field-input-container]:after:z-default [&_.orbit-input-field-input-container]:after:h-600 [&_.orbit-input-field-input-container]:after:absolute [&_.orbit-input-field-input-container]:after:end-0 [&_.orbit-input-field-input-container]:after:top-1/2 [&_.orbit-input-field-input-container]:after:block [&_.orbit-input-field-input-container]:after:-translate-y-1/2 [&_.orbit-input-field-input-container]:after:border-r [&_.orbit-input-field-input-container]:after:transition-colors [&_.orbit-input-field-input-container]:after:ease-in-out [&_.orbit-input-field-input-container]:last-of-type:after:content-none",
+                      // Select:after
+                      "[&_.orbit-select-container]:after:duration-fast [&_.orbit-select-container]:after:h-600 [&_.orbit-select-container]:bg-transparent [&_.orbit-select-container]:after:absolute [&_.orbit-select-container]:after:end-0 [&_.orbit-select-container]:after:top-1/2 [&_.orbit-select-container]:after:z-[2] [&_.orbit-select-container]:after:block [&_.orbit-select-container]:after:-translate-y-1/2 [&_.orbit-select-container]:after:border-r [&_.orbit-select-container]:after:transition-colors [&_.orbit-select-container]:after:ease-in-out [&_.orbit-select-container]:last-of-type:after:content-none",
+                      Boolean(errorReal) && !active
+                        ? "[&_.orbit-select-container]:after:border-form-element-error [&_.orbit-input-field-input-container]:after:border-form-element-error"
+                        : "[&_.orbit-select-container]:after:border-form-element [&_.orbit-input-field-input-container]:after:border-form-element",
+                      label != null && "[&_.orbit-form-label]:hidden",
+                    )}
+                    style={{ flex: childFlex }}
+                  >
+                    {React.cloneElement(item, {
+                      disabled: item.props.disabled || disabled,
+                      label: undefined,
+                      onChange: handleChange(item.props.onChange),
+                      onBlur: handleBlur(item.props.onBlur),
+                      onFocus: handleFocus(item.props.onFocus),
+                      ariaLabel: item.props.label as string,
+                      insideInputGroup: true,
+                    })}
+                  </div>
+                );
+              })}
+            </div>
           </div>
-        </div>
+        </fieldset>
         <ErrorFormTooltip
           help={helpReal}
           error={errorReal}

--- a/packages/orbit-components/src/InputGroup/types.d.ts
+++ b/packages/orbit-components/src/InputGroup/types.d.ts
@@ -22,4 +22,6 @@ export interface Props extends Common.Globals, Common.SpaceAfter {
   readonly onBlur?: React.FocusEventHandler<
     HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
   >;
+  readonly ariaLabel?: string;
+  readonly ariaLabelledby?: string;
 }

--- a/packages/orbit-components/src/Select/README.md
+++ b/packages/orbit-components/src/Select/README.md
@@ -42,6 +42,7 @@ Table below contains all types of the props available in the Select component.
 | customValueText | `string`                   |         | The custom text alternative of current value. [See Functional specs](#functional-specs). |
 | ariaLabel       | `string`                   |         | Optional prop for `aria-label` value. See Accessibility tab.                             |
 | ariaLabelledby  | `string`                   |         | Optional prop for `aria-labelledby` value. See Accessibility tab.                        |
+| ariaDescribedby | `string`                   |         | Optional prop for `aria-describedby` value. See Accessibility tab.                       |
 
 ### enum
 

--- a/packages/orbit-components/src/Select/index.tsx
+++ b/packages/orbit-components/src/Select/index.tsx
@@ -41,6 +41,7 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
     dataAttrs,
     ariaLabel,
     ariaLabelledby,
+    ariaDescribedby,
   } = props;
   const filled = !(value == null || value === "");
 
@@ -62,6 +63,11 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
   const inputRef = React.useRef<HTMLLabelElement | null>(null);
 
   const shown = tooltipShown || tooltipShownHover;
+  const tooltipId = shown ? `${selectId}-feedback` : undefined;
+
+  const ariaDescribedbyValue = insideInputGroup
+    ? ariaDescribedby
+    : [ariaDescribedby, tooltipId].filter(Boolean).join(" ") || undefined;
 
   return (
     <div
@@ -78,8 +84,8 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
             help={!!help}
             labelRef={labelRef}
             iconRef={iconRef}
-            onMouseEnter={() => setTooltipShownHover(true)}
-            onMouseLeave={() => setTooltipShownHover(false)}
+            onMouseEnter={() => (hasTooltip ? setTooltipShownHover(true) : undefined)}
+            onMouseLeave={() => (hasTooltip ? setTooltipShownHover(false) : undefined)}
             required={required}
           >
             {label}
@@ -179,7 +185,7 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
               tabIndex={tabIndex ? Number(tabIndex) : undefined}
               required={required}
               ref={ref}
-              aria-describedby={shown ? `${selectId}-feedback` : undefined}
+              aria-describedby={ariaDescribedbyValue}
               aria-invalid={error ? true : undefined}
               aria-label={ariaLabel}
               aria-labelledby={ariaLabelledby}
@@ -216,7 +222,7 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
       </label>
       {!insideInputGroup && hasTooltip && (
         <ErrorFormTooltip
-          id={`${selectId}-feedback`}
+          id={tooltipId}
           help={help}
           error={error}
           shown={shown}

--- a/packages/orbit-components/src/Select/index.tsx
+++ b/packages/orbit-components/src/Select/index.tsx
@@ -218,7 +218,7 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
                 : "text-form-element-filled-foreground",
             )}
           >
-            <ChevronDown color="secondary" />
+            <ChevronDown color="secondary" ariaHidden />
           </div>
           <FakeInput disabled={disabled} error={error} />
         </div>

--- a/packages/orbit-components/src/Select/index.tsx
+++ b/packages/orbit-components/src/Select/index.tsx
@@ -159,7 +159,10 @@ const Select = React.forwardRef<HTMLSelectElement, Props>((props, ref) => {
             )}
             <select
               className={cx(
-                "cursor-pointer appearance-none bg-transparent outline-none",
+                "cursor-pointer appearance-none bg-transparent",
+                insideInputGroup
+                  ? "focus:outline-blue-normal focus:rounded-150 focus:tb:rounded-100 focus:outline-2 focus:outline-offset-0"
+                  : "outline-none",
                 filled ? "text-form-element-filled-foreground" : "text-form-element-foreground",
                 "font-base text-form-element-normal",
                 "pe-1000",

--- a/packages/orbit-components/src/Select/types.d.ts
+++ b/packages/orbit-components/src/Select/types.d.ts
@@ -36,4 +36,5 @@ export interface Props extends Common.Globals, Common.SpaceAfter, Common.DataAtt
   readonly customValueText?: Common.Translation;
   readonly ariaLabel?: string;
   readonly ariaLabelledby?: string;
+  readonly ariaDescribedby?: string;
 }


### PR DESCRIPTION
I replaced outer div with `fieldset` for better accessibility - `fieldset` has role "group" and is setting label from legend so it's not necessary to set it separately via `aria-labelledby`. I added new props `ariaLabel` and `ariaLabelledby`.

`aria-describedby` wasn't working properly as id of InputGroup's tooltip wasn't propagated to children and these were setting `aria-describedby` id to not visible tooltip. To fix this I added `ariaDescribedby` prop to both Select and InputField components and also did some refactoring as they were setting `shown` value even if component had no `error`/`help` which was adding `aria-describedby` prop incorrectly. As both already had Accessibility tab created, I added info about `ariaDescribedby` prop (it was matter of seconds with Cursor).

I removed focus indicator from the outer InputGroup wrapper (and did some other refactoring there) and refactored Select and InputField to display focus indicator even when inside InputGroup as this should be correct behavior.

Fixed stories.

Noticed bug inside Select (chevron icon was being read by screen reader) so I did small fix.

Closes https://kiwicom.atlassian.net/browse/FEPLT-2293

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR enhances accessibility for the InputGroup and its child components by introducing new props for ARIA attributes and refactoring existing code to ensure proper accessibility associations.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Screen Reader
    participant InputGroup
    participant InputField
    participant Select
    participant ErrorFormTooltip

    Note over InputGroup,Select: New Accessibility Flow

    InputGroup->>InputField: Set aria-describedby
    InputGroup->>Select: Set aria-describedby

    alt InputGroup has error/help
        InputGroup->>ErrorFormTooltip: Create tooltip with ID
        InputGroup->>InputField: Link to group tooltip
        InputGroup->>Select: Link to group tooltip
        Screen Reader->>InputGroup: Read group error/help message
    else Individual component has error/help
        InputField->>ErrorFormTooltip: Create component tooltip
        Select->>ErrorFormTooltip: Create component tooltip
        Screen Reader->>InputField: Read component error/help
        Screen Reader->>Select: Read component error/help
    end

    Note over InputGroup,Screen Reader: Combined Descriptions
    alt Both group and component messages exist
        Screen Reader->>InputGroup: Read group message first
        Screen Reader->>InputField: Then read component message
        Screen Reader->>Select: Then read component message
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4679/files#diff-2ad882504eac28fad21af9efb45f5506c134a3935b808531913e8f53914b7e09>docs/src/documentation/03-components/05-input/inputfield/03-accessibility.mdx</a></td><td>Updated documentation to include new <code>ariaDescribedby</code> prop and its usage examples.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4679/files#diff-dabc7c7accf066fd10c57cb9eb8c4a311fb66a0b333287aed98b13f143a67d77>docs/src/documentation/03-components/05-input/select/03-accessibility.mdx</a></td><td>Added documentation for the new <code>ariaDescribedby</code> prop in the Select component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4679/files#diff-b12bab43f299d4badaa7cc5aec122e2ea2ff4bd7302a9fa076c76b9ff89d0b06>packages/orbit-components/src/InputField/README.md</a></td><td>Documented the new <code>ariaDescribedby</code> prop in the InputField component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4679/files#diff-a22047902ec5dad314f04706476107ebd04df90a6577b33c7fdf40c9887e6355>packages/orbit-components/src/InputField/index.tsx</a></td><td>Implemented the <code>ariaDescribedby</code> prop in the InputField component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4679/files#diff-57fefd5d0ae43e5d10e62df7aa73be8d4237c139be050f358fc3c0a9891f032b>packages/orbit-components/src/InputGroup/index.tsx</a></td><td>Refactored InputGroup to use <code>fieldset</code> for better accessibility and added support for new ARIA props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4679/files#diff-20126b7c9184dcfd6338647a40e574b48fc234a828dbd6397344997bf60d1917>packages/orbit-components/src/Select/README.md</a></td><td>Updated documentation to include the new <code>ariaDescribedby</code> prop for the Select component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4679/files#diff-61824b9b2a0a9e5ee91f1145d6f2fda89d4bf4351b49ec38337904222f02eb91>packages/orbit-components/src/Select/index.tsx</a></td><td>Implemented the <code>ariaDescribedby</code> prop in the Select component.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->
























