### PR TITLE
Adjust Accessibility docs for the InputField component

### DIFF
--- a/docs/src/documentation/03-components/05-input/inputfield/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/05-input/inputfield/03-accessibility.mdx
@@ -4,28 +4,87 @@ redirect_from:
   - /components/inputfield/accessibility/
 ---
 
-### Accessibility
+## Accessibility
 
-- For special cases you can use your own, detached `label`. Simply like this:
+The InputField component has been designed with accessibility in mind, providing features that enhance the experience for users of assistive technologies.
+
+### Accessibility props
+
+The following props are available to improve the accessibility of your InputField component:
+
+| Name                 | Type                             | Description                                                                                                                 |
+| :------------------- | :------------------------------- | :-------------------------------------------------------------------------------------------------------------------------- |
+| label                | `Translation`                    | Provides a visible label that is associated with the input field.                                                           |
+| role                 | `string`                         | Defines the role of the input element, which helps screen readers understand its purpose and behavior.                      |
+| ariaLabel            | `string`                         | Adds an `aria-label` to the input, providing a description for screen readers when no visible label is present.             |
+| ariaLabelledby       | `string`                         | References the ID of an element that labels the input, establishing a relationship for screen readers.                      |
+| ariaDescribedby      | `string`                         | References the ID of an element that describes the input, useful for associating additional information with the field.     |
+| ariaAutocomplete     | `inline \| list \| both \| none` | Indicates to screen readers whether and how the input provides autocomplete suggestions.                                    |
+| ariaActiveDescendant | `string`                         | Identifies the currently active descendant in a composite widget, such as when navigating through autocomplete suggestions. |
+| ariaHasPopup         | `boolean`                        | Indicates to screen readers that the input can trigger a popup, like a dropdown menu or dialog.                             |
+| ariaExpanded         | `boolean`                        | Indicates to screen readers whether the associated popup or dropdown is currently expanded.                                 |
+| ariaControls         | `string`                         | Identifies the element controlled by the input, establishing a relationship for screen readers.                             |
+
+### Automatic Accessibility Features
+
+The InputField component automatically handles several important ARIA attributes:
+
+- `aria-invalid`: When the `error` prop is provided, the input is automatically marked as invalid (`aria-invalid="true"`). This helps screen readers announce to users that the input contains an error.
+
+- `aria-describedby`: This attribute is automatically managed to associate `error` or `help` text with the input field:
+  - When the component is not inside an InputGroup and has `error` or `help` text, a unique ID is generated (based on the input's ID) and is combined with the `ariaDescribedby` prop to ensure all descriptions are announced by screen readers.
+  - When the component is inside an InputGroup, the InputGroup completely overrides any `ariaDescribedby` value that was set on the InputField. The InputGroup sets its own feedback ID as the `aria-describedby` value if there are any `error` or `help` values and the tooltip is shown.
+
+These automatic features ensure that the InputField remains accessible even without explicitly setting every ARIA attribute, while still allowing for customization when needed. See the [Examples section](#using-ariadescribedby-for-enhanced-accessibility) for detailed usage examples of `ariaDescribedby`.
+
+### Best practices
+
+- When no visible `label` is provided, use `ariaLabel` to provide an accessible name for the input field to ensure the input's purpose is clear to screen reader users. Alternatively, you can use `ariaLabelledby` to reference the ID of an existing element that labels the input.
+
+- Always ensure that `ariaLabel` text and any text in elements referenced by `ariaLabelledby` are properly translated to match the user's language.
+
+- Don't rely solely on `placeholder` for providing instructions or label of the input.
+
+- For inputs that trigger autocomplete behavior or control other elements, use the appropriate ARIA attributes (`ariaAutocomplete`, `ariaActiveDescendant`, `ariaHasPopup`, `ariaExpanded`, `ariaControls`) to make the functionality accessible.
+
+- When using `prefix` or `suffix` elements, ensure they don't interfere with the accessibility of the input field and are properly labeled if they are interactive.
+
+### Examples
+
+#### Basic InputField with label
 
 ```jsx
-<label for="NICEID">Content</label>
+<InputField label="Email address" placeholder="your@email.com" type="email" name="email" required />
+```
+
+In this example, screen readers would announce "Email address, required, edit, email" when focusing on the input field.
+
+#### InputField with autocomplete
+
+```jsx
 <InputField
-  id="NICEID"
+  label="City"
+  placeholder="Start typing..."
+  role="combobox"
+  ariaHasPopup={true}
+  ariaExpanded={suggestionsVisible}
+  ariaControls="city-suggestions"
+  ariaAutocomplete="list"
+  ariaActiveDescendant={activeItemId}
 />
 ```
 
-- The `ariaLabel` prop allows you to specify an `aria-label` attribute for the InputField component. This attribute provides additional information to screen readers, enhancing the accessibility of the component. By using `ariaLabel`, you can ensure that users who rely on assistive technologies receive the necessary context and information about the component's purpose and functionality.
+In this example, the InputField is configured as a combobox with autocomplete features. Screen readers would announce information about the combobox state, including whether suggestions are available and which suggestion is currently active.
 
-- If the `label` prop is not provided, the `ariaLabel` prop must be specified to ensure component accessibility.
+#### Using ariaDescribedby for enhanced accessibility
 
-- The `ariaDescribedby` prop allows you to specify an `aria-describedby` attribute for the InputField component. This attribute links the component to additional descriptive text, enhancing accessibility by providing supplementary information to screen readers.
+The `ariaDescribedby` prop allows you to specify an `aria-describedby` attribute for the InputField component. This attribute links the component to additional descriptive text, enhancing accessibility by providing supplementary information to screen readers.
 
 ```jsx
-  <InputField label="Password" type="password" ariaDescribedby="password-requirements" />
-  <p id="password-requirements" style={{ display: "none", visibility: "hidden" }}>
-    Password must be at least 8 characters long and include at least one uppercase letter and one number.
-  </p>
+<InputField label="Password" type="password" ariaDescribedby="password-requirements" />
+<p id="password-requirements" style={{ display: "none", visibility: "hidden" }}>
+  Password must be at least 8 characters long and include at least one uppercase letter and one number.
+</p>
 ```
 
 When using the `error` or `help` props, the component automatically manages the `aria-describedby` attribute:
@@ -39,10 +98,10 @@ In this example, the error message is automatically associated with the input fi
 If you provide both an `ariaDescribedby` prop and use `error` or `help`, the component automatically combines them, ensuring that screen readers announce all descriptive content:
 
 ```jsx
-  <p id="email-hint" style={{ display: "none", visibility: "hidden" }}>
-    We'll never share your email with anyone else.
-  </p>
-  <InputField label="Email" error="Invalid email format" ariaDescribedby="email-hint" />
+<InputField label="Email" error="Invalid email format" ariaDescribedby="email-hint" />
+<p id="email-hint" style={{ display: "none", visibility: "hidden" }}>
+  We'll never share your email with anyone else.
+</p>
 ```
 
 In this example, both the "email-hint" text and the error message will be announced by screen readers. The text from `ariaDescribedby` will be announced first, followed by the text from `error`.
@@ -51,9 +110,9 @@ In this example, both the "email-hint" text and the error message will be announ
 
 When using InputField within an InputGroup, the `aria-describedby` association follows these rules:
 
-#### Example 1
+#### Group-level error/help messages
 
-If the InputGroup has `error`/`help` messages, these will be properly associated with all child components:
+If the InputGroup has `error`/`help` messages, all child components will have `aria-describedby` set to these values **by default:**
 
 ```jsx
 <InputGroup label="Passenger details" error="Incomplete information">
@@ -64,7 +123,7 @@ If the InputGroup has `error`/`help` messages, these will be properly associated
 
 In this example, all InputField components will have the InputGroup's error message "Incomplete information" announced by screen readers.
 
-#### Example 2
+#### Component-level error/help messages
 
 If individual InputField components have their own `error`/`help` messages (and the InputGroup doesn't), only those specific components will have `aria-describedby` set:
 
@@ -77,7 +136,7 @@ If individual InputField components have their own `error`/`help` messages (and 
 
 In this example, only the second InputField will have its error message "Last name is required" announced.
 
-#### Example 3
+#### Component-level ariaDescribedby value
 
 Avoid setting `ariaDescribedby` directly on InputField components when inside an InputGroup, as these values will be overwritten by the InputGroup's internal accessibility logic:
 


### PR DESCRIPTION
Added missing aria-* attributes previously not documented and adjusted the document based on the new rules for the accessibility documentation.

Closes https://kiwicom.atlassian.net/browse/FEPLT-2345

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the accessibility documentation for the InputField component by adding missing `aria-*` attributes and adjusting the content based on new accessibility documentation rules.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Screen Reader
    participant InputField
    participant ARIA System

    User->>InputField: Interacts with field
    InputField->>ARIA System: Set automatic attributes
    Note over ARIA System: Sets aria-invalid if error exists
    Note over ARIA System: Manages aria-describedby for error/help

    alt Has Label
        InputField->>Screen Reader: Announce visible label
    else No Label
        InputField->>Screen Reader: Announce via aria-label
    end

    alt Has Autocomplete
        User->>InputField: Types text
        InputField->>ARIA System: Update aria-expanded
        InputField->>ARIA System: Set aria-controls
        InputField->>ARIA System: Update aria-activedescendant
        ARIA System->>Screen Reader: Announce suggestions state
    end

    alt Has Error/Help
        InputField->>ARIA System: Combine describedby references
        ARIA System->>Screen Reader: Announce all descriptions
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4727/files#diff-2ad882504eac28fad21af9efb45f5506c134a3935b808531913e8f53914b7e09>docs/src/documentation/03-components/05-input/inputfield/03-accessibility.mdx</a></td><td>Updated accessibility documentation for the InputField component, including new props and best practices.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




