### PR TITLE
fix(TextLink): onClick prop type was incorrectly set

### DIFF
--- a/packages/orbit-components/src/TextLink/index.tsx
+++ b/packages/orbit-components/src/TextLink/index.tsx
@@ -61,11 +61,15 @@ const TextLink = ({
   noUnderline,
   ...props
 }: Props) => {
-  const onClickHandler = (ev: React.SyntheticEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+  const onClickHandler = (ev: React.SyntheticEvent<HTMLAnchorElement | HTMLElement>) => {
     if (stopPropagation) {
       ev.stopPropagation();
     }
-    if (onClick) onClick(ev);
+
+    if (onClick) {
+      // @ts-expect-error We can't infer the correct event type here, but it works at runtime
+      onClick(ev);
+    }
   };
 
   const filteredAriaDataProps = filterAriaDataProps(props);

--- a/packages/orbit-components/src/TextLink/types.ts
+++ b/packages/orbit-components/src/TextLink/types.ts
@@ -17,7 +17,9 @@ interface BaseProps extends Common.Globals {
   readonly iconLeft?: React.ReactNode;
   readonly iconRight?: React.ReactNode;
   readonly noUnderline?: boolean;
-  readonly onClick?: Common.Event<React.SyntheticEvent<HTMLAnchorElement | HTMLButtonElement>>;
+  readonly onClick?:
+    | Common.Event<React.SyntheticEvent<HTMLAnchorElement>>
+    | Common.Event<React.SyntheticEvent<HTMLElement>>;
   readonly rel?: string;
   readonly size?: Common.Size;
   readonly standAlone?: boolean;


### PR DESCRIPTION
This allows for a broader onClick type. The previous type definition broke for users that had props defined as just AnchorElement.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the `onClick` prop type in the `TextLink` component to allow for a broader type definition, accommodating users with props defined as just `AnchorElement`.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    actor User
    participant TextLink
    participant EventHandler

    User->>TextLink: Clicks TextLink
    TextLink->>EventHandler: onClickHandler(event)
    alt stopPropagation is true
        EventHandler->>EventHandler: ev.stopPropagation()
    end
    alt onClick handler exists
        EventHandler->>EventHandler: onClick(event)
    end
    EventHandler-->>TextLink: Return
    TextLink-->>User: Visual feedback

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4760/files#diff-7a9b2693ef2078b7b43d4908cd16c22964b1fc0a49931002638afb2794162b2b>packages/orbit-components/src/TextLink/index.tsx</a></td><td>Updated the <code>onClickHandler</code> to accept a broader event type and added a type assertion for the <code>onClick</code> function.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4760/files#diff-173d6886acb5891a532ed4e9cc12ad1dd763505c1632cb909ea2297f466d13df>packages/orbit-components/src/TextLink/types.ts</a></td><td>Modified the <code>onClick</code> prop type to include <code>HTMLElement</code> in addition to <code>HTMLAnchorElement</code>.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


