### PR TITLE
docs: add Accessibility tab for the Accordion component

### DIFF
--- a/docs/src/documentation/03-components/02-structure/accordion/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/02-structure/accordion/03-accessibility.mdx
@@ -1,0 +1,54 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/accordion/accessibility/
+---
+
+## Accessibility
+
+The Accordion component has been designed with accessibility in mind, providing collapsible sections that are fully keyboard navigable and screen reader compatible.
+
+### Accessibility Props
+
+**AccordionSection props:**
+
+| Name              | Type      | Default | Description                                                                                                                           |
+| :---------------- | :-------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------ |
+| expandOnTileClick | `boolean` | `false` | When `true`, makes the entire header area clickable to expand/collapse the section, improving the touch target size for mobile users. |
+
+### Automatic Accessibility Features
+
+- The component automatically manages ARIA attributes when a section is expandable AND `expandOnTileClick` is true:
+  - `role="button"` is applied to the header
+  - `aria-expanded` is set to `true` or `false` based on the section's expanded state
+  - `aria-controls` associates the header with its controlled content section
+  - `tabIndex` is set to 0 to include the header in the tab order
+
+### Keyboard Navigation
+
+The Accordion component supports the following keyboard interactions:
+
+- **Enter/Space:** When focus is on a section header with `expandOnTileClick` enabled, pressing Enter or Space will toggle the expansion state
+- **Tab:** Moves focus to the next focusable element (header or interactive elements within expanded sections)
+- **Shift + Tab:** Moves focus to the previous focusable element
+
+### Best Practices
+
+- Provide descriptive headers that clearly indicate the content of each section
+- Consider enabling `expandOnTileClick` for interfaces primarily used on mobile devices
+- Interactive elements in the main content area should only be accessible when their section is expanded
+
+### Example
+
+```jsx
+<Accordion id="faq-accordion">
+  <AccordionSection id="section-1" header="What is Orbit?" expandOnTileClick>
+    Orbit is Kiwi.com's design system for creating consistent user experiences across products.
+  </AccordionSection>
+  <AccordionSection id="section-2" header="How do I use Accordion?" expandOnTileClick>
+    Import the Accordion and AccordionSection components and nest the sections within the accordion.
+  </AccordionSection>
+</Accordion>
+```
+
+Screen reader announces: "What is Orbit?, button, collapsed" when focusing on the first section header.

--- a/packages/orbit-components/src/Accordion/README.md
+++ b/packages/orbit-components/src/Accordion/README.md
@@ -20,31 +20,27 @@ After adding import into your project you can use it simply like:
 | --------------- | --------------------------------------------------------------------------------- | -------- | ------- | --------------------------------------------------------------------------- |
 | children        | `React.ReactNode`                                                                 |          |         | The content of the Accordion. You can use only AccordionSection             |
 | expandedSection | `string \| number`                                                                |          |         | Optional prop to control which AccordionSection (by id) is expanded         |
-| loading         | `boolean`                                                                         |          |         | If true it will render the Loading component                                |
+| loading         | `boolean`                                                                         |          | `false` | If true it will render the Loading component                                |
 | onExpand        | `(sectionId: string \| number) => void \| Promise<any>`                           |          |         | Callback (along with sectionId) that is triggered when section is expanding |
-| dataTest        | `string`                                                                          |          |         |                                                                             |
+| dataTest        | `string`                                                                          |          |         | Optional prop for testing purposes                                          |
 | id              | `string`                                                                          |          |         | Set `id` for `Accordion`                                                    |
-| spaceAfter      | `"none" \| "smallest" \| "small" \| "normal" \| "medium" \| "large" \| "largest"` |          |         |                                                                             |
+| spaceAfter      | `"none" \| "smallest" \| "small" \| "normal" \| "medium" \| "large" \| "largest"` |          |         | Additional space after the component                                        |
 
 ## AccordionSection
 
 ## Props
 
-| Name              | Type               | Required | Default | Description                                                                                             |
-| ----------------- | ------------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| id                | `string \| number` |          |         |                                                                                                         |
-| children          | `React.ReactNode`  |          |         |                                                                                                         |
-| actions           | `React.ReactNode`  |          |         |                                                                                                         |
-| expanded          | `boolean`          |          |         |                                                                                                         |
-| expandable        | `boolean`          |          |         |                                                                                                         |
-| expandOnTileClick | `boolean`          |          | `false` | If true, enables mobile-first interaction where the entire header area becomes clickable for expansion. |
-| onExpand          | `Common.Callback`  |          |         |                                                                                                         |
-| header            | `React.ReactNode`  |          |         |                                                                                                         |
-| footer            | `React.ReactNode`  |          |         |                                                                                                         |
-| dataTest          | `string`           |          |         |                                                                                                         |
+| Name              | Type              | Required | Default | Description                                                                                   |
+| ----------------- | ----------------- | -------- | ------- | --------------------------------------------------------------------------------------------- |
+| id                | `string`          |          |         | Unique identifier for the section, used by `expandedSection`                                  |
+| children          | `React.ReactNode` |          |         | The content of the AccordionSection                                                           |
+| actions           | `React.ReactNode` |          |         | Additional actions to be displayed in the header                                              |
+| expandable        | `boolean`         |          | `true`  | Whether the section can be expanded                                                           |
+| expandOnTileClick | `boolean`         |          | `false` | Enables mobile-first interaction where the entire header area becomes clickable for expansion |
+| header            | `React.ReactNode` |          |         | The content of the section header                                                             |
+| footer            | `React.ReactNode` |          |         | Additional content to display at the bottom of an expanded section                            |
+| dataTest          | `string`          |          |         | Optional prop for testing purposes                                                            |
 
-### Callback
+## Functional specs
 
-| Callback                      |
-| ----------------------------- |
-| `() => void \| Promise<void>` |
+- By default, the Accordion component operates in an uncontrolled mode. For programmatic control, use the `expandedSection` and `onExpand` props together.


### PR DESCRIPTION
AI-generated, with little tweaks 
FEPLT-2346


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds an Accessibility tab for the Accordion component, detailing its accessibility features, props, keyboard navigation, and best practices.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Accordion
    participant AccordionSection
    participant ScreenReader

    User->>Accordion: Loads accordion component
    Note over Accordion: Initializes with loading state<br/>and expanded section tracking

    alt When expandOnTileClick is true
        Accordion->>AccordionSection: Applies ARIA attributes
        AccordionSection->>AccordionSection: Sets role="button"
        AccordionSection->>AccordionSection: Sets aria-expanded
        AccordionSection->>AccordionSection: Sets aria-controls
        AccordionSection->>AccordionSection: Sets tabIndex=0
    end

    User->>AccordionSection: Focuses on header
    AccordionSection->>ScreenReader: Announces section state
    Note over ScreenReader: "Header text, button, collapsed"

    alt Keyboard Interaction
        User->>AccordionSection: Presses Enter/Space
        AccordionSection->>AccordionSection: Toggles expansion
        AccordionSection->>ScreenReader: Announces new state
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4723/files#diff-d9b47a9bcce290891f1d97fee167e0e736236611e4fd535acc94b8b9dfdfdb97>docs/src/documentation/03-components/02-structure/accordion/03-accessibility.mdx</a></td><td>Added documentation for accessibility features of the Accordion component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4723/files#diff-8299409eb2fa566d728c84fc2c40a6ed5745cb0cc7bbf9076132fc45d93a0017>packages/orbit-components/src/Accordion/README.md</a></td><td>Updated README to include new props and functional specifications for the Accordion component.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->














