### PR TITLE
NavigationBar accessibility

### DIFF
--- a/docs/src/documentation/05-development/04-migration-guides/01-v23.mdx
+++ b/docs/src/documentation/05-development/04-migration-guides/01-v23.mdx
@@ -12,6 +12,12 @@ With this guide, we aim to walk through all the breaking changes and how they ca
 
 ## Breaking changes
 
+### Removal of ariaLabel prop in NavigationBar
+
+The `NavigationBar` component now renders a `header` element instead of a `nav` element, and the `ariaLabel` prop has been removed.
+
+If you're using `NavigationBar` with `ariaLabel`, you now need to set the `aria-label` attribute on the `nav` element(s) passed as children to `NavigationBar`.
+
 ### Title prop for Skeleton component
 
 The `Skeleton` component used to have a default value for the prop `title`. We have removed this default value.

--- a/packages/orbit-components/src/Box/README.md
+++ b/packages/orbit-components/src/Box/README.md
@@ -54,6 +54,7 @@ Table below contains all types of the props available in the Box component.
 | tablet       | [`MediaQueries`](#media-queries)                                     |         | Object for setting up properties for the tablet viewport.       |
 | largeMobile  | [`MediaQueries`](#media-queries)                                     |         | Object for setting up properties for the largeMobile viewport.  |
 | mediumMobile | [`MediaQueries`](#media-queries)                                     |         | Object for setting up properties for the mediumMobile viewport. |
+| ariaLabel    | `string`                                                             |         | Optional prop for setting `aria-label` attribute.               |
 
 ### Media Queries
 

--- a/packages/orbit-components/src/Box/TYPESCRIPT_TEMPLATE.template
+++ b/packages/orbit-components/src/Box/TYPESCRIPT_TEMPLATE.template
@@ -91,4 +91,5 @@ export interface Props extends Common.Globals {
   readonly largeDesktop?: MediaQueryObject;
   readonly children?: React.ReactNode;
   readonly className?: string; // Box is a only component where extending make sense
+  readonly ariaLabel?: string;
 }

--- a/packages/orbit-components/src/Box/index.tsx
+++ b/packages/orbit-components/src/Box/index.tsx
@@ -46,6 +46,7 @@ const Box = React.forwardRef<HTMLDivElement, Props>(
       background,
       padding,
       margin,
+      ariaLabel,
     },
     ref,
   ) => {
@@ -248,6 +249,7 @@ const Box = React.forwardRef<HTMLDivElement, Props>(
         id={id}
         data-test={dataTest}
         style={vars}
+        aria-label={ariaLabel}
       >
         {children}
       </Component>

--- a/packages/orbit-components/src/Box/types.d.ts
+++ b/packages/orbit-components/src/Box/types.d.ts
@@ -168,4 +168,5 @@ export interface Props extends Common.Globals {
   readonly largeDesktop?: MediaQueryObject;
   readonly children?: React.ReactNode;
   readonly className?: string; // Box is a only component where extending make sense
+  readonly ariaLabel?: string;
 }

--- a/packages/orbit-components/src/NavigationBar/README.md
+++ b/packages/orbit-components/src/NavigationBar/README.md
@@ -35,9 +35,4 @@ Table below contains all types of the props available in the NavigationBar compo
 | hideOnScroll       | `boolean`               | `true`                   | Turn on or off hiding navigation bar on scroll                                                              |
 | openTitle          | `string`                | `"Open navigation menu"` | Property for passing translation string to open Button.                                                     |
 | bottomStyle        | `"shadow" \| "border"`  | `"shadow"`               | Property for setting bottom style of NavigationBar.                                                         |
-| ariaLabel          | `string`                | `"navigation"`           | Optional prop for `aria-label` value (accessibility).                                                       |
 | transparentBgAtTop | `boolean`               | `false`                  | Property for setting the background to be transparent when the NavigationBar is at the top of the viewport. |
-
-## Accessibility
-
-- The `ariaLabel` prop allows you to specify an `aria-label` attribute for the component. This attribute provides additional information to screen readers, enhancing the accessibility of the component. By using `ariaLabel`, you can ensure that users who rely on assistive technologies receive the necessary context and information about the component's purpose and functionality.

--- a/packages/orbit-components/src/NavigationBar/index.tsx
+++ b/packages/orbit-components/src/NavigationBar/index.tsx
@@ -20,7 +20,6 @@ const NavigationBar = ({
   onHide,
   hideOnScroll = true,
   bottomStyle = "shadow",
-  ariaLabel = "navigation",
   transparentBgAtTop = false,
 }: Props) => {
   const resolveCallback = React.useCallback(
@@ -101,7 +100,6 @@ const NavigationBar = ({
         !isTransparentBg && bottomStyle === "border" && "border-cloud-normal border-b",
         isTransparentBg ? "bg-transparent" : "bg-white-normal",
       )}
-      aria-label={ariaLabel}
     >
       <div className={cx("block w-full", onMenuOpen && "me-200")}>{children}</div>
       {onMenuOpen && (

--- a/packages/orbit-components/src/NavigationBar/index.tsx
+++ b/packages/orbit-components/src/NavigationBar/index.tsx
@@ -84,7 +84,7 @@ const NavigationBar = ({
   }, [hideOnScroll, setShown]);
 
   return (
-    <nav
+    <header
       data-test={dataTest}
       id={id}
       className={cx(
@@ -110,7 +110,7 @@ const NavigationBar = ({
           title={openTitle}
         />
       )}
-    </nav>
+    </header>
   );
 };
 

--- a/packages/orbit-components/src/NavigationBar/types.d.ts
+++ b/packages/orbit-components/src/NavigationBar/types.d.ts
@@ -12,6 +12,5 @@ export interface Props extends Common.Globals {
   readonly openTitle?: string;
   readonly hideOnScroll?: boolean;
   readonly bottomStyle?: "shadow" | "border";
-  readonly ariaLabel?: string;
   readonly transparentBgAtTop?: boolean;
 }

--- a/packages/orbit-components/src/Stack/README.md
+++ b/packages/orbit-components/src/Stack/README.md
@@ -41,6 +41,7 @@ The table below contains all types of props available in the Stack component.
 | tablet       | [`Object`](#media-queries) |            | Object for setting up properties for the tablet viewport. [See Media queries](#media-queries)       |
 | wrap         | `boolean`                  | `false`    | If `true`, the Stack will have `flex-wrap` set to `wrap`, otherwise it will be `nowrap`.            |
 | useMargin    | `boolean`                  | `false`    | If `true`, the Stack will be using margins instead of gap                                           |
+| ariaLabel    | `string`                   |            | Optional prop for setting `aria-label` attribute.                                                   |
 
 ### Media Queries
 

--- a/packages/orbit-components/src/Stack/index.tsx
+++ b/packages/orbit-components/src/Stack/index.tsx
@@ -47,6 +47,7 @@ const Stack = (props: Props) => {
     tablet,
     desktop,
     largeDesktop,
+    ariaLabel,
   } = props;
 
   const viewportProps = { mediumMobile, largeMobile, tablet, desktop, largeDesktop };
@@ -177,6 +178,7 @@ const Stack = (props: Props) => {
           );
         }),
       )}
+      aria-label={ariaLabel}
     >
       {children}
     </ComponentTag>

--- a/packages/orbit-components/src/Stack/types.d.ts
+++ b/packages/orbit-components/src/Stack/types.d.ts
@@ -52,4 +52,5 @@ export interface Props extends CommonProps, Common.Globals {
   readonly as?: string;
   readonly largeDesktop?: CommonProps;
   readonly children: React.ReactNode;
+  readonly ariaLabel?: string;
 }


### PR DESCRIPTION
We currently don't have any `header` element on the page. Based on my research, I believe the NavigationBar component should have `header` tag and children rendered inside this component should be `nav` elements (when appropriate). As there shouldn't be more than one element on the page with `role="banner"` (role of `header` element), I believe `ariaLabel` prop is redundant here and should be set on the children `nav` elements so I removed it.

As `Stack` component supports `as` prop that can be used to convert current `div` elements to `nav` elements, I added `ariaLabel` prop there so it can ease the migration.

I created [new task](https://kiwicom.atlassian.net/browse/FEPLT-2396) to refactor Nitro's TopNav to use `nav` elements and add SkipNavigation.

Closes https://kiwicom.atlassian.net/browse/FEPLT-2298

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the `NavigationBar` component to use a `header` element instead of a `nav` element, removes the `ariaLabel` prop, and adds the `aria-label` attribute to the `nav` elements passed as children. It also updates the `Box` and `Stack` components to support the `ariaLabel` prop for accessibility.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant NavigationBar
    participant Box
    participant Stack

    Note over NavigationBar: Changed from nav to header element
    User->>NavigationBar: Interact with component
    NavigationBar-->>User: Renders as header element
    Note over NavigationBar: Removed ariaLabel prop

    User->>Box: Use Box component
    Box-->>User: Render with new ariaLabel support
    Note over Box: Added ariaLabel prop

    User->>Stack: Use Stack component
    Stack-->>User: Render with new ariaLabel support
    Note over Stack: Added ariaLabel prop
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4686/files#diff-ecefe6caf96517f49615628dd191b37ea0860205a0ad7e08c562a3ad3eb8f48a>docs/src/documentation/05-development/04-migration-guides/01-v23.mdx</a></td><td>Added a section about the removal of the <code>ariaLabel</code> prop in the <code>NavigationBar</code> component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4686/files#diff-c3b23f9a734e410eda98bae5ee987566b6354e911936616ad12fc08088a4520a>packages/orbit-components/src/Box/README.md</a></td><td>Updated documentation to include the <code>ariaLabel</code> prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4686/files#diff-2f2107b81067660a9262ae1165b49b4977543bbd46d26af46e546a6716c934de>packages/orbit-components/src/Box/TYPESCRIPT_TEMPLATE.template</a></td><td>Added <code>ariaLabel</code> prop to the TypeScript template.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4686/files#diff-96f7cb749800d386144dd76ebac61b437f60342a21fed3e12ef7a84efa51e7b1>packages/orbit-components/src/Box/index.tsx</a></td><td>Modified the <code>Box</code> component to accept and render the <code>aria-label</code> attribute.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4686/files#diff-b6454d7498389c342fc3e050a542d0d20d1a4cb40798cfc14eb197420e9eb018>packages/orbit-components/src/Box/types.d.ts</a></td><td>Updated the type definitions to include <code>ariaLabel</code> prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4686/files#diff-5cfcc97b511eca6782561475d76b51610305e6b768ad9c3b3c2afe3f74e6ead8>packages/orbit-components/src/NavigationBar/README.md</a></td><td>Removed the <code>ariaLabel</code> prop documentation from the <code>NavigationBar</code> component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4686/files#diff-baa0d116f2cd2a7ed17331472d0251da1103511273373bd3424fe42f4639d759>packages/orbit-components/src/NavigationBar/index.tsx</a></td><td>Changed the <code>NavigationBar</code> component to render a <code>header</code> element and removed the <code>ariaLabel</code> prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4686/files#diff-4b8aace655a5d59f1921958c3558a02c9cdbb18dc5faf77b7d39855458def35e>packages/orbit-components/src/NavigationBar/types.d.ts</a></td><td>Removed <code>ariaLabel</code> from the <code>NavigationBar</code> props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4686/files#diff-d1e17442a3e06dde21743300583641ab4780c56ca56b480d397f338a11dfe455>packages/orbit-components/src/Stack/README.md</a></td><td>Updated documentation to include the <code>ariaLabel</code> prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4686/files#diff-30c9103b612af0d457bcc391892bf0e96e77003fb02f1f0df204308229b934e0>packages/orbit-components/src/Stack/index.tsx</a></td><td>Modified the <code>Stack</code> component to accept and render the <code>aria-label</code> attribute.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4686/files#diff-2425be32f8c8a010c6fd797cca499bb13a0d2d979c2e206bbecf95834a2c2645>packages/orbit-components/src/Stack/types.d.ts</a></td><td>Updated the type definitions to include <code>ariaLabel</code> prop.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`, `.template`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->
















