### PR TITLE
Add TextLink accessibility documentation

### DIFF
--- a/docs/src/documentation/03-components/01-action/textlink/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/01-action/textlink/03-accessibility.mdx
@@ -1,0 +1,191 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/textlink/accessibility/
+---
+
+## Accessibility
+
+The TextLink component has been designed with accessibility in mind.
+
+### Accessibility Props
+
+The following props are available to improve the accessibility of your TextLink component:
+
+| Name          | Type                            | Description                                                                                         |
+| :------------ | :------------------------------ | :-------------------------------------------------------------------------------------------------- |
+| asComponent   | `string \| () => React.Element` | Allows rendering the component as a different element.                                              |
+| ariaCurrent   | `string`                        | Indicates if the component represents the current item within a set of related elements.            |
+| aria-label    | `string`                        | Defines accessible text for the component, replacing the visible text for screen readers.           |
+| aria-controls | `string`                        | Identifies the element controlled by the component, establishing a relationship for screen readers. |
+| title         | `string`                        | HTML attribute providing additional information.                                                    |
+
+The TextLink component accepts all standard HTML attributes including ARIA attributes. While `ariaCurrent` is implemented as a specific prop, other ARIA attributes (like `aria-controls`, `aria-label`, etc.) can be passed directly as HTML attributes.
+
+### Automatic Accessibility Features
+
+The TextLink component automatically manages several accessibility features:
+
+- The component automatically manages HTML semantics and ARIA attributes:
+
+  - Uses the semantically correct element based on props:
+    - Renders as `<a>` when `href` is provided
+    - Renders as `<button>` when no `href` is provided
+    - Renders as specified custom element when `asComponent` is provided
+  - Sets `role="button"` when `onClick` is provided without `href`
+  - Sets proper `rel` attributes for external links (`noopener`, `noreferrer`)
+  - Sets `type="button"` when rendered as a button element
+
+- Focus management is handled automatically:
+  - Native focus behavior is preserved based on the rendered element
+  - Ensures proper focus appearance for keyboard users
+
+### Best Practices
+
+- Use clear and descriptive link text that describes the destination or purpose of the link. Avoid generic text like "click here" or "read more" without proper context.
+
+- When using icons in links (with `iconLeft` or `iconRight`), ensure they have appropriate accessibility labels:
+
+  - If the icon is decorative and accompanied by text, the icon should be hidden from screen readers
+  - If the icon alone conveys meaning (especially when used without text), use the `ariaLabel` prop on the icon to describe its purpose
+
+- For links that open in a new window/tab (when `external={true}`), ensure users are aware of this behavior:
+
+  - Always use the `<NewWindow />` icon to visually indicate that the link opens in a new window/tab
+  - Add an accessibility label to the icon using `ariaLabel="Opens in new window"` to ensure screen reader users are informed
+
+- For TextLinks with only icons (no text content), always provide an `aria-label` to ensure screen reader users understand the link's purpose.
+
+- The `title` attribute is not reliably announced by screen readers and should not be used as the primary method for providing additional information to screen reader users. Instead:
+  - Use descriptive link text
+  - Use `aria-label` for links with unclear text or icon-only links
+  - For additional descriptive information, consider using visible text or alternative ARIA attributes
+
+### Keyboard Navigation
+
+TextLink components are navigable with keyboard by default:
+
+- **When rendered as anchor (`<a>`):**
+
+  - Users can focus on links using the **Tab** key
+  - Users can activate links using the **Enter** key
+
+- **When rendered as button (`<button>`):**
+  - Users can focus using the **Tab** key
+  - Users can activate using both **Enter** and **Space** keys
+
+On mobile devices with on-screen keyboards, standard touch interactions apply while maintaining the same keyboard accessibility patterns when an external keyboard is connected.
+
+### Examples
+
+#### Using aria-label
+
+```jsx
+<TextLink href="https://orbit.kiwi" aria-label="Visit the Orbit design system website">
+  Orbit
+</TextLink>
+```
+
+Screen reader announces: "Visit the Orbit design system website, link".
+
+#### External link with accessible icon
+
+```jsx
+<TextLink
+  href="https://orbit.kiwi"
+  external
+  iconRight={<NewWindow ariaLabel="Opens in new window" />}
+>
+  Orbit design system
+</TextLink>
+```
+
+Screen reader announces: "Orbit design system, opens in new window, link".
+
+This pattern ensures both visual users and screen reader users understand that the link will open in a new window/tab.
+
+#### Button behavior with onClick
+
+```jsx
+<TextLink onClick={handleClick}>Perform an action</TextLink>
+```
+
+Screen reader announces: "Perform an action, button".
+
+This example shows TextLink rendering as a semantically correct button element when no `href` is provided, improving accessibility while maintaining link-like styling. This ensures proper keyboard interaction patterns, as buttons respond to both Enter and Space keys, while links only respond to Enter.
+
+#### Using ariaCurrent for navigation
+
+```jsx
+import { Stack, List, ListItem, TextLink } from "@kiwicom/orbit-components";
+
+function Navigation() {
+  // Assuming current page is "profile"
+  const currentPage = "profile";
+
+  return (
+    <Stack as="nav" aria-label="Main navigation">
+      <List type="secondary">
+        <ListItem>
+          <TextLink href="/home" ariaCurrent={currentPage === "home" ? "page" : undefined}>
+            Home
+          </TextLink>
+        </ListItem>
+        <ListItem>
+          <TextLink href="/profile" ariaCurrent={currentPage === "profile" ? "page" : undefined}>
+            Profile
+          </TextLink>
+        </ListItem>
+        <ListItem>
+          <TextLink href="/settings" ariaCurrent={currentPage === "settings" ? "page" : undefined}>
+            Settings
+          </TextLink>
+        </ListItem>
+      </List>
+    </Stack>
+  );
+}
+```
+
+When on the profile page, screen readers announce: "Profile, current page, link" when focused on the Profile link.
+
+The `ariaCurrent="page"` attribute helps users of assistive technologies understand which navigation item represents the current page, enhancing orientation within the site.
+
+#### Using aria-controls with TextLink
+
+```jsx
+import { Stack, Text, Box, TextLink } from "@kiwicom/orbit-components";
+import { ChevronDown, ChevronUp } from "@kiwicom/orbit-components/icons";
+
+function ExpandableContent() {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const contentId = "expandable-content";
+
+  return (
+    <Stack>
+      <TextLink
+        onClick={() => setIsExpanded(!isExpanded)}
+        aria-expanded={isExpanded}
+        aria-controls={contentId}
+        iconRight={isExpanded ? <ChevronUp ariaHidden /> : <ChevronDown ariaHidden />}
+        type="secondary"
+      >
+        {isExpanded ? "Hide details" : "Show details"}
+      </TextLink>
+
+      {isExpanded && (
+        <Box id={contentId}>
+          <Text>
+            This content is controlled by the TextLink. When expanded, screen readers can navigate
+            directly between the control and this content.
+          </Text>
+        </Box>
+      )}
+    </Stack>
+  );
+}
+```
+
+In this example, the TextLink controls the visibility of content with ID "expandable-content". The `aria-controls` attribute creates a programmatic relationship between the TextLink and the content it controls, while `aria-expanded` indicates the current state.
+
+When the TextLink is focused, screen readers will announce its text content ('Show details'), its role ('button'), and its expanded state ('collapsed'). Depending on the screen reader, it may also indicate the control relationship with the content it manages.

--- a/packages/orbit-components/src/Breadcrumbs/types.ts
+++ b/packages/orbit-components/src/Breadcrumbs/types.ts
@@ -8,7 +8,7 @@ import type * as Common from "../common/types";
 export interface Props extends Common.Globals, Common.SpaceAfter {
   readonly children: React.ReactNode;
   readonly goBackTitle?: React.ReactNode;
-  readonly onGoBack?: Common.Event<React.SyntheticEvent<HTMLAnchorElement>>;
+  readonly onGoBack?: Common.Event<React.SyntheticEvent<HTMLAnchorElement | HTMLButtonElement>>;
   readonly backHref?: string;
   readonly ariaLabel?: string;
 }

--- a/packages/orbit-components/src/TextLink/README.md
+++ b/packages/orbit-components/src/TextLink/README.md
@@ -16,27 +16,27 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in TextLink component.
 
-| Name            | Type                            | Default     | Description                                                                                                                  |
-| :-------------- | :------------------------------ | :---------- | :--------------------------------------------------------------------------------------------------------------------------- |
-| ariaCurrent     | `string`                        |             | Indicates whether the element represents the current item within within a container or set of related elements.              |
-| asComponent     | `string \| () => React.Element` | `"a"`       | The component used for the root node. Either a string to use a DOM element or a component.                                   |
-| children        | `React.Node`                    |             | The content of the TextLink.                                                                                                 |
-| dataTest        | `string`                        |             | Optional prop for testing purposes.                                                                                          |
-| download        | `boolean \| string`             |             | Can only be used when `href` is defined. Adds the `download` attribute to the the anchor element.                            |
-| id              | `string`                        |             | Set `id` for `TextLink`                                                                                                      |
-| external        | `boolean`                       | `false`     | If `true`, the TextLink opens link in a new tab.                                                                             |
-| href            | `string`                        |             | The URL to link when the TextLink is clicked.                                                                                |
-| iconLeft        | `React.Node`                    |             | The displayed icon.                                                                                                          |
-| iconRight       | `React.Node`                    |             | The displayed icon.                                                                                                          |
-| noUnderline     | `boolean`                       |             | If `true` the TextLink won't have underline in any its state.                                                                |
-| onClick         | `event => void \| Promise`      |             | Function for handling onClick event.                                                                                         |
-| rel             | `string`                        |             | The rel of the TextLink. [See Functional specs](#functional-specs)                                                           |
-| size            | [`enum`](#enum)                 |             | The size of the TextLink. [See Functional specs](#functional-specs)                                                          |
-| standAlone      | `boolean`                       |             | If `true` the TextLink will have safe clickable area, so it's properly accessible. Useful for usages out of a block of text. |
-| stopPropagation | `boolean`                       |             | If `true` the click event on children won't bubble. Useful when you use TextLink inside another clickable element.           |
-| tabIndex        | `string \| number`              |             | Specifies the tab order of an element                                                                                        |
-| title           | `string`                        |             | HTML attribute Title, used forclarification of a link, for screen readers.                                                   |
-| **type**        | [`enum`](#enum)                 | `"primary"` | The color type of the TextLink.                                                                                              |
+| Name            | Type                            | Default        | Description                                                                                                                                                                    |
+| :-------------- | :------------------------------ | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ariaCurrent     | `string`                        |                | Indicates whether the element represents the current item within a container or set of related elements.                                                                       |
+| asComponent     | `string \| () => React.Element` | `"a"/"button"` | The component used for the root node. Either a string to use a DOM element or a component. Defaults to `"a"` when `href` is provided or `"button"` when no `href` is provided. |
+| children        | `React.Node`                    |                | The content of the TextLink.                                                                                                                                                   |
+| dataTest        | `string`                        |                | Optional prop for testing purposes.                                                                                                                                            |
+| download        | `boolean \| string`             |                | Can only be used when `href` is defined. Adds the `download` attribute to the anchor element.                                                                                  |
+| id              | `string`                        |                | Set `id` for `TextLink`                                                                                                                                                        |
+| external        | `boolean`                       | `false`        | If `true`, the TextLink opens link in a new tab.                                                                                                                               |
+| href            | `string`                        |                | The URL to link when the TextLink is clicked.                                                                                                                                  |
+| iconLeft        | `React.Node`                    |                | The displayed icon.                                                                                                                                                            |
+| iconRight       | `React.Node`                    |                | The displayed icon.                                                                                                                                                            |
+| noUnderline     | `boolean`                       |                | If `true` the TextLink won't have underline in any its state.                                                                                                                  |
+| onClick         | `event => void \| Promise`      |                | Function for handling onClick event.                                                                                                                                           |
+| rel             | `string`                        |                | The rel of the TextLink. [See Functional specs](#functional-specs)                                                                                                             |
+| size            | [`enum`](#enum)                 |                | The size of the TextLink. [See Functional specs](#functional-specs)                                                                                                            |
+| standAlone      | `boolean`                       |                | If `true` the TextLink will have safe clickable area, so it's properly accessible. Useful for usages out of a block of text.                                                   |
+| stopPropagation | `boolean`                       |                | If `true` the click event on children won't bubble. Useful when you use TextLink inside another clickable element.                                                             |
+| tabIndex        | `string \| number`              |                | Specifies the tab order of an element                                                                                                                                          |
+| title           | `string`                        |                | HTML attribute `title`.                                                                                                                                                        |
+| **type**        | [`enum`](#enum)                 | `"primary"`    | The color type of the TextLink.                                                                                                                                                |
 
 ### enum
 
@@ -55,3 +55,5 @@ Table below contains all types of the props available in TextLink component.
 - When the `external` is specified, `noopener` value will be automatically added to attribute `rel` for security reason. Read more about it [here](https://web.dev/external-anchors-use-rel-noopener/).
 
 - The default size of the `TextLink` is inherited from parent element, e.g. `TextLink` is wrapped in `Text` component. Use `size` prop only when you need to set it explicitly.
+
+- When no `href` is provided, the component renders as a `<button>` element.

--- a/packages/orbit-components/src/TextLink/TextLink.stories.tsx
+++ b/packages/orbit-components/src/TextLink/TextLink.stories.tsx
@@ -26,11 +26,21 @@ const meta: Meta<typeof TextLink> = {
     onClick: action("onClick"),
   },
 
+  argTypes: {
+    children: {
+      control: {
+        type: "text",
+      },
+    },
+    asComponent: {
+      control: {
+        type: "text",
+      },
+    },
+  },
+
   parameters: {
     info: "TextLink component. Check Orbit.Kiwi for more detailed guidelines.",
-    controls: {
-      exclude: ["onClick", "type", "external", "asComponent", "stopPropagation"],
-    },
   },
 };
 
@@ -43,6 +53,24 @@ export const Default: Story = {
 
   parameters: {
     info: "Default configuration of TextLink component. Check Orbit.Kiwi for more detailed guidelines.",
+    controls: {
+      exclude: [
+        "onClick",
+        "type",
+        "external",
+        "asComponent",
+        "stopPropagation",
+        "ariaCurrent",
+        "iconLeft",
+        "iconRight",
+        "noUnderline",
+        "rel",
+        "size",
+        "standAlone",
+        "tabIndex",
+        "title",
+      ],
+    },
   },
 };
 
@@ -69,6 +97,26 @@ export const LinkWithLeftIcon: Story = {
       },
     },
   },
+
+  parameters: {
+    controls: {
+      exclude: [
+        "onClick",
+        "type",
+        "external",
+        "asComponent",
+        "stopPropagation",
+        "ariaCurrent",
+        "iconRight",
+        "noUnderline",
+        "rel",
+        "size",
+        "standAlone",
+        "tabIndex",
+        "title",
+      ],
+    },
+  },
 };
 
 export const LinkWithRightIcon: Story = {
@@ -91,6 +139,26 @@ export const LinkWithRightIcon: Story = {
       ...LinkWithLeftIcon.argTypes?.iconLeft,
     },
   },
+
+  parameters: {
+    controls: {
+      exclude: [
+        "onClick",
+        "type",
+        "external",
+        "asComponent",
+        "stopPropagation",
+        "ariaCurrent",
+        "iconLeft",
+        "noUnderline",
+        "rel",
+        "size",
+        "standAlone",
+        "tabIndex",
+        "title",
+      ],
+    },
+  },
 };
 
 export const TextLinkInText: Story = {
@@ -110,7 +178,18 @@ export const TextLinkInText: Story = {
   parameters: {
     info: "An example of usage of TextLink in Text component. Check Orbit.Kiwi for more detailed guidelines.",
     controls: {
-      exclude: ["onClick", "external", "asComponent", "stopPropagation"],
+      exclude: [
+        "onClick",
+        "external",
+        "asComponent",
+        "stopPropagation",
+        "iconLeft",
+        "iconRight",
+        "ariaCurrent",
+        "rel",
+        "tabIndex",
+        "title",
+      ],
     },
   },
 
@@ -162,12 +241,7 @@ export const Playground: Story = {
     ...LinkWithRightIcon.args,
     ...TextLinkInText.args,
     external: true,
-    rel: "",
-    tabIndex: "",
     stopPropagation: false,
-    title: "link title",
-    ariaCurrent: "text-link",
-    id: "link-id",
   },
 
   argTypes: {
@@ -179,7 +253,7 @@ export const Playground: Story = {
   parameters: {
     info: "Playground of TextLink component. Check Orbit.Kiwi for more detailed guidelines.",
     controls: {
-      exclude: ["onClick", "asComponent"],
+      exclude: ["onClick", "ariaCurrent", "rel", "id", "title", "stopPropagation"],
     },
   },
 };

--- a/packages/orbit-components/src/TextLink/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/TextLink/__tests__/index.test.tsx
@@ -87,13 +87,17 @@ describe("TextLink", () => {
     expect(element).toHaveAttribute("target", "_blank");
   });
 
-  it("should be focusable and have button role", () => {
-    render(<TextLink>{title}</TextLink>);
+  it("should respect custom tabIndex when provided", () => {
+    const onClick = jest.fn();
+    render(
+      <TextLink onClick={onClick} tabIndex={-1}>
+        {title}
+      </TextLink>,
+    );
 
     const element = screen.getByText(title);
 
-    expect(element).toHaveAttribute("tabIndex", "0");
-    expect(element).toHaveAttribute("role", "button");
+    expect(element).toHaveAttribute("tabIndex", "-1");
   });
 
   it("should render as the given component", () => {
@@ -172,5 +176,32 @@ describe("TextLink", () => {
       const icon = screen.getByTestId("icon");
       expect(icon).toHaveStyle(ICON_SIZES[size]);
     });
+  });
+
+  it("should render as button when no href is provided", () => {
+    const onClick = jest.fn();
+    render(<TextLink onClick={onClick}>{title}</TextLink>);
+
+    const element = screen.getByText(title);
+
+    expect(element.tagName).toBe("BUTTON");
+    expect(element).toHaveAttribute("type", "button");
+    expect(element).toHaveAttribute("role", "button");
+  });
+
+  it("should render as anchor when href is provided", () => {
+    const onClick = jest.fn();
+    render(
+      <TextLink href="https://example.com" onClick={onClick}>
+        {title}
+      </TextLink>,
+    );
+
+    const element = screen.getByText(title);
+
+    expect(element.tagName).toBe("A");
+    expect(element).toHaveAttribute("href", "https://example.com");
+    expect(element).not.toHaveAttribute("type");
+    expect(element).not.toHaveAttribute("role");
   });
 });

--- a/packages/orbit-components/src/TextLink/index.tsx
+++ b/packages/orbit-components/src/TextLink/index.tsx
@@ -17,8 +17,11 @@ function filterAriaDataProps(props: object) {
   }, {});
 }
 
-// eslint-disable-next-line jsx-a11y/anchor-has-content
-const DefaultComponent = props => <a {...props} />;
+const getComponent = (href: string | undefined, asComponent: Props["asComponent"]) => {
+  if (asComponent) return asComponent;
+  if (href) return "a";
+  return "button";
+};
 
 const IconContainer = ({ children, size }) => {
   if (!children) return null;
@@ -51,14 +54,14 @@ const TextLink = ({
   download,
   id,
   tabIndex,
-  asComponent: Component = DefaultComponent,
+  asComponent,
   stopPropagation = false,
   title,
   standAlone,
   noUnderline,
   ...props
 }: Props) => {
-  const onClickHandler = (ev: React.SyntheticEvent<HTMLAnchorElement>) => {
+  const onClickHandler = (ev: React.SyntheticEvent<HTMLAnchorElement | HTMLButtonElement>) => {
     if (stopPropagation) {
       ev.stopPropagation();
     }
@@ -66,6 +69,7 @@ const TextLink = ({
   };
 
   const filteredAriaDataProps = filterAriaDataProps(props);
+  const Component = getComponent(href, asComponent);
 
   return (
     <Component
@@ -76,8 +80,9 @@ const TextLink = ({
       rel={createRel({ href, external, rel })}
       onClick={onClickHandler}
       data-test={dataTest}
-      tabIndex={tabIndex || (!href ? 0 : undefined)}
-      role={!href ? "button" : undefined}
+      tabIndex={tabIndex}
+      type={Component === "button" ? "button" : undefined}
+      role={!href && onClick ? "button" : undefined}
       title={title}
       download={download}
       className={cx(

--- a/packages/orbit-components/src/TextLink/types.ts
+++ b/packages/orbit-components/src/TextLink/types.ts
@@ -17,7 +17,7 @@ interface BaseProps extends Common.Globals {
   readonly iconLeft?: React.ReactNode;
   readonly iconRight?: React.ReactNode;
   readonly noUnderline?: boolean;
-  readonly onClick?: Common.Event<React.SyntheticEvent<HTMLAnchorElement>>;
+  readonly onClick?: Common.Event<React.SyntheticEvent<HTMLAnchorElement | HTMLButtonElement>>;
   readonly rel?: string;
   readonly size?: Common.Size;
   readonly standAlone?: boolean;


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2361

I made the changes in order to fix [the reported violation](https://accesstime.notion.site/Price-breakdown-modal-have-accessibility-issues-1ea87ab0aeef813683ccd98eb6ddb929) (point 1).

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds accessibility documentation for the TextLink component, addressing reported accessibility violations and providing best practices for usage.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant TextLink
    participant Screen Reader
    participant DOM

    Note over TextLink: Component Initialization

    alt Has href prop
        TextLink->>DOM: Render as <a> element
    else No href prop
        TextLink->>DOM: Render as <button> element
    end

    User->>TextLink: Interact with component
    
    alt Keyboard Navigation
        User->>TextLink: Press Tab
        TextLink->>Screen Reader: Announce link/button state
        TextLink->>DOM: Show focus state
        
        alt Is Button
            User->>TextLink: Press Space/Enter
        else Is Link
            User->>TextLink: Press Enter
        end
    end

    alt Has aria-current
        TextLink->>Screen Reader: Announce "current page"
    end

    alt Is External Link
        TextLink->>DOM: Add noopener/noreferrer
        TextLink->>Screen Reader: Announce "Opens in new window"
    end

    alt Has aria-controls
        TextLink->>Screen Reader: Announce controlled element relationship
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4754/files#diff-fdbb76da06f23044ad9aed73edb4546d744b4ef701934185f9a4a56a3a5681f4>docs/src/documentation/03-components/01-action/textlink/03-accessibility.mdx</a></td><td>Added comprehensive accessibility documentation for the TextLink component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4754/files#diff-2188fbe4c8629cad68deec5b4536a1556e07c1b149797b132950f416779f0180>packages/orbit-components/src/Breadcrumbs/types.ts</a></td><td>Updated the <code>onGoBack</code> prop type to accept both anchor and button elements.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4754/files#diff-a449c28402ce15f78f1dd9f6c3c1c84a0408374118c07508342bc67320863516>packages/orbit-components/src/TextLink/README.md</a></td><td>Updated the README to reflect changes in the TextLink component's behavior and props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4754/files#diff-61f1a00a2658e68a7c8f38e725b8727119fe27f57c5790d61241174857ff85cb>packages/orbit-components/src/TextLink/TextLink.stories.tsx</a></td><td>Modified story parameters to include new controls for accessibility props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4754/files#diff-090ed230e714cbeb548cd89f7c1517eb9fdf5db809c27be13cceb377d8579178>packages/orbit-components/src/TextLink/__tests__/index.test.tsx</a></td><td>Added tests to ensure the TextLink component renders correctly as a button or anchor based on props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4754/files#diff-7a9b2693ef2078b7b43d4908cd16c22964b1fc0a49931002638afb2794162b2b>packages/orbit-components/src/TextLink/index.tsx</a></td><td>Refactored component logic to determine the rendered element based on props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4754/files#diff-173d6886acb5891a532ed4e9cc12ad1dd763505c1632cb909ea2297f466d13df>packages/orbit-components/src/TextLink/types.ts</a></td><td>Updated the <code>onClick</code> prop type to accept both anchor and button elements.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






















