### PR TITLE
SocialButton accessibility

### DIFF
--- a/packages/orbit-components/src/SocialButton/helpers/getSocialButtonIcon.tsx
+++ b/packages/orbit-components/src/SocialButton/helpers/getSocialButtonIcon.tsx
@@ -9,11 +9,11 @@ import Email from "../../icons/Email";
 import type { Type } from "../types";
 
 const getSocialButtonIcon = (type: Type): React.ReactNode | null => {
-  if (type === TYPE_OPTIONS.APPLE) return <Apple />;
-  if (type === TYPE_OPTIONS.FACEBOOK) return <Facebook />;
-  if (type === TYPE_OPTIONS.GOOGLE) return <Google />;
-  if (type === TYPE_OPTIONS.X) return <X />;
-  if (type === TYPE_OPTIONS.EMAIL) return <Email />;
+  if (type === TYPE_OPTIONS.APPLE) return <Apple ariaHidden />;
+  if (type === TYPE_OPTIONS.FACEBOOK) return <Facebook ariaHidden />;
+  if (type === TYPE_OPTIONS.GOOGLE) return <Google ariaHidden />;
+  if (type === TYPE_OPTIONS.X) return <X ariaHidden />;
+  if (type === TYPE_OPTIONS.EMAIL) return <Email ariaHidden />;
 
   return null;
 };

--- a/packages/orbit-components/src/SocialButton/index.tsx
+++ b/packages/orbit-components/src/SocialButton/index.tsx
@@ -37,6 +37,7 @@ const SocialButton = React.forwardRef<HTMLButtonElement, Props>(
           <ChevronForwardIcon
             customColor={type === TYPE_OPTIONS.APPLE ? "#FFF" : ""}
             color="primary"
+            ariaHidden
           />
         }
         circled={false}

--- a/packages/orbit-components/src/SocialButton/index.tsx
+++ b/packages/orbit-components/src/SocialButton/index.tsx
@@ -38,6 +38,7 @@ const SocialButton = React.forwardRef<HTMLButtonElement, Props>(
             customColor={type === TYPE_OPTIONS.APPLE ? "#FFF" : ""}
             color="primary"
             ariaHidden
+            reverseOnRtl
           />
         }
         circled={false}


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2305

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR enhances the accessibility of the `SocialButton` component by adding `ariaHidden` attributes to the icons and the `ChevronForwardIcon`.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Client
    participant SocialButton
    participant getSocialButtonIcon
    participant Icons

    Client->>SocialButton: Render with type prop
    SocialButton->>getSocialButtonIcon: Get icon for type
    alt type is APPLE
        getSocialButtonIcon->>Icons: Return Apple icon
    else type is FACEBOOK
        getSocialButtonIcon->>Icons: Return Facebook icon
    else type is GOOGLE
        getSocialButtonIcon->>Icons: Return Google icon
    else type is X
        getSocialButtonIcon->>Icons: Return X icon
    else type is EMAIL
        getSocialButtonIcon->>Icons: Return Email icon
    else no match
        getSocialButtonIcon->>SocialButton: Return null
    end
    SocialButton->>Client: Render button with icon<br/>and RTL-aware chevron
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4687/files#diff-41a64aac1a2db4e90fa3685e313d5b980b61f15b14f6c8915d846a5fc99824c1>packages/orbit-components/src/SocialButton/helpers/getSocialButtonIcon.tsx</a></td><td>Added <code>ariaHidden</code> attribute to social button icons for improved accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4687/files#diff-6c6483df468055a73d1ec29f4cf49f985722c91565d38c7f862b8470b0e4a7ed>packages/orbit-components/src/SocialButton/index.tsx</a></td><td>Added <code>ariaHidden</code> and <code>reverseOnRtl</code> attributes to <code>ChevronForwardIcon</code> for better accessibility.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->




