### PR TITLE
fix(Modal): focus trap was not reacting to DOM changes

### DIFF
--- a/packages/orbit-components/src/Modal/index.tsx
+++ b/packages/orbit-components/src/Modal/index.tsx
@@ -150,13 +150,34 @@ const Modal = React.forwardRef<Instance, Props>(
     };
 
     React.useEffect(() => {
-      focusableElements.current = Array.from(
-        modalContent.current?.querySelectorAll<HTMLElement>(FOCUSABLE_ELEMENT_SELECTORS) || [],
-      );
+      const findFocusableElements = () => {
+        return Array.from(
+          modalContent.current?.querySelectorAll<HTMLElement>(FOCUSABLE_ELEMENT_SELECTORS) || [],
+        );
+      };
+
+      // Find all focusable elements within the modal
+      focusableElements.current = findFocusableElements();
 
       if (focusableElements.current.length) {
         focusableElements.current[0].focus();
       }
+
+      if (!modalContent.current) return undefined;
+
+      const observer = new MutationObserver(() => {
+        focusableElements.current = findFocusableElements();
+      });
+
+      // Start observing the modal content for DOM changes
+      observer.observe(modalContent.current, {
+        childList: true, // Watch for added/removed nodes
+        subtree: true, // Watch all descendants, not just direct children
+      });
+
+      return () => {
+        observer.disconnect();
+      };
     }, []);
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {


### PR DESCRIPTION
When the DOM changed, the focusable list of elements was not updated. By using the MutationObserver, we can update the list of focusable elements.

This was tested with the playroom snippet (paste it as `code` query param):
```
N4Igxg9gJgpiBcIA8UCWA3ABGANgQwGcCA5PAWxgF4AdEAIwHMBaAdwAtUAXGJgOwgBOZPDkwAHJgGYADNMxsmBMAJgxetAHzVemTEgDCEXtwAenLTt2ZgACgCUmShuvarVlZwCuAnTddurJABZaBFMADNUExgoADEICG4BCwCApAAVPDoCFNS0zLoAGVQCc388-KyNAswARiQAegLcircMrMxOAE8xKlo6QlQwTRqAJkbm8taJrOLSlumCgAU8XhgcHKnWvWXV9YXt3SQAIU9OTiNqjtrMU-OjOsa7i94Dw5Ozl6u6OtvPh-GDWely20yaWRWaxwbwq7TokP2oO2H3urzGf1RjyB-1eSOmwLRHVGGJemEBBJheRm8L20LxbXBNKhm0ssMZLLZISgIjedgA3FMAL6C-yNQzGGBmCyNNDoCwgAA0IBYqCgnDYBAQAG0ACy1HUKgCchtGAF1BUA
```
However, to properly test it, you'd need to rebase this branch with the one from #4755. With that you'll be able to navigate Tabs using keyboard and introduce a DOM change.

FEPLT-2736

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces a fix for the focus trap in the Modal component by implementing a MutationObserver to update the list of focusable elements when the DOM changes.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant Modal
    participant MutationObserver
    participant DOM

    Note over Modal: Component Mounts

    Modal->>DOM: Find focusable elements
    DOM-->>Modal: Return focusable elements array
    
    alt Has focusable elements
        Modal->>Modal: Focus first element
    end

    Modal->>MutationObserver: Create observer
    Modal->>MutationObserver: Start observing modal content
    
    loop When DOM changes
        DOM->>MutationObserver: Notify changes
        MutationObserver->>Modal: Update focusable elements
    end

    Note over Modal: Component Unmounts
    Modal->>MutationObserver: Disconnect observer

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4758/files#diff-9a3d7525e5a961e314bd72a8e1b0fd737de3adcf97ea62cd44a6e01142faf132>packages/orbit-components/src/Modal/index.tsx</a></td><td>Updated the Modal component to use MutationObserver for tracking focusable elements.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->




