### PR TITLE
Fix prop type import on Dialog

### DIFF
--- a/packages/orbit-components/src/Dialog/index.tsx
+++ b/packages/orbit-components/src/Dialog/index.tsx
@@ -126,7 +126,13 @@ const Dialog = ({
           {illustration && <div className="mb-400 lm:text-start text-center">{illustration}</div>}
           <div className="mb-400 gap-200 lm:text-start lm:[&>.orbit-text]:text-start flex flex-col text-center [&>.orbit-text]:text-center">
             {title && (
-              <Heading type="title3" align="center" largeMobile={{ align: "start" }} as={titleAs}>
+              <Heading
+                type="title3"
+                align="center"
+                largeMobile={{ align: "start" }}
+                role={undefined}
+                as={titleAs}
+              >
                 {title}
               </Heading>
             )}

--- a/packages/orbit-components/src/Dialog/types.d.ts
+++ b/packages/orbit-components/src/Dialog/types.d.ts
@@ -4,7 +4,7 @@
 import type * as React from "react";
 
 import type * as Common from "../common/types";
-import type { HeadingProps } from "../Heading/types";
+import type { Props as HeadingProps } from "../Heading/types";
 
 export interface Props extends Common.Globals {
   readonly title: React.ReactNode;


### PR DESCRIPTION
Closes #4708

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR fixes the import of prop types for the `Heading` component in the `Dialog` component and updates the `Heading` usage to include a `role` prop set to `undefined`.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant D as Dialog Component
    participant H as Heading Component
    
    Note over D: Receives title prop
    D->>H: Renders title with new props
    Note over H: Applies new properties:<br/>type="title3"<br/>align="center"<br/>largeMobile.align="start"<br/>as={titleAs}
    H-->>D: Returns styled heading
    D->>D: Renders final dialog<br/>with formatted title
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4709/files#diff-5c71d3edf1a7133883c93ebfb29b7eae352894259a2e3f64ca4fa0a048321ce9>packages/orbit-components/src/Dialog/index.tsx</a></td><td>Updated the <code>Heading</code> component usage to include a <code>role</code> prop set to <code>undefined</code>.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4709/files#diff-8271fe03312c13b8b452be615e8eeef89ba75ab3a7df0ffbc35e21afb382c24e>packages/orbit-components/src/Dialog/types.d.ts</a></td><td>Changed the import statement for <code>HeadingProps</code> to import from the correct path.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


