### PR TITLE
Add Accessibility docs for Alert

### DIFF
--- a/docs/src/documentation/03-components/03-information/alert/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/03-information/alert/03-accessibility.mdx
@@ -1,0 +1,101 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/alert/accessibility/
+---
+
+# Accessibility
+
+## Alert
+
+The Alert component has been designed with accessibility in mind.
+
+### Accessibility props
+
+The following props are available to improve the accessibility of your Alert component:
+
+| Prop       | Type     | Description                                                              |
+| :--------- | :------- | :----------------------------------------------------------------------- |
+| labelClose | `string` | Defines accessible text for the close button when the alert is closable. |
+
+When the `closable` prop is set to `true`, the `labelClose` prop is required. It provides the text that screen readers will announce when focusing on the close button, helping users understand its purpose.
+
+The `labelClose` text should be properly translated.
+
+### Best practices
+
+- When using the `icon` prop, follow the accessibility guidelines documented in the Icon component's accessibility documentation to ensure that the icon is properly accessible or visually hidden from screen readers when it is purely decorative.
+
+### Code examples
+
+#### Using labelClose with closable alert
+
+```jsx
+<Alert
+  type="info"
+  title="Notification"
+  closable
+  labelClose="Close notification" // Should be a translated string
+  onClose={() => {
+    // handle close action
+  }}
+>
+  This is an important update for your upcoming flight.
+</Alert>
+```
+
+In this example, screen readers would announce "Close notification" when focusing on the close button.
+
+#### Non-closable alert (no accessibility props required)
+
+```jsx
+<Alert type="success" title="Success">
+  Your booking has been confirmed.
+</Alert>
+```
+
+In this example, the alert doesn't require additional accessibility props as it doesn't have interactive elements that need labels.
+
+## AlertButton
+
+The AlertButton component also includes several accessibility features:
+
+### Accessibility props
+
+| Prop           | Type      | Description                                                                                      |
+| :------------- | :-------- | :----------------------------------------------------------------------------------------------- |
+| title          | `string`  | Adds `aria-label` to the button, providing a description for screen readers.                     |
+| ariaControls   | `string`  | Identifies the element controlled by the button, establishing a relationship for screen readers. |
+| ariaExpanded   | `boolean` | Indicates to screen readers whether the controlled element is expanded.                          |
+| ariaLabelledby | `string`  | References the ID of an element that labels the button.                                          |
+
+### Best practices
+
+- The `title` prop should be used when the button's purpose isn't clear from its content alone or when additional context would help screen reader users.
+- When the AlertButton controls the visibility of another element (like a collapsible section), use `ariaControls` with the ID of that element and `ariaExpanded` to indicate its state.
+- Always translate accessibility-related text to match the user's language.
+- Use the `asComponent` prop to change the rendered element when the AlertButton is used inside another interactive element (like another button or a link). This helps avoid accessibility violations from nesting interactive elements, which can confuse screen readers and keyboard navigation.
+- When using `iconLeft` or `iconRight` props, follow the accessibility guidelines documented in the Icon component's accessibility documentation to ensure that icons are properly accessible or visually hidden from screen readers when they are purely decorative.
+
+You can find additional accessibility guidance in the Button accessibility documentation.
+
+### Code example
+
+```jsx
+<Alert type="warning" title="Flight delay information">
+  <p>Your flight has been delayed by 2 hours.</p>
+  <AlertButton
+    type="warning"
+    ariaControls="details-panel"
+    ariaExpanded={detailsVisible}
+    onClick={() => setDetailsVisible(!detailsVisible)}
+  >
+    {detailsVisible ? "Hide details" : "Show details"}
+  </AlertButton>
+  <div id="details-panel" style={{ display: detailsVisible ? "block" : "none" }}>
+    Detailed information about the delay...
+  </div>
+</Alert>
+```
+
+In this example, screen readers would announce the button text along with information about what element it controls and whether that element is currently expanded.

--- a/packages/orbit-components/src/Alert/Alert.stories.tsx
+++ b/packages/orbit-components/src/Alert/Alert.stories.tsx
@@ -98,7 +98,9 @@ export const Button: Story = {
   },
 
   parameters: {
-    controls: { exclude: ["title", "children", "icon", "closable", "spaceAfter", "suppressed"] },
+    controls: {
+      exclude: ["title", "children", "icon", "closable", "spaceAfter", "suppressed", "labelClose"],
+    },
   },
 
   args: {

--- a/packages/orbit-components/src/Alert/README.md
+++ b/packages/orbit-components/src/Alert/README.md
@@ -21,15 +21,15 @@ The table below contains all types of the props available in Alert component.
 | children      | `React.Node`                    |          | The content of the Alert.                                                              |
 | closable      | `boolean`                       | `false`  | If `true`, the Close icon will be displayed. [See Functional specs](#functional-specs) |
 | dataTest      | `string`                        |          | Optional prop for testing purposes.                                                    |
-| id            | `string`                        |          | Set `id` for `Alert`                                                                   |
+| id            | `string`                        |          | Set `id` for `Alert`.                                                                  |
 | icon          | `React.Element<any> \| boolean` |          | The displayed icon. [See Functional specs](#functional-specs)                          |
 | inlineActions | `React.Node`                    |          | Renders action to a right side of a Alert. [See Functional specs](#functional-specs)   |
 | onClose       | `() => void \| Promise`         |          | Function for handling Alert onClose.                                                   |
 | spaceAfter    | `enum`                          |          | Additional `margin-bottom` after component.                                            |
 | title         | `string`                        |          | The title of the Alert.                                                                |
 | **type**      | [`enum`](#enum)                 | `"info"` | The type of Alert.                                                                     |
-| suppressed    | `boolean`                       |          | If `suppressed` is on, Alert will not have colored background                          |
-| labelClose    | `string`                        |          | The label of the close button.                                                         |
+| suppressed    | `boolean`                       |          | If `suppressed` is on, Alert will not have colored background.                         |
+| labelClose    | `string`                        |          | The label of the close button. **Required** when `closable` is `true`.                 |
 
 ### enum
 
@@ -45,7 +45,7 @@ The table below contains all types of the props available in Alert component.
 
 ## Functional specs
 
-- By passing the `closable` prop into Alert, you will be able to handle `onClose` function and Close icon will be displayed. Also, if you want to select the Close Button element for testing purposes, use [data-test="AlertCloseButton"] selector.
+- By passing the `closable` prop into Alert, you will be able to handle `onClose` function and Close icon will be displayed. When `closable` is `true`, the `labelClose` prop is required for accessibility. Also, if you want to select the Close Button element for testing purposes, use [data-test="AlertCloseButton"] selector.
 
 - When the Alert has a `title` prop, if you pass an `icon` prop as `true`, the Alert will have its own icon based on the selected `type`. If you want to use a different icon, just pass it to the `icon` prop as a `React.Element`. Alerts without a `title` or with a `title` but without an `icon` prop don't have an icon.
 


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2342

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds accessibility documentation for the Alert component, including details on accessibility props and best practices.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Alert
    participant Screen Reader
    participant CloseButton

    Note over Alert: New Accessibility Features

    User->>Alert: Interacts with Alert
    
    alt Alert is Closable
        Alert->>Alert: Check labelClose prop
        Alert-->>Screen Reader: Announce close button label
        User->>CloseButton: Focus on close button
        CloseButton-->>Screen Reader: Announce "labelClose" text
        User->>CloseButton: Click close
        CloseButton->>Alert: Trigger onClose()
    end

    alt Alert has Title & Icon
        Alert->>Alert: Display type-specific icon
        Alert-->>Screen Reader: Skip icon if decorative
    end

    alt Alert is Suppressed
        Alert->>Alert: Remove colored background
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4713/files#diff-b2347a63a0938377cdd24d5eeff57d16163a81c42d824c8eaace158ebb2aa957>docs/src/documentation/03-components/03-information/alert/03-accessibility.mdx</a></td><td>Added accessibility documentation for the Alert component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4713/files#diff-e89b03e948f4cf9bae7742026c0a2f07ae75c9e64add7a006c3f9aead22d5bd4>packages/orbit-components/src/Alert/Alert.stories.tsx</a></td><td>Updated story parameters to exclude the new 'labelClose' prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4713/files#diff-dc79a145037de14788e50dc550d5bd6c334217b9a3a2282c40d877cd32f9b533>packages/orbit-components/src/Alert/README.md</a></td><td>Updated README to include the 'labelClose' prop and its accessibility requirement.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






