### PR TITLE
fix(Dialog): correct import type name

### DIFF
--- a/packages/orbit-components/src/Dialog/types.d.ts
+++ b/packages/orbit-components/src/Dialog/types.d.ts
@@ -4,7 +4,7 @@
 import type * as React from "react";
 
 import type * as Common from "../common/types";
-import type { HeadingProps } from "../Heading/types";
+import type { Props as HeadingProps } from "../Heading/types";
 
 export interface Props extends Common.Globals {
   readonly title: React.ReactNode;


### PR DESCRIPTION
Corrects import type on Dialog component.

FEPLT-2424

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR corrects the import type name for the `HeadingProps` in the `Dialog` component.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Dialog
    participant HeadingProps
    Dialog->>HeadingProps: imports Props type
    Note over Dialog,HeadingProps: Type dependency added
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4708/files#diff-8271fe03312c13b8b452be615e8eeef89ba75ab3a7df0ffbc35e21afb382c24e>packages/orbit-components/src/Dialog/types.d.ts</a></td><td>Corrects import type from <code>HeadingProps</code> to <code>Props as HeadingProps</code>.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


