### PR TITLE
Add Accessibility docs for Popover

### DIFF
--- a/docs/src/__examples__/Popover/DEFAULT.tsx
+++ b/docs/src/__examples__/Popover/DEFAULT.tsx
@@ -14,6 +14,7 @@ export default {
     <OrbitProvider theme={defaultTheme} useId={React.useId}>
       <Popover
         renderInPortal={false}
+        ariaLabel="Help and documentation links"
         content={
           <Stack spacing="300">
             <ButtonLink
@@ -35,7 +36,7 @@ export default {
           </Stack>
         }
       >
-        <Button circled title="Help" iconLeft={<QuestionCircle />} />
+        <Button asComponent="div" circled title="Help" iconLeft={<QuestionCircle />} />
       </Popover>
     </OrbitProvider>
   ),
@@ -73,7 +74,7 @@ export default {
             "bottom-end",
           ],
         },
-        { name: "ariaLabel", type: "text", defaultValue: "" },
+        { name: "ariaLabel", type: "text", defaultValue: "Help and documentation links" },
         { name: "ariaLabelledby", type: "text", defaultValue: "" },
       ],
     },

--- a/docs/src/__examples__/Popover/TRIGGER.tsx
+++ b/docs/src/__examples__/Popover/TRIGGER.tsx
@@ -14,6 +14,7 @@ export default {
     <OrbitProvider theme={defaultTheme} useId={React.useId}>
       <Popover
         renderInPortal={false}
+        ariaLabel="Documentation resources"
         content={
           <Stack spacing="300">
             <ButtonLink
@@ -35,7 +36,7 @@ export default {
           </Stack>
         }
       >
-        <Button iconRight={<ChevronDown />} type="secondary">
+        <Button asComponent="div" iconRight={<ChevronDown />} type="secondary">
           Learn more
         </Button>
       </Popover>

--- a/docs/src/documentation/03-components/04-overlay/popover/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/04-overlay/popover/03-accessibility.mdx
@@ -1,0 +1,143 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/popover/accessibility/
+---
+
+## Accessibility
+
+The Popover component has been designed with accessibility in mind, providing features that enhance the experience for users of assistive technologies.
+
+### Accessibility props
+
+The following props are available to improve the accessibility of your Popover component:
+
+| Prop           | Type                                                  | Default    | Description                                                                           |
+| :------------- | :---------------------------------------------------- | :--------- | :------------------------------------------------------------------------------------ |
+| ariaLabel      | `string`                                              |            | Adds `aria-label` to the popover content, providing a description for screen readers. |
+| ariaLabelledby | `string`                                              |            | References the ID of an element that labels the popover content for screen readers.   |
+| role           | `"dialog" \| "menu" \| "grid" \| "listbox" \| "tree"` | `"dialog"` | Defines the ARIA role of the popover component.                                       |
+| labelClose     | `React.Node`                                          | `"Close"`  | The label for the close button displayed on mobile devices.                           |
+
+### Automatic Accessibility Features
+
+The Popover component automatically handles several important ARIA attributes on the trigger element:
+
+- `aria-controls`: Links the trigger element to the popover content using a unique ID or `id` provided via props.
+- `aria-haspopup`: Indicates that the trigger reveals additional content (set to the popover's role).
+- `aria-expanded`: Indicates whether the popover is currently visible or hidden.
+
+These attributes are managed by the component and do not need to be manually added to your code.
+
+### Best practices
+
+#### Non-interactive trigger elements
+
+The Popover's trigger element (provided as `children`) should not be an interactive element like a native `<button>` or `<a>` tag, as this creates nested interactive elements which is an accessibility violation.
+
+For example, if using a Button component as a trigger, set `asComponent="div"` to avoid this issue:
+
+```jsx
+<Popover content="Popover content">
+  <Button asComponent="div">Open popover</Button>
+</Popover>
+```
+
+#### Descriptive labels
+
+- Provide meaningful `ariaLabel` or `ariaLabelledby` props to help screen reader users understand the purpose of the popover.
+- The `ariaLabel` should be concise but descriptive, such as "Passenger selection" or "Filter options".
+- When using `ariaLabelledby`, ensure the referenced element (by ID) contains clear, descriptive text that explains the popover's purpose.
+- Always ensure that `ariaLabel` text and any text in elements referenced by `ariaLabelledby` are properly translated to match the user's language.
+
+For example:
+
+```jsx
+// Using ariaLabel
+<Popover ariaLabel="Passenger selection options" content={passengerSelectionContent}>
+  <Button asComponent="div">Select passengers</Button>
+</Popover>
+```
+
+```jsx
+// Using ariaLabelledby
+<div>
+  <h2 id="passenger-selection-heading">Passenger selection</h2>
+  <Popover ariaLabelledby="passenger-selection-heading" content={passengerSelectionContent}>
+    <Button asComponent="div">Select passengers</Button>
+  </Popover>
+</div>
+```
+
+The `ariaLabel` and `ariaLabelledby` props provide important context about the popover's content to screen reader users. Always use one of these props to ensure your Popover is accessible.
+
+#### Custom close label
+
+When the popover is closable on mobile devices, the default "Close" label can be overridden with a more descriptive one using the `labelClose` prop.
+
+```jsx
+<Popover content="Popover content" labelClose="Close passenger selection">
+  <Button asComponent="div">Select passengers</Button>
+</Popover>
+```
+
+#### Keyboard navigation
+
+The Popover component supports keyboard navigation:
+
+- The popover can be opened by pressing <kbd>Enter</kbd> or <kbd>Space</kbd> when the trigger element has focus.
+- When open, the popover can be closed by pressing <kbd>Escape</kbd>.
+- Focus is properly managed within the popover when it's open.
+
+#### Appropriate roles
+
+The `role` prop should be chosen based on the popover's content and purpose:
+
+- Use `"dialog"` (the default) for most cases, especially when presenting forms or information.
+- Use `"menu"` when the popover contains a list of actions or menu items.
+- Use `"listbox"` when presenting a list of selectable options.
+- Use `"grid"` for tabular data.
+- Use `"tree"` for hierarchical, expandable/collapsible content.
+
+### Examples
+
+#### Basic popover with proper labeling
+
+```jsx
+<Popover
+  content={<Text>This is additional information about this feature.</Text>}
+  ariaLabel="Feature information"
+>
+  <Button asComponent="div">More info</Button>
+</Popover>
+```
+
+Screen readers would announce: "More info, dialogue pop-up collapsed, button" and when opened: "Feature information, dialog".
+
+#### Popover with custom role and existing label
+
+```jsx
+<Stack>
+  <h2 id="passenger-selection">Passenger selection</h2>
+  <Popover
+    content={
+      <Stack>
+        <Stepper
+          minValue={0}
+          ariaLabelValue="Number of adult passengers"
+          titleIncrement="Add adult passenger"
+          titleDecrement="Remove adult passenger"
+        />
+      </Stack>
+    }
+    role="menu"
+    ariaLabelledby="passenger-selection"
+  >
+    <Button asComponent="div" iconRight={<ChevronDown />}>
+      Select passengers
+    </Button>
+  </Popover>
+</Stack>
+```
+
+In this example, screen readers would announce "Select passengers, menu pop-up collapsed, button" and when opened: "Passenger selection, menu".

--- a/packages/orbit-components/src/Popover/Popover.stories.tsx
+++ b/packages/orbit-components/src/Popover/Popover.stories.tsx
@@ -80,7 +80,6 @@ const meta: Meta<typeof Popover> = {
     onOpen: action("open"),
     onClose: action("close"),
     ariaLabel: "Passengers select",
-    ariaLabelledby: "passengers",
     role: "dialog",
   },
 

--- a/packages/orbit-components/src/Popover/README.md
+++ b/packages/orbit-components/src/Popover/README.md
@@ -20,7 +20,7 @@ The table below contains all types of props available in the Popover component.
 
 | Name           | Type                                                  | Default             | Description                                                                                                                                          |
 | :------------- | :---------------------------------------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
-| actions        | `React.Node`                                          |                     | Actions to display at the bottom of the Popover [See Functional specs](#functional-specs).                                                           |
+| actions        | `React.Node`                                          |                     | Actions to display at the bottom of the Popover. [See Functional specs](#functional-specs)                                                           |
 | **content**    | `React.Node`                                          |                     | The content to display in the Popover.                                                                                                               |
 | **children**   | `React.Node`                                          |                     | The reference element where the Popover will appear.                                                                                                 |
 | dataTest       | `string`                                              |                     | Optional prop for testing purposes.                                                                                                                  |
@@ -35,7 +35,7 @@ The table below contains all types of props available in the Popover component.
 | maxHeight      | `string`                                              |                     | The maximum height of the content of the popover, if undefined, it is set to `100%`.                                                                 |
 | onClose        | `() => void \| Promise`                               |                     | Function for handling onClose.                                                                                                                       |
 | onOpen         | `() => void \| Promise`                               |                     | Function for handling onOpen.                                                                                                                        |
-| placement      | [`placement`](#placement)                             | `bottom-start`      | 12 different placements to choose from.                                                                                                              |
+| placement      | [`placement`](#placement)                             | `bottom-start`      | 15 different placements to choose from.                                                                                                              |
 | lockScrolling  | `boolean`                                             | `true`              | Whether to prevent scrolling of the rest of the page while Popover is open on mobile. This is `true` by default to provide a better user experience. |
 | noFlip         | `boolean`                                             | `false`             | Turns off automatic flipping of the Popover when there is not enough space.                                                                          |
 | allowOverflow  | `boolean`                                             | `false`             | Allows the Popover to be cut off instead of moving it while scrolling to keep it visible.                                                            |
@@ -109,11 +109,3 @@ The table below contains all types of props available in the Popover component.
   <Button>Open Popover</Button>
 </Popover>
 ```
-
-## Accessibility
-
-- `Button` is the most common trigger component for opening and closing the popover. The `Popover` component renders a wrapping `div` with the `role="button"` attribute by default. Ensure that the trigger component is set as a non-interactive component (for example, using the `asComponent` prop) to avoid the accessibility violation of nesting interactive controls (`Interactive controls must not be nested`).
-
-- The `ariaLabelledby` prop allows you to specify an `aria-labelledby` attribute for the popover content component. This attribute provides a reference to one or more elements that label the popover content. By using `ariaLabelledby`, the accessibility of popover component is improved and it is easier for users with assistive technologies to understand the context and purpose of the content.
-
-- The `ariaLabel` prop allows you to specify an `aria-label` attribute for the popover content component. This attribute provides additional information to screen readers, enhancing the accessibility of the component. By using `ariaLabel`, you can ensure that users who rely on assistive technologies receive the necessary context and information about the component's purpose and functionality.

--- a/packages/orbit-components/src/Popover/index.tsx
+++ b/packages/orbit-components/src/Popover/index.tsx
@@ -188,7 +188,7 @@ const Popover = ({
         tabIndex={0}
         onClick={handleClick}
         onKeyDown={handleKeyDown<HTMLDivElement>(handleClick)}
-        aria-controls={overlayId}
+        aria-controls={shown ? id || popoverId : undefined}
         aria-haspopup={role}
         aria-expanded={shown}
       >


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2341, https://kiwicom.atlassian.net/browse/FEPLT-2392

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds accessibility documentation for the Popover component and updates the component's props to enhance accessibility features.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Trigger as Popover Trigger
    participant Popover
    participant Screen Reader

    User->>Trigger: Focuses on trigger element
    Screen Reader-->>User: Announces trigger state and role

    Note over Trigger,Popover: New ARIA attributes added:<br/>aria-controls<br/>aria-haspopup<br/>aria-expanded

    User->>Trigger: Clicks/Presses Enter
    Trigger->>Popover: Opens popover
    Popover-->>Screen Reader: Announces ariaLabel/role
    
    Note over Popover: New accessibility props:<br/>ariaLabel<br/>ariaLabelledby<br/>role (dialog/menu/etc)

    User->>Popover: Interacts with content
    Popover-->>Screen Reader: Provides context via ARIA labels

    User->>Popover: Presses Escape
    Popover->>Trigger: Closes popover
    Screen Reader-->>User: Announces closed state
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4718/files#diff-75026a419a27c1f4d178149db48b26bde704f601267bfd98d7e17c440ef50c49>docs/src/__examples__/Popover/DEFAULT.tsx</a></td><td>Added ariaLabel prop to the Popover component for better accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4718/files#diff-ed447b1016f399c0c413d78745f6c9c218e7a78f4c29da6fd5309c3d13bc5da3>docs/src/__examples__/Popover/TRIGGER.tsx</a></td><td>Added ariaLabel prop to the Popover component for better accessibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4718/files#diff-db0d228307fd524be648092ceabc8d10b0161c86de4f83604beb9a9c72b43e94>docs/src/documentation/03-components/04-overlay/popover/03-accessibility.mdx</a></td><td>Created a new documentation file detailing accessibility features and best practices for the Popover component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4718/files#diff-ca29b1b6c6e3ddd66c963c9eb160b7558afe340a282948a873269ca514eda188>packages/orbit-components/src/Popover/Popover.stories.tsx</a></td><td>Updated story to remove ariaLabelledby prop for better clarity.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4718/files#diff-9ca39918a965f479ab1b26f600baee10d735108736c0babb261fe247b0605444>packages/orbit-components/src/Popover/README.md</a></td><td>Updated README to clarify the actions prop description.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4718/files#diff-1749fd3089b157f03d9a036ffcccba86319fe6c34eb3331487f8bcdf94be5c2f>packages/orbit-components/src/Popover/index.tsx</a></td><td>Modified aria-controls attribute to conditionally include the ID based on the popover's visibility.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->










