### PR TITLE
Add Accessibility docs for Tabs

### DIFF
--- a/docs/src/documentation/03-components/02-structure/tabs/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/02-structure/tabs/03-accessibility.mdx
@@ -1,0 +1,93 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/tabs/accessibility/
+---
+
+# Accessibility
+
+## Tabs
+
+The Tabs component has been designed with accessibility in mind.
+
+### Accessibility props
+
+The following props are available to improve the accessibility of your Tabs component:
+
+#### TabList
+
+| Prop           | Type     | Description                                                    |
+| :------------- | :------- | :------------------------------------------------------------- |
+| ariaLabel      | `string` | Allows you to provide an accessible label for the set of tabs. |
+| ariaLabelledby | `string` | References the ID of an element that labels the set of tabs.   |
+
+The `ariaLabel` prop should ideally be translated and descriptive of the purpose of the tab set. It should clearly communicate the type of content users will find within the tabs.
+
+The `ariaLabelledby` prop is used when you already have a visible heading that describes the tab set, allowing you to reuse that text for screen readers.
+
+#### Tab
+
+| Prop     | Type      | Description                                                        |
+| :------- | :-------- | :----------------------------------------------------------------- |
+| disabled | `boolean` | Indicates that the tab is not interactive and cannot be activated. |
+
+### Accessibility implementation
+
+The Tabs component automatically implements proper accessibility features including:
+
+- Correct ARIA roles: `tablist` for the TabList, `tab` for individual tabs, and `tabpanel` for tab panels
+- Appropriate ARIA states and relationships:
+- `aria-selected`: Indicates which tab is currently active
+- `aria-disabled`: Applied to tabs that cannot be activated
+- `aria-controls`: Applied to each tab to reference its associated panel
+- `aria-labelledby`: Applied to each panel to reference its associated tab (this is different from the `ariaLabelledby` prop on TabList)
+
+### Best practices
+
+- Use the `ariaLabel` or `ariaLabelledby` props on the `TabList` component to provide a descriptive label for the set of tabs, especially when there are multiple tab sets on a page.
+- Ensure that tab labels are clear and descriptive of the content they control.
+- When a tab is disabled, use the `disabled` prop to properly communicate this state to assistive technologies.
+- Always translate accessibility-related strings to match the user's language.
+
+### Code examples
+
+#### Using ariaLabel
+
+```jsx
+<Tabs>
+  <TabList ariaLabel="Content sections">
+    <Tab>Section 1</Tab>
+    <Tab>Section 2</Tab>
+    <Tab disabled>Section 3</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>Content for section 1</TabPanel>
+    <TabPanel>Content for section 2</TabPanel>
+    <TabPanel>Content for section 3</TabPanel>
+  </TabPanels>
+</Tabs>
+```
+
+In this example, screen readers would announce "Content sections, tab group" when focusing on the tab list.
+
+#### Using ariaLabelledby
+
+```jsx
+<div>
+  <h2 id="tabs-title">Flight Options</h2>
+  <Tabs>
+    <TabList ariaLabelledby="tabs-title">
+      <Tab>Economy</Tab>
+      <Tab>Business</Tab>
+      <Tab>First Class</Tab>
+    </TabList>
+    <TabPanels>
+      <TabPanel>Economy class options</TabPanel>
+      <TabPanel>Business class options</TabPanel>
+      <TabPanel>First class options</TabPanel>
+    </TabPanels>
+  </Tabs>
+</div>
+```
+
+In this example, screen readers would announce "Flight Options, tab group" when focusing on the tab list.

--- a/packages/orbit-components/src/Tabs/README.md
+++ b/packages/orbit-components/src/Tabs/README.md
@@ -31,26 +31,28 @@ Once you have imported the Tabs component, you can use it in your React applicat
 
 Table below contains all types of the props available in Tabs component.
 
-| Name            | Type                                               | Default | Description                                                                                                  |
-| :-------------- | :------------------------------------------------- | :------ | :----------------------------------------------------------------------------------------------------------- |
-| dataTest        | `string`                                           |         | Optional prop for testing purposes.                                                                          |
-| defaultSelected | `number`                                           | `0`     | Optional prop to set the initial active tab index. Use only if you do not want to control state on your side |
-| children        | `React.node`                                       |         | Required prop that should contain the `TabList`, `TabPanels` components.                                     |
-| onChange        | `(selectedIndex: number) => void \| Promise<void>` |         | Function for handling onChange. Use only if you do not want to control state on your side.                   |
+| Name            | Type                                               | Default | Description                                                                                                   |
+| :-------------- | :------------------------------------------------- | :------ | :------------------------------------------------------------------------------------------------------------ |
+| dataTest        | `string`                                           |         | Optional prop for testing purposes.                                                                           |
+| defaultSelected | `number`                                           | `0`     | Optional prop to set the initial active tab index. Use only if you do not want to control state on your side. |
+| children        | `React.node`                                       |         | Required prop that should contain the `TabList`, `TabPanels` components.                                      |
+| onChange        | `(selectedIndex: number) => void \| Promise<void>` |         | Function for handling onChange. Use only if you do not want to control state on your side.                    |
 
 ### TabList
 
 Table below contains all types of the props available in TabList component.
 
-| Name           | Type            | Default | Description                                                                          |
-| :------------- | :-------------- | :------ | :----------------------------------------------------------------------------------- |
-| dataTest       | `string`        |         | Optional prop for testing purposes.                                                  |
-| children       | `React.node`    |         | Required prop that should contain the `Tab` components.                              |
-| compact        | `boolean`       | `false` | Optional prop that responsible for `Tab`size, if provided, the Tabs will be smaller. |
-| spacing        | [`enum`](#enum) | `none`  | Optional prop to set gap between `Tab` elements.                                     |
-| fullWidth      | `boolean`       | `false` | Optional prop to set `TabList` to full width.                                        |
-| ariaLabel      | `string`        |         | Optional prop for `aria-label`.                                                      |
-| ariaLabelledBy | `string`        |         | Optional prop for `aria-labelledby`.                                                 |
+| Name           | Type                         | Default | Description                                                                          |
+| :------------- | :--------------------------- | :------ | :----------------------------------------------------------------------------------- |
+| dataTest       | `string`                     |         | Optional prop for testing purposes.                                                  |
+| children       | `React.node`                 |         | Required prop that should contain the `Tab` components.                              |
+| compact        | `boolean`                    | `false` | Optional prop that responsible for `Tab`size, if provided, the Tabs will be smaller. |
+| spacing        | [`enum`](#enum)              | `none`  | Optional prop to set gap between `Tab` elements.                                     |
+| fullWidth      | `boolean`                    | `false` | Optional prop to set `TabList` to full width.                                        |
+| margin         | `string \| number \| Object` | `"0"`   | Utility property to set margin.                                                      |
+| padding        | `string \| number \| Object` | `"0"`   | Utility property to set padding.                                                     |
+| ariaLabel      | `string`                     |         | Optional prop for `aria-label`.                                                      |
+| ariaLabelledby | `string`                     |         | Optional prop for `aria-labelledby`.                                                 |
 
 ### Tab
 

--- a/packages/orbit-components/src/Tabs/Tabs.stories.tsx
+++ b/packages/orbit-components/src/Tabs/Tabs.stories.tsx
@@ -28,6 +28,7 @@ interface CustomProps {
   tabPanelChildrenFirst: string;
   tabPanelChildrenSecond: string;
   spacingTabList: SPACINGS;
+  ariaLabelTabList: string;
 }
 
 type TabsPropsAndCustomArgs = React.ComponentProps<typeof Tabs> &
@@ -88,7 +89,7 @@ export const Controlled: Story = {
 
     return (
       <Tabs>
-        <TabList>
+        <TabList ariaLabel="Controlled tabs example">
           <Tab onClick={() => setSelected(0)} active={selected === 0}>
             Tab 1
           </Tab>
@@ -137,11 +138,18 @@ export const Playground: Story = {
     tabChildrenSecond,
     tabPanelChildrenFirst,
     tabPanelChildrenSecond,
+    ariaLabelTabList,
     ...args
   }) => (
     <Box background="cloudLight">
       <Tabs defaultSelected={defaultSelected} spacing={spacing}>
-        <TabList spacing={spacingTabList} margin={marginTabList} padding={paddingTabList} {...args}>
+        <TabList
+          spacing={spacingTabList}
+          margin={marginTabList}
+          padding={paddingTabList}
+          ariaLabel={ariaLabelTabList}
+          {...args}
+        >
           <Tab type={typeFirstTab} disabled={disabledFirstTab}>
             {tabChildrenFirst}
           </Tab>
@@ -179,6 +187,7 @@ export const Playground: Story = {
     tabPanelChildrenSecond: "Tab content 2",
     marginTabPanel: "10px",
     paddingTabPanel: "20px",
+    ariaLabelTabList: "Playground tabs example",
   },
 
   argTypes: {
@@ -213,6 +222,7 @@ export const Playground: Story = {
     fullWidth: { table: { category: "TabList" } },
     marginTabList: { name: "margin", table: { category: "TabList" } },
     paddingTabList: { name: "padding", table: { category: "TabList" } },
+    ariaLabelTabList: { name: "ariaLabel", table: { category: "TabList" } },
     spacingTabList: {
       name: "spacing",
       options: Object.values(SPACINGS),
@@ -235,7 +245,7 @@ export const RTL: Story = {
   render: () => (
     <RenderInRtl>
       <Tabs>
-        <TabList>
+        <TabList ariaLabel="RTL tabs example">
           <Tab>Tab 1</Tab>
           <Tab type="basic">Tab 2</Tab>
           <Tab type="medium">Tab 3</Tab>


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2339

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds accessibility documentation for the Tabs component, including props, implementation details, best practices, and code examples.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Screen Reader
    participant TabList
    participant Tab
    participant TabPanel

    User->>TabList: Focuses on TabList
    TabList->>Screen Reader: Announces "ariaLabel" or "ariaLabelledby"
    
    User->>Tab: Selects Tab
    Tab->>Screen Reader: Announces tab state (selected/disabled)
    Tab->>TabPanel: Controls associated panel
    TabPanel->>Screen Reader: Announces panel content
    
    Note over TabList,TabPanel: Accessibility Features Added:<br/>- ariaLabel prop<br/>- ariaLabelledby prop<br/>- ARIA roles & states<br/>- Proper relationships
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4711/files#diff-31fac7f0e818e60e6cff080bad977267552f3f2a3ae29476c4af8787d65a021d>docs/src/documentation/03-components/02-structure/tabs/03-accessibility.mdx</a></td><td>Added a new documentation file for accessibility features of the Tabs component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4711/files#diff-ee1ae5f2e9c2ed5a0e3ff3b7420f19f3528fc176c9ee01af748797774327407f>packages/orbit-components/src/Tabs/README.md</a></td><td>Updated the README to include new props related to accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4711/files#diff-07803688343920da2fbfea517351907424ff6bab26d15f8cc66a057933263c55>packages/orbit-components/src/Tabs/Tabs.stories.tsx</a></td><td>Modified stories to include accessibility props for TabList.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






