### PR TITLE
docs(Tag): add accessibility documentation

### DIFF
--- a/docs/src/documentation/03-components/07-interaction/tag/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/07-interaction/tag/03-accessibility.mdx
@@ -1,0 +1,77 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/tag/accessibility/
+---
+
+## Accessibility
+
+The Tag component has been designed with accessibility in mind, providing proper semantic structure and keyboard navigation for interactive labels that can be selected, clicked, or removed.
+
+### Accessibility Props
+
+**Tag props:**
+
+| Name         | Type   | Description                                                                                                                                                        |
+| :----------- | :----- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| labelDismiss | string | Specifies the accessible name for the dismiss button when `onRemove` is provided. Required for screen reader users to understand the purpose of the remove action. |
+
+### Automatic Accessibility Features
+
+- The component automatically manages ARIA attributes:
+  - When `onClick` is provided, the tag receives `role="button"` and `tabIndex="0"` to make it keyboard accessible
+  - When `onRemove` is provided, the dismiss button receives `role="button"`, `tabIndex="0"`, and `aria-label` from the `labelDismiss` prop
+  - The dismiss button is properly isolated from the main tag interaction to prevent nested interactive elements
+- Focus management is handled automatically:
+  - Interactive tags are included in the tab order with proper focus indicators
+  - The dismiss button can be focused independently from the main tag when both are present
+- Keyboard navigation is fully supported:
+  - **Space** and **Enter** keys activate both the main tag and dismiss button
+  - Event propagation is properly managed to prevent conflicts between tag and dismiss actions
+
+### Best Practices
+
+- Always provide a `labelDismiss` prop when using `onRemove` to ensure screen reader users understand the purpose of the dismiss button.
+- Use clear, descriptive text content for tags to help users understand their meaning and purpose.
+- Use the `selected` prop to indicate which tags are currently active or applied, providing clear visual feedback through enhanced contrast and styling.
+
+### Icons
+
+When using icons in tags:
+
+- Provide an `ariaLabel` if the icon has a meaning by itself that is not obvious to screen readers, regardless of the existence of text
+- If the icon is decorative and the badge contains text, the icon should be marked as `aria-hidden="true"`
+
+### Examples
+
+#### Basic Interactive Tag
+
+```jsx
+<Tag onClick={() => console.log("Tag clicked")}>Transport</Tag>
+```
+
+Screen reader announces: "Transport, button"
+
+#### Tag with Both Click and Remove Actions
+
+```jsx
+<Tag
+  onClick={() => console.log("Tag clicked")}
+  onRemove={() => console.log("Tag removed")}
+  labelDismiss="Remove transport filter"
+>
+  Transport
+</Tag>
+```
+
+Screen reader announces: "Transport, button" for the main tag, then "Remove transport filter, button" for the dismiss button
+
+#### Tag with Icon
+
+```jsx
+<Tag iconLeft={<Icons.PlusMinus ariaHidden />} onClick={() => console.log("Tag clicked")}>
+  Add Filter
+</Tag>
+```
+
+Screen reader announces: "Add Filter, button"

--- a/packages/orbit-components/src/Tag/README.md
+++ b/packages/orbit-components/src/Tag/README.md
@@ -22,12 +22,12 @@ Table below contains all types of the props available in the Tag component.
 | dataTest     | `string`                |           | Optional prop for testing purposes.                                                                  |
 | iconLeft     | `React.Node`            |           | The displayed icon on the left.                                                                      |
 | id           | `string`                |           | Set `id` for `Tag`.                                                                                  |
-| dateTag      | `string`                |           | Optional prop, if it's true, selected color has a different background.                              |
+| dateTag      | `boolean`               |           | Optional prop, if it's true, selected color has a different background.                              |
 | type         | [`enum`](#enum)         | `neutral` | The color type of the Tag.                                                                           |
 | onClick      | `() => void \| Promise` |           | Function for handling the onClick event.                                                             |
 | onRemove     | `() => void \| Promise` |           | Function for handling the onClick event of the close icon. [See Functional specs](#functional-specs) |
 | selected     | `boolean`               | `false`   | If `true`, the Tag will have selected styles.                                                        |
-| size         | [`enum`](#enum)         | `small`   | Size of the Tag.                                                                                     |
+| size         | [`enum`](#enum)         | `normal`  | Size of the Tag.                                                                                     |
 | ref          | `func`                  |           | Prop for forwarded ref of the Tag.                                                                   |
 | labelDismiss | `string`                |           | Optional prop for `aria-label` attribute of dismiss button (available when `onRemove` is not null).  |
 

--- a/packages/orbit-components/src/Tag/index.tsx
+++ b/packages/orbit-components/src/Tag/index.tsx
@@ -40,6 +40,7 @@ const Tag = React.forwardRef<HTMLDivElement, Props>(
     return (
       <div
         className={cx(
+          "orbit-tag",
           "font-base rounded-150 box-border inline-flex items-stretch justify-center font-medium",
           "duration-fast transition-[color,_background-color,_box-shadow] ease-in-out",
           "tb:rounded-100",
@@ -81,7 +82,7 @@ const Tag = React.forwardRef<HTMLDivElement, Props>(
       >
         <div
           className={cx(
-            "orbit-tag flex items-center",
+            "flex items-center",
             "focus:rounded-150 focus:z-default",
             onRemove ? "ps-200 py-200 pe-100 rounded-l-150" : "p-200 rounded-150",
             selected && [


### PR DESCRIPTION
closes FEPLT-2364


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds accessibility documentation for the Tag component, detailing its accessibility features, props, best practices, and examples.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Tag
    participant Screen Reader
    participant Keyboard

    User->>Tag: Interacts with Tag
    alt Click Interaction
        Tag->>Screen Reader: Announces "Tag content, button"
        Tag-->>User: Visual feedback
    else Keyboard Navigation
        Keyboard->>Tag: Space/Enter key
        Tag->>Screen Reader: Announces interaction
    end

    alt Has Remove Button
        User->>Tag: Clicks remove button
        Tag->>Screen Reader: Announces "labelDismiss text, button"
        Tag-->>User: Removes tag
    end

    Note over Tag: New features:<br/>- dateTag prop for different background<br/>- size enum prop<br/>- Enhanced accessibility support<br/>- Added CSS classes
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4761/files#diff-d40fa55604d8279be0556544709869c4803de154e485309fc3b871df4a0543ca>docs/src/documentation/03-components/07-interaction/tag/03-accessibility.mdx</a></td><td>Added a new documentation file for accessibility features of the Tag component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4761/files#diff-f53862e6bfbb70ba0e3841189296ef2d0f2edfa9a906b276aa0b887e9287e271>packages/orbit-components/src/Tag/README.md</a></td><td>Updated the README to change the type of the <code>dateTag</code> prop from string to boolean.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4761/files#diff-56bd004a2254a93816f9871be6d362dd059114a42c82ad8b6c81e9a21cdd4b7c>packages/orbit-components/src/Tag/index.tsx</a></td><td>Modified the class names for the Tag component to include 'orbit-tag'.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->








