### PR TITLE
docs(AirportIllustration): add a11y docs for AirportIllustration component

### DIFF
--- a/docs/src/documentation/03-components/08-visuals/airportillustration/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/08-visuals/airportillustration/03-accessibility.mdx
@@ -1,0 +1,67 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/airportillustration/accessibility/
+---
+
+## Accessibility
+
+The AirportIllustration component has been designed with accessibility in mind, providing appropriate ARIA roles and alt text options for screen reader users.
+
+### Accessibility Props
+
+The following props are available to improve the accessibility of your AirportIllustration component:
+
+| Name | Type                      | Description                                                                                                                                                                                                                                      |
+| :--- | :------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| alt  | `string`                  | Provides alternative text description of the illustration for screen readers when using `role="img"`. Should be used when the illustration conveys important information.                                                                        |
+| role | `"img" \| "presentation"` | Defines the ARIA role of the illustration. Default is `"presentation"`, which hides the illustration from screen readers. Use `"img"` when the illustration conveys important information and be sure to include a meaningful `alt` description. |
+
+### Automatic Accessibility Features
+
+- The component automatically manages ARIA attributes:
+  - Default role is set to `"presentation"` to hide the illustration from screen readers.
+  - When using `role="img"`, the alt text is announced to screen readers.
+
+### Best Practices
+
+- Use `role="presentation"` (default) for illustrations that are purely decorative and do not convey important information.
+- Use `role="img"` with a descriptive `alt` text when the AirportIllustration conveys important information that users need to understand.
+- Keep `alt` text descriptions concise but descriptive when the illustration has informational value.
+- The `alt` text should always be translated to the user's language.
+- Do not use empty alt text (`alt=""`) with `role="img"` as this creates confusion for screen reader users.
+- Consider providing text alternatives in the surrounding content for complex illustrations.
+
+### Examples
+
+#### Decorative Illustration (Default)
+
+```jsx
+<AirportIllustration name="PRGSmartPass" />
+```
+
+Nothing is announced by a screen reader (illustration is skipped as it has `role="presentation"` by default).
+
+#### Informational Illustration
+
+```jsx
+<AirportIllustration
+  name="PRGSmartPass"
+  role="img"
+  alt="Prague Airport SmartPass illustration showing fast track entrance"
+/>
+```
+
+Screen reader announces: "Prague Airport SmartPass illustration showing fast track entrance".
+
+#### Illustration within Content Context
+
+```jsx
+<div>
+  <Heading>Prague Fast Track</Heading>
+  <AirportIllustration name="PRGSmartPass" role="presentation" />
+  <Text>Skip the regular security lines with our SmartPass option at Prague Airport.</Text>
+</div>
+```
+
+Screen reader announces the heading content (`Prague Fast Track`) and text content (`Skip the regular security lines with our SmartPass option at Prague Airport.`), but skips the illustration.

--- a/packages/orbit-components/src/AirportIllustration/README.md
+++ b/packages/orbit-components/src/AirportIllustration/README.md
@@ -16,15 +16,15 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in AirportIllustration component.
 
-| Name       | Type                | Default          | Description                                                                                                      |
-| :--------- | :------------------ | :--------------- | :--------------------------------------------------------------------------------------------------------------- |
-| alt        | `string`            |                  | Optional property for passing own `alt` attribute to the DOM image element. By default, an empty string is used. |
-| dataTest   | `string`            |                  | Optional prop for testing purposes.                                                                              |
-| id         | `string`            |                  | Set `id` for `Illustration`.                                                                                     |
-| **name**   | [`enum`](#enum)     |                  | Name for the displayed Airportillustration.                                                                      |
-| size       | [`enum`](#enum)     | `"medium"`       | The size of the AirportIllustration.                                                                             |
-| spaceAfter | `enum`              |                  | Additional `margin-bottom` after component.                                                                      |
-| role       | `img\|presentation` | `"presentation"` | Optional property for a role attribute.                                                                          |
+| Name       | Type                | Default          | Description                                                                                                                             |
+| :--------- | :------------------ | :--------------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
+| alt        | `string`            |                  | Optional property for passing own `alt` attribute to the DOM image element. By default, an empty string is used. See Accessibility tab. |
+| dataTest   | `string`            |                  | Optional prop for testing purposes.                                                                                                     |
+| id         | `string`            |                  | Set `id` for `Illustration`.                                                                                                            |
+| **name**   | [`enum`](#enum)     |                  | Name for the displayed Airportillustration.                                                                                             |
+| size       | [`enum`](#enum)     | `"medium"`       | The size of the AirportIllustration.                                                                                                    |
+| spaceAfter | `enum`              |                  | Additional `margin-bottom` after component.                                                                                             |
+| role       | `img\|presentation` | `"presentation"` | Optional property for a role attribute. See Accessibility tab.                                                                          |
 
 ### enum
 


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2365

# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds accessibility documentation for the `AirportIllustration` component, detailing accessibility props, automatic features, best practices, and examples for usage.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User as Screen Reader User
    participant AI as AirportIllustration
    participant SR as Screen Reader

    Note over AI: Default role="presentation"

    alt role="presentation" (Default)
        User->>AI: Encounters illustration
        AI->>SR: Skip illustration
        SR->>User: No announcement
    else role="img" with alt text
        User->>AI: Encounters illustration
        AI->>SR: Read alt description
        SR->>User: Announces alt text
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4757/files#diff-8c23b1dae43c63ef974812f30a8fb40a2d565ca8d00c7b72670cb03e24174944>docs/src/documentation/03-components/08-visuals/airportillustration/03-accessibility.mdx</a></td><td>Added accessibility documentation for the AirportIllustration component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4757/files#diff-e7f8ffa331d8f4809a1f8ce87f7fee50111a4d91e53ab2c7465e3796f5a44cfc>packages/orbit-components/src/AirportIllustration/README.md</a></td><td>Updated README to reference accessibility features in the AirportIllustration component.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->










