### PR TITLE
feat(ChoiceGroup): refactor component for improved accessibility

### DIFF
--- a/packages/orbit-components/src/ChoiceGroup/index.tsx
+++ b/packages/orbit-components/src/ChoiceGroup/index.tsx
@@ -73,8 +73,6 @@ const ChoiceGroup = React.forwardRef<HTMLDivElement, Props>(
       <div
         ref={ref}
         data-test={dataTest}
-        role="group"
-        aria-labelledby={label ? groupID : undefined}
         id={id}
         className={cx(
           "flex w-full flex-col",
@@ -92,32 +90,34 @@ const ChoiceGroup = React.forwardRef<HTMLDivElement, Props>(
             {label}
           </Heading>
         )}
-        {typeof children === "function" ? (
-          children({
-            Container: "div",
-            Item: ItemContainer({ filter, onOnlySelection, onlySelectionText, itemProps }),
-            spacing: filter ? "0px" : theme.orbit.space200,
-          })
-        ) : (
-          <Stack direction="column" spacing={filter ? "none" : "200"}>
-            {React.Children.map(children, child => {
-              return !filter ? (
-                // @ts-expect-error TODO
-                React.cloneElement(child, itemProps)
-              ) : (
-                <FilterWrapper
+        <div aria-labelledby={label ? groupID : undefined} role="group">
+          {typeof children === "function" ? (
+            children({
+              Container: "div",
+              Item: ItemContainer({ filter, onOnlySelection, onlySelectionText, itemProps }),
+              spacing: filter ? "0px" : theme.orbit.space200,
+            })
+          ) : (
+            <Stack direction="column" spacing={filter ? "none" : "200"}>
+              {React.Children.map(children, child => {
+                return !filter ? (
                   // @ts-expect-error TODO
-                  child={child}
-                  onOnlySelection={onOnlySelection}
-                  onlySelectionText={onlySelectionText}
-                >
-                  {/* @ts-expect-error TODO */}
-                  {React.cloneElement(child, itemProps)}
-                </FilterWrapper>
-              );
-            })}
-          </Stack>
-        )}
+                  React.cloneElement(child, itemProps)
+                ) : (
+                  <FilterWrapper
+                    // @ts-expect-error TODO
+                    child={child}
+                    onOnlySelection={onOnlySelection}
+                    onlySelectionText={onlySelectionText}
+                  >
+                    {/* @ts-expect-error TODO */}
+                    {React.cloneElement(child, itemProps)}
+                  </FilterWrapper>
+                );
+              })}
+            </Stack>
+          )}
+        </div>
         {error && <Feedback>{error}</Feedback>}
       </div>
     );


### PR DESCRIPTION
Based on the observation at: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/examples/checkbox/ 
We've found out that the accessibility structure of our ChoiceGroup component is not correct. This PR includes improvement of the component. mainly the announcement flow by screen reader.

# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

Refactored the `ChoiceGroup` component to improve accessibility by correcting the ARIA roles and properties.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant CG as ChoiceGroup
    participant Group as Group Container
    participant Children as Children Handler
    participant Stack as Stack Component
    participant Filter as FilterWrapper

    CG->>Group: Create group with aria-labelledby
    Group->>Children: Process children
    alt is function
        Children->>Children: Render with Container & Item props
    else is React elements
        Children->>Stack: Create Stack component
        alt filter enabled
            Stack->>Filter: Wrap child with FilterWrapper
            Filter->>Filter: Apply onlySelection props
        else filter disabled
            Stack->>Stack: Clone element with itemProps
        end
    end

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4695/files#diff-7616b26166b41921709548bbe9c788c7f98fcd7621d79a1621e71ac199bd7d39>packages/orbit-components/src/ChoiceGroup/index.tsx</a></td><td>Removed redundant <code>role</code> and <code>aria-labelledby</code> attributes from the outer <code>div</code> and added them to a new inner <code>div</code> for better accessibility.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->






