### PR TITLE
Edit FeatureIcon component documentation

### DIFF
--- a/docs/src/documentation/03-components/08-visuals/featureicon/01-guidelines.mdx
+++ b/docs/src/documentation/03-components/08-visuals/featureicon/01-guidelines.mdx
@@ -26,4 +26,4 @@ import ShortNonvisualSnippet from "snippets/short-nonvisual.mdx";
 
 ## Content
 
-<ShortNonvisualSnippet version={2} visual="icon" associated="feature" />
+<ShortNonvisualSnippet visual="icon" associated="feature" />

--- a/docs/src/documentation/03-components/08-visuals/featureicon/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/08-visuals/featureicon/03-accessibility.mdx
@@ -1,0 +1,59 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/featureicon/accessibility/
+---
+
+## Accessibility
+
+The FeatureIcon component displays an image representing a specific feature or ticket type.
+
+### Accessibility Props
+
+| Name | Type     | Default | Description                                                                  |
+| :--- | :------- | :------ | :--------------------------------------------------------------------------- |
+| alt  | `string` | `""`    | Text alternative for the icon, used by screen readers to describe the image. |
+
+### Image Announcements and Alt Text
+
+The `alt` attribute determines how screen readers announce the FeatureIcon:
+
+- `alt=""` (default): Icon is treated as **decorative** and ignored by screen readers
+- `alt="text"`: Screen readers will announce the provided text
+
+### Best Practices
+
+#### Empty alt text
+
+- The icon has adjacent text describing the feature
+- The icon is purely decorative and doesn't add meaningful information
+
+```jsx
+<Stack direction="row" align="center">
+  <FeatureIcon name="TicketFlexi" alt="" />
+  <Text>Flexi Ticket</Text>
+</Stack>
+```
+
+Screen reader announces: "Flexi Ticket" (the icon is ignored)
+
+#### Descriptive alt text
+
+- The icon stands alone without accompanying text
+- The icon conveys unique information
+
+```jsx
+<FeatureIcon name="TicketFlexi" alt="Flexible ticket option" />
+```
+
+Screen reader announces: "Flexible ticket option"
+
+#### Avoid redundant information
+
+```jsx
+<!-- DON'T do this -->
+<FeatureIcon name="TicketSaver" alt="Saver Ticket" />
+<Text>Saver Ticket</Text>
+```
+
+Screen reader announces: "Saver Ticket, Saver Ticket" (redundant and confusing)

--- a/packages/orbit-components/src/FeatureIcon/README.md
+++ b/packages/orbit-components/src/FeatureIcon/README.md
@@ -16,12 +16,12 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in the FeatureIcon component.
 
-| Name     | Type            | Default | Description                                                                 |
-| :------- | :-------------- | :------ | :-------------------------------------------------------------------------- |
-| alt      | `string`        | `""`    | Optional property for passing own `alt` attribute to the DOM image element. |
-| dataTest | `string`        |         | Optional prop for testing purposes.                                         |
-| id       | `string`        |         | Set `id` for `FeatureIcon`                                                  |
-| **name** | [`enum`](#enum) |         | The name for the displayed feature icon.                                    |
+| Name     | Type            | Default | Description                                                                                                                      |
+| :------- | :-------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------- |
+| alt      | `string`        | `""`    | Defines the alt attribute for the image. Default empty value (`""`) makes the icon decorative (not announced by screen readers). |
+| dataTest | `string`        |         | Optional prop for testing purposes.                                                                                              |
+| id       | `string`        |         | Set unique identifier for `FeatureIcon`                                                                                          |
+| **name** | [`enum`](#enum) |         | The name for the displayed feature icon.                                                                                         |
 
 ### enum
 


### PR DESCRIPTION
closes FEPLT-2408

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the documentation for the `FeatureIcon` component, including accessibility guidelines and prop descriptions.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant FeatureIcon
    participant ScreenReader

    Note over FeatureIcon: Component can be used with or without alt text

    alt With Empty Alt Text (Decorative)
        User->>FeatureIcon: Render with alt=""
        FeatureIcon-->>ScreenReader: Skip announcement
        Note over ScreenReader: Only announces adjacent text
    else With Descriptive Alt Text
        User->>FeatureIcon: Render with alt="description"
        FeatureIcon-->>ScreenReader: Announce alt text
        Note over ScreenReader: Announces provided description
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4745/files#diff-24409a1f67074d7eced2f60a4fba4718d6a588f59310d7334aeabb57c7e205cd>docs/src/documentation/03-components/08-visuals/featureicon/01-guidelines.mdx</a></td><td>Updated the usage of <code>ShortNonvisualSnippet</code> by removing the version prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4745/files#diff-172db56dddef6df190adabb28e249ab29a4696601bad2a3dfadd71dd2049d582>docs/src/documentation/03-components/08-visuals/featureicon/03-accessibility.mdx</a></td><td>Added a new document outlining accessibility considerations for the <code>FeatureIcon</code> component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4745/files#diff-7ef8a668a1bf33b1fac639596d6485d628bf3ab27b87820bfcee372c3a1cd27f>packages/orbit-components/src/FeatureIcon/README.md</a></td><td>Revised the prop table for <code>FeatureIcon</code> to clarify the purpose of the <code>alt</code> attribute.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






