### PR TITLE
Support react 19 in peerDeps

### DIFF
--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -73,8 +73,8 @@
   },
   "peerDependencies": {
     "@babel/runtime": "^7.21.0",
-    "react": "^18.3.0",
-    "react-dom": "^18.3.0"
+    "react": ">=18.3.0",
+    "react-dom": ">=18.3.0"
   },
   "dependencies": {
     "@floating-ui/react": "0.26.24",


### PR DESCRIPTION
By changing the peerDeps, we should now support both React 18.3 and React 19 versions.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the peer dependencies for React and React DOM to support versions 18.3 and above.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant OC as Orbit Components
    participant React as React >=18.3.0
    participant ReactDOM as ReactDOM >=18.3.0
    
    Note over OC,ReactDOM: Added peer dependencies
    OC->>React: Requires >=18.3.0
    OC->>ReactDOM: Requires >=18.3.0
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4747/files#diff-ced9b8c475e111867f2bd565020cd6b2ae431ef7d69db7e7cb5a8bdb57bc46f8>packages/orbit-components/package.json</a></td><td>Updated peer dependencies for React and React DOM to support version 18.3 and above.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.json`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




