### PR TITLE
docs: add Accessibility tab for the ListChoice component

### DIFF
--- a/docs/src/documentation/03-components/05-input/listchoice/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/05-input/listchoice/03-accessibility.mdx
@@ -1,0 +1,111 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/listchoice/accessibility/
+---
+
+## Accessibility
+
+The ListChoice component has been designed with accessibility in mind, providing interactive list options that can function as buttons or selectable items.
+
+### Accessibility Props
+
+The following props are available to improve the accessibility of your ListChoice component:
+
+| Name     | Type     | Description                                                                                        |
+| :------- | :------- | :------------------------------------------------------------------------------------------------- |
+| role     | `string` | Specifies the ARIA role of the component. If not provided, the role is set automatically.          |
+| tabIndex | `number` | Specifies the tab order of the component. Default is `0`, automatically set to `-1` when disabled. |
+
+### Automatic Accessibility Features
+
+The ListChoice component handles several important ARIA attributes automatically:
+
+- `aria-disabled` is automatically set to match the `disabled` prop value
+- `aria-checked` is automatically set to the value of the `selected` prop when `selectable` is true
+- Role is automatically determined in this order:
+  - If a `role` prop is explicitly provided, it will use that value
+  - Otherwise, if `selectable` is true, it uses "checkbox"
+  - Otherwise, if `action` is not provided, it uses "button"
+  - If none of these conditions are met, the role will be undefined
+
+### Keyboard Navigation
+
+- **Enter** or **Space** keys trigger the `onClick` action when the component is focused
+- **Tab** key moves focus to and from the component following the document's tab order
+
+### Best practices
+
+- Provide a descriptive `title` that clearly explains the purpose of the list item
+- Use `description` to provide additional context when the action isn't self-explanatory
+- When using `icon`, ensure it visually reinforces the action and is marked as decorative
+- When using a custom `role`, ensure it matches the component's behavior (e.g., use "link" only if it navigates to another page)
+- When using the `selectable` prop, group related options together and ensure your implementation correctly updates the selected state
+
+### Examples
+
+#### Navigation Option
+
+In this example, the ListChoice functions like a navigation link:
+
+```jsx
+<ListChoice
+  title="Flight details"
+  description="View your booking information"
+  icon={<Airplane ariaHidden />}
+  role="link"
+  onClick={() => navigate("/booking-details")}
+/>
+```
+
+Screen reader announces: "Flight details, View your booking information, link"
+
+#### Selectable Option in a Group
+
+```jsx
+<Stack>
+  <ListChoice
+    title="Window seat"
+    selectable
+    selected={selectedSeat === "window"}
+    onClick={() => setSelectedSeat("window")}
+  />
+  <ListChoice
+    title="Aisle seat"
+    selectable
+    selected={selectedSeat === "aisle"}
+    onClick={() => setSelectedSeat("aisle")}
+  />
+</Stack>
+```
+
+Screen reader announces: "Window seat, checkbox, checked" (when selected)
+
+#### Disabled Option
+
+```jsx
+<ListChoice
+  title="Unavailable flight"
+  description="This flight is fully booked"
+  disabled
+  icon={<CloseCircle ariaHidden />}
+/>
+```
+
+Screen reader announces: "Unavailable flight, This flight is fully booked, button, disabled"
+
+#### Option with Action Component
+
+```jsx
+<ListChoice
+  title="Priority boarding"
+  description="Board the plane first"
+  action={
+    <Button size="small" type="secondary">
+      Add €10
+    </Button>
+  }
+/>
+```
+
+Screen reader announces: "Priority boarding, Board the plane first" for the ListChoice content and then "Add €10, button" when navigating to the action button.

--- a/packages/orbit-components/src/ListChoice/README.md
+++ b/packages/orbit-components/src/ListChoice/README.md
@@ -16,17 +16,17 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the ListChoice component.
 
-| Name        | Type                       | Default  | Description                                                                                                                                     |
-| :---------- | :------------------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |
-| dataTest    | `string`                   |          | Optional prop for testing purposes.                                                                                                             |
-| id          | `string`                   |          | Set `id` for `ListChoice`.                                                                                                                      |
-| description | `Translation`              |          | The additional info about the ListChoice.                                                                                                       |
-| disabled    | `boolean`                  | `false`  | If `true`, the ListChoice won't perform any `onClick` action and if `selectable` is set to `true`, the check box glyph will use disabled state. |
-| icon        | `React.Node`               |          | The icon on the left of the ListChoice.                                                                                                         |
-| onClick     | `event => void \| Promise` |          | Function for handling onClick event.                                                                                                            |
-| selectable  | `boolean`                  | `false`  | If `true`, the check box glyph appears on the right size and it will be possible to select the ListChoice.                                      |
-| selected    | `boolean`                  | `false`  | If `true`, the check box glyph will be checked.                                                                                                 |
-| **title**   | `Translation`              |          | The title of the ListChoice.                                                                                                                    |
-| action      | `React.Node`               |          | Area for action elements, like Button.                                                                                                          |
-| role        | `string`                   | `button` | Role of the ListChoice. By default is `button`, if `selectable` is `true` and `role` prop is not set, the role changes to `checkbox`.           |
-| tabIndex    | `number`                   | `0`      | Specifies the tab order of an element.                                                                                                          |
+| Name        | Type                       | Default | Description                                                                                                                                     |
+| :---------- | :------------------------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------- |
+| dataTest    | `string`                   |         | Optional prop for testing purposes.                                                                                                             |
+| id          | `string`                   |         | Set `id` for `ListChoice`.                                                                                                                      |
+| description | `Translation`              |         | The additional info about the ListChoice.                                                                                                       |
+| disabled    | `boolean`                  |         | If `true`, the ListChoice won't perform any `onClick` action and if `selectable` is set to `true`, the check box glyph will use disabled state. |
+| icon        | `React.Node`               |         | The icon on the left of the ListChoice.                                                                                                         |
+| onClick     | `event => void \| Promise` |         | Function for handling onClick event.                                                                                                            |
+| selectable  | `boolean`                  |         | If `true`, the check box glyph appears on the right size and it will be possible to select the ListChoice.                                      |
+| selected    | `boolean`                  | `false` | If `true`, the check box glyph will be checked.                                                                                                 |
+| **title**   | `Translation`              |         | The title of the ListChoice.                                                                                                                    |
+| action      | `React.Node`               |         | Area for action elements, like Button.                                                                                                          |
+| role        | `string`                   |         | ARIA role. Defaults to "checkbox" when selectable, "button" when no action is provided or undefined otherwise.                                  |
+| tabIndex    | `number`                   | `0`     | Specifies the tab order of an element.                                                                                                          |


### PR DESCRIPTION
AI generated, with couple of tweaks.

FEPLT-2351

# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds an Accessibility tab for the ListChoice component, detailing its accessibility features, props, and best practices.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant ListChoice
    participant ScreenReader
    
    Note over ListChoice: Component initialized with props
    
    alt Selectable ListChoice
        User->>ListChoice: Focus on element
        ListChoice->>ScreenReader: Announce title & role="checkbox"
        User->>ListChoice: Press Space/Enter
        ListChoice->>ListChoice: Toggle selected state
        ListChoice->>ScreenReader: Announce checked/unchecked state
    else Navigation ListChoice
        User->>ListChoice: Focus on element
        ListChoice->>ScreenReader: Announce title & role="link"
        User->>ListChoice: Press Space/Enter
        ListChoice->>ListChoice: Execute onClick handler
    else Disabled ListChoice
        User->>ListChoice: Focus on element
        ListChoice->>ScreenReader: Announce title & "disabled"
        Note over ListChoice: No interaction possible
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4729/files#diff-b1ea52adde6acbecfaa4288b09bd3db7886e403ff1ca7f38a9c07563a5d587e1>docs/src/documentation/03-components/05-input/listchoice/03-accessibility.mdx</a></td><td>Added documentation for accessibility features of the ListChoice component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4729/files#diff-c4283d2967303d0b1fcb2384e0b918aca45abb3201338f6f47961697cf9889d2>packages/orbit-components/src/ListChoice/README.md</a></td><td>Updated README to reflect changes in accessibility props and their descriptions.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






