### PR TITLE
chore: adjust type files to templates

### DIFF
--- a/packages/orbit-components/src/AirportIllustration/types.d.ts
+++ b/packages/orbit-components/src/AirportIllustration/types.d.ts
@@ -11,6 +11,7 @@ type Name =
   | "PRGSmartPass"
   | "VCESmartPass";
 
+// Interface content is fetched from /src/Illustration/TYPESCRIPT_TEMPLATE.template
 export interface Props extends Common.Globals, Common.SpaceAfter {
   readonly size?: "extraSmall" | "small" | "medium" | "large" | "display";
   readonly name: Name;

--- a/packages/orbit-components/src/Illustration/types.d.ts
+++ b/packages/orbit-components/src/Illustration/types.d.ts
@@ -107,7 +107,7 @@ export type Name =
 // TODO: remove spaceAfter in the next major version
 /** SpaceAfter is deprecated, use margin instead */
 
-// Interface content is fetched from /src/Illustration/TYPESCRIPT_TEMPLATE.template.
+// Interface content is fetched from /src/Illustration/TYPESCRIPT_TEMPLATE.template
 export interface Props extends Common.Globals, Common.SpaceAfter {
   readonly size?: "extraSmall" | "small" | "medium" | "large" | "display";
   readonly name: Name;


### PR DESCRIPTION
Diff generated after running `yarn components build`.

This diff prevented lerna from publishing releases.


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adjusts type files to templates, ensuring that the interface content is correctly referenced from the specified template file.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Types
    participant Template
    
    Note over Types: Adding documentation about<br/>interface source
    Types->>Template: Fetch interface content from<br/>TYPESCRIPT_TEMPLATE.template
    Note over Types: Applied to both:<br/>- AirportIllustration/types.d.ts<br/>- Illustration/types.d.ts
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4680/files#diff-3436a93a1f5a0a93e298a3183547434ac6bd96c4cb7ee7e3ea1b6c7546c4ccc4>packages/orbit-components/src/AirportIllustration/types.d.ts</a></td><td>Added a comment indicating that the interface content is fetched from a template.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4680/files#diff-e4ad7de091dfabd7af58496dd3c717f49e3c5445e2eb73da7c02e385a8f5558a>packages/orbit-components/src/Illustration/types.d.ts</a></td><td>Updated a comment to remove the period at the end of the sentence referencing the template.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


