### PR TITLE
chore(Breadcrumbs): fix incorrectly set onGoBack prop type

### DIFF
--- a/packages/orbit-components/src/Breadcrumbs/types.ts
+++ b/packages/orbit-components/src/Breadcrumbs/types.ts
@@ -8,7 +8,9 @@ import type * as Common from "../common/types";
 export interface Props extends Common.Globals, Common.SpaceAfter {
   readonly children: React.ReactNode;
   readonly goBackTitle?: React.ReactNode;
-  readonly onGoBack?: Common.Event<React.SyntheticEvent<HTMLAnchorElement | HTMLButtonElement>>;
+  readonly onGoBack?:
+    | Common.Event<React.SyntheticEvent<HTMLAnchorElement>>
+    | Common.Event<React.SyntheticEvent<HTMLElement>>;
   readonly backHref?: string;
   readonly ariaLabel?: string;
 }


### PR DESCRIPTION
# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the type definition for the `onGoBack` prop in the `Breadcrumbs` component to allow for a broader range of event types.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Breadcrumbs
    participant HTMLElement

    Note over Breadcrumbs: Added onGoBack event handler
    
    User->>Breadcrumbs: Click back button
    alt Has onGoBack handler
        Breadcrumbs->>HTMLElement: Trigger synthetic event
        HTMLElement-->>Breadcrumbs: Event processed
        Breadcrumbs-->>User: Navigation handled
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4762/files#diff-2188fbe4c8629cad68deec5b4536a1556e07c1b149797b132950f416779f0180>packages/orbit-components/src/Breadcrumbs/types.ts</a></td><td>Updated the type definition for the <code>onGoBack</code> prop to include events from <code>HTMLElement</code>.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


