### PR TITLE
Breadcrumbs accessibility

### DIFF
--- a/packages/orbit-components/src/Breadcrumbs/README.md
+++ b/packages/orbit-components/src/Breadcrumbs/README.md
@@ -21,13 +21,13 @@ The Table below contains all types of props available in the Breadcrumbs compone
 | Name         | Type                       | Default  | Description                                                                                                                |
 | :----------- | :------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------- |
 | dataTest     | `string`                   |          | Optional prop for testing purposes.                                                                                        |
-| id           | `string`                   |          | Set `id` for `Breadcrumbs`                                                                                                 |
+| id           | `string`                   |          | Set `id` for `Breadcrumbs`.                                                                                                |
 | **children** | `React.Node`               |          | The content of the Breadcrumbs, normally [`BreadcrumbsItem`](#breadcrumbsitem).                                            |
 | onGoBack     | `event => void \| Promise` |          | Callback for handling back button action. If present the back button is visible.                                           |
 | backHref     | `string`                   |          | The location for the back button to direct to. Turns the back button into a link when present (renders as an `a` element). |
 | goBackTitle  | `React.Node`               | `"Back"` | Translation string for the go back link on mobile, defined when onGoBack is defined.                                       |
-|              |
 | spaceAfter   | `enum`                     |          | Additional `margin-bottom` after component.                                                                                |
+| ariaLabel    | `string`                   |          | Optional prop for `aria-label`.                                                                                            |
 
 ### enum
 

--- a/packages/orbit-components/src/Breadcrumbs/index.tsx
+++ b/packages/orbit-components/src/Breadcrumbs/index.tsx
@@ -18,6 +18,7 @@ const Breadcrumbs = ({
   spaceAfter,
   backHref,
   id,
+  ariaLabel = "Breadcrumb",
 }: Props) => {
   const childEls = React.Children.toArray(children) as React.ReactElement<BreadcrumbsItemProps>[];
 
@@ -26,7 +27,7 @@ const Breadcrumbs = ({
       <Hide on={["smallMobile", "mediumMobile"]}>
         <nav
           className={cx("font-base text-small", spaceAfter && spaceAfterClasses[spaceAfter])}
-          aria-label="Breadcrumb"
+          aria-label={ariaLabel}
           id={id}
           data-test={dataTest}
         >

--- a/packages/orbit-components/src/Breadcrumbs/types.d.ts
+++ b/packages/orbit-components/src/Breadcrumbs/types.d.ts
@@ -10,4 +10,5 @@ export interface Props extends Common.Globals, Common.SpaceAfter {
   readonly goBackTitle?: React.ReactNode;
   readonly onGoBack?: Common.Event<React.SyntheticEvent<HTMLAnchorElement>>;
   readonly backHref?: string;
+  readonly ariaLabel?: string;
 }


### PR DESCRIPTION
Closes 
https://kiwicom.atlassian.net/browse/FEPLT-2278

# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds an `ariaLabel` prop to the `Breadcrumbs` component for improved accessibility and updates the README to reflect this change.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant User
    participant Breadcrumbs
    participant Screen Reader

    Note over Breadcrumbs: Added new props:<br/>- id<br/>- ariaLabel

    User->>Breadcrumbs: Interact with component
    Breadcrumbs->>Screen Reader: Provide aria-label="Breadcrumb"<br/>(default value)
    Note over Screen Reader: Improved accessibility<br/>through ARIA labeling
    
    alt Custom ARIA Label
        User->>Breadcrumbs: Set custom ariaLabel prop
        Breadcrumbs->>Screen Reader: Provide custom aria-label
    end

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4684/files#diff-a4d60f545535556db0cca3d683d8b4c510b0532cfaa0a794d8e8c422c3bd77bf>packages/orbit-components/src/Breadcrumbs/README.md</a></td><td>Updated the README to include the new <code>ariaLabel</code> prop for the <code>Breadcrumbs</code> component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4684/files#diff-1dca16bc6c20c6c483cbab0b7a24bc9c66546a623a97887f5106b3b1a9a40d41>packages/orbit-components/src/Breadcrumbs/index.tsx</a></td><td>Added <code>ariaLabel</code> prop to the <code>Breadcrumbs</code> component and used it in the <code>aria-label</code> attribute.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4684/files#diff-f3ad713147ece9c84237e5e3f3405699900afcb258bc0df3d2b908689178197c>packages/orbit-components/src/Breadcrumbs/types.d.ts</a></td><td>Updated the <code>Props</code> interface to include the new <code>ariaLabel</code> prop.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






