### PR TITLE
docs(Slide): add accessibility docs

### DIFF
--- a/packages/orbit-components/src/utils/Slide/README.md
+++ b/packages/orbit-components/src/utils/Slide/README.md
@@ -16,11 +16,75 @@ import Slide from "@kiwicom/orbit-components/lib/utils/Slide";
 
 ## Props
 
-| Name               | Type             | Default  | Description                                                                                 |
-| :----------------- | :--------------- | :------- | :------------------------------------------------------------------------------------------ |
-| transitionDuration | `string`         | `"fast"` | Determines the duration of the animation. Can be `"slow"`, `"normal"` or `"fast`.           |
-| children           | `React.Node`     |          | The expandable content that should be animated.                                             |
-| maxHeight          | `number \| null` |          | The maximum height the animation should take. Usually it is the height of the container.    |
-| expanded           | `boolean`        | `false`  | Determines if the content is expanded or not. When changed to `true`, the animation occurs. |
-| id                 | `string`         |          | Sets the id for the wrapper component responsible for the animation.                        |
-| ariaLabelledBy     | `string`         |          | Sets the ariaLabelledBy for the wrapper component responsible for the animation.            |
+| Name                 | Type             | Default  | Description                                                                                 |
+| :------------------- | :--------------- | :------- | :------------------------------------------------------------------------------------------ |
+| transitionDuration   | `string`         | `"fast"` | Determines the duration of the animation. Can be `"slow"`, `"normal"` or `"fast"`.          |
+| children             | `React.Node`     |          | The expandable content that should be animated.                                             |
+| maxHeight            | `number \| null` |          | The maximum height the animation should take. Usually it is the height of the container.    |
+| expanded             | `boolean`        | `false`  | Determines if the content is expanded or not. When changed to `true`, the animation occurs. |
+| id                   | `string`         |          | Sets the id for the wrapper component responsible for the animation.                        |
+| ariaLabelledBy       | `string`         |          | Sets the ariaLabelledBy for the wrapper component responsible for the animation.            |
+| stopClickPropagation | `boolean`        | `true`   | Prevents click events inside the component from propagating to parent elements.             |
+
+## Accessibility
+
+### Automatic Accessibility Features
+
+The `Slide` component implements several accessibility features to ensure proper interaction for all users:
+
+- `aria-hidden`: Automatically set to `true` when the content is collapsed and `false` when expanded
+- `aria-labelledby`: When provided via the `ariaLabelledBy` prop, associates the collapsible content with its label element
+
+### Best Practices
+
+When using `Slide` for expandable components (like accordions or collapsible panels), ensure that:
+
+1. The control that toggles the `expanded` state is keyboard focusable and has the corresponding `aria-expanded` attribute
+2. The control has appropriate `aria-controls` attribute pointing to the Slide component's `id`
+3. If the control is an icon or icon button, it should have an accessible name via `aria-label`
+
+### Example with Accessibility Features
+
+```jsx
+import Slide from "@kiwicom/orbit-components/lib/utils/Slide";
+import Button from "@kiwicom/orbit-components/lib/Button";
+import Heading from "@kiwicom/orbit-components/lib/Heading";
+import Text from "@kiwicom/orbit-components/lib/Text";
+import ChevronDown from "@kiwicom/orbit-components/lib/icons/ChevronDown";
+import ChevronUp from "@kiwicom/orbit-components/lib/icons/ChevronUp";
+
+const CollapsibleSection = () => {
+  const [expanded, setExpanded] = React.useState(false);
+  const toggleExpanded = () => setExpanded(!expanded);
+
+  return (
+    <>
+      <Button
+        onClick={toggleExpanded}
+        iconRight={expanded ? <ChevronUp ariaHidden /> : <ChevronDown ariaHidden />}
+        aria-expanded={expanded}
+        aria-controls="details-section"
+      >
+        Toggle Details
+      </Button>
+      <Slide
+        expanded={expanded}
+        maxHeight={200}
+        id="details-section"
+        ariaLabelledBy="details-heading"
+      >
+        <Heading type="title3" id="details-heading">
+          Section Details
+        </Heading>
+        <Text>This content expands and collapses with animation.</Text>
+      </Slide>
+    </>
+  );
+};
+```
+
+### Click Propagation
+
+By default, the `stopClickPropagation` prop is set to `true`, which prevents click events inside the Slide component from bubbling up to parent elements. This helps avoid unintended behaviors when the collapsible content contains interactive elements.
+
+If you need click events to propagate normally, set `stopClickPropagation={false}`.


### PR DESCRIPTION
Closes FEPLT-2404


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds accessibility documentation for the `Slide` component, including props, automatic accessibility features, best practices, and an example usage.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    actor User
    participant Button
    participant Slide
    participant Content

    User->>Button: Clicks "Toggle Details"
    Button->>Button: Updates aria-expanded state
    Button->>Slide: Sets expanded={true}
    Slide->>Slide: Sets aria-hidden={false}
    Slide->>Content: Animates expansion
    Note over Content: Shows content with<br/>maxHeight constraint
    
    User->>Button: Clicks again
    Button->>Button: Updates aria-expanded state
    Button->>Slide: Sets expanded={false}
    Slide->>Slide: Sets aria-hidden={true}
    Slide->>Content: Animates collapse
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4743/files#diff-22b9b41c15efd7a39c8c6c141d0ccbc6d370f19ef248b48b04217277c4786137>packages/orbit-components/src/utils/Slide/README.md</a></td><td>Added detailed accessibility documentation for the Slide component.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






