### PR TITLE
fix(Button): remove invalid className prop type

### DIFF
--- a/packages/orbit-components/src/Button/types.d.ts
+++ b/packages/orbit-components/src/Button/types.d.ts
@@ -3,9 +3,9 @@
 
 import type {
   ButtonCommonProps,
-  Size,
   DownloadWithHrefConditionalProps,
   FullWidthConditionalProps,
+  Size,
 } from "../primitives/ButtonPrimitive/types";
 
 export type Type =
@@ -20,8 +20,9 @@ export type Type =
   | "bundleTop";
 
 export type ButtonStates = "default" | "hover" | "active" | "focus";
+type OmittedButtonCommonProps = Omit<ButtonCommonProps, "className">;
 
-interface ButtonProps extends ButtonCommonProps {
+interface ButtonProps extends OmittedButtonCommonProps {
   readonly type?: Type;
   readonly size?: Size;
 }


### PR DESCRIPTION
This PR removes invalid className prop type on the button component. It's overwritten in the implementation and having it in types was misleading to users as the styles were never applied.

FEPLT-2331

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR removes the invalid `className` prop type from the `ButtonProps` interface, which was misleading as it was overwritten in the implementation.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant ButtonPrimitive
    participant ButtonProps
    participant Types

    ButtonPrimitive->>Types: Exports Size type
    ButtonPrimitive->>ButtonProps: Extends ButtonCommonProps
    Note over ButtonProps: Omits className from ButtonCommonProps
    ButtonProps->>Types: Defines Type & Size properties
    Note over ButtonProps: Creates interface with<br/>type?: Type<br/>size?: Size
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4700/files#diff-b99d0dc786f2a1199c8d70155b9a40c5f674e2368864696834bc3479a3e318e1>packages/orbit-components/src/Button/types.d.ts</a></td><td>Updated <code>ButtonProps</code> to omit the <code>className</code> prop type.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


