### PR TITLE
docs(ButtonMobileStore): add accessibility documentation

### DIFF
--- a/docs/src/documentation/03-components/01-action/buttonmobilestore/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/01-action/buttonmobilestore/03-accessibility.mdx
@@ -1,0 +1,96 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/buttonmobilestore/accessibility/
+---
+
+## Accessibility
+
+The ButtonMobileStore component has been designed with accessibility in mind, providing accessible mobile app store download buttons with proper semantic structure and screen reader support.
+
+### Accessibility Props
+
+The following props are available to improve the accessibility of your ButtonMobileStore component:
+
+| Name            | Type      | Description                                                                                                                                                                                                                             |
+| :-------------- | :-------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| alt             | `string`  | **Required.** Provides alternative text description of the store button image for screen readers. Should clearly describe the action and store type (e.g., "Download on the App Store" or "Get it on Google Play"). Must be translated. |
+| title           | `string`  | Provides additional context as a tooltip and is announced by screen readers after the alt text. Use to provide supplementary information about the app or download. Must be translated.                                                 |
+| stopPropagation | `boolean` | Controls event bubbling behavior. When `true`, prevents the click event from bubbling up to parent elements, which can help avoid focus management issues in complex layouts.                                                           |
+
+### Automatic Accessibility Features
+
+- The component automatically renders with proper semantic structure:
+  - Renders as a semantic `<a>` element when `href` is provided, creating a proper link that assistive technologies can identify and navigate
+  - Renders as a semantic `<button>` element when no `href` is provided, ensuring proper keyboard focusability and button behavior
+- The component uses an `<img>` element with proper `srcSet` for responsive images while maintaining accessibility through the required `alt` attribute
+- Focus management follows standard behavior with visible focus indicators:
+  - Links (with `href`) are focusable with Tab and activated with Enter
+  - Buttons (without `href`) are focusable with Tab and activated with Enter or Space
+- The component structure ensures screen readers announce both the `alt` text and any title information
+- When rendered as a link, it automatically opens in a new tab with proper `rel="noopener noreferrer"` attributes for security
+
+### Best Practices
+
+- Always provide a descriptive and translated `alt` text that clearly indicates the action and store type
+- Use specific alt text like "Download on the App Store" or "Get it on Google Play" rather than generic text like "Download app"
+- Ensure the `href` points to the actual app store page for the specific app to provide a functional download experience
+- When using the `title` prop, provide additional translated context that supplements but doesn't duplicate the `alt` text
+- Consider the language of your users and use the appropriate `lang` prop to display store buttons in the correct language
+- Ensure sufficient color contrast between the button and its background for users with visual impairments
+- **Inform users that the link opens in a new tab**: Since ButtonMobileStore always opens in a new tab, consider adding context in your surrounding content or using the `title` prop to inform users about this behavior (e.g., "Download the Kiwi.com app (opens in new tab)")
+- **Avoid nesting interactive elements**: Do not place ButtonMobileStore inside other interactive elements like buttons or links, as this creates invalid HTML and confusing user experiences for assistive technology users
+- **Use stopPropagation sparingly**: The `stopPropagation` prop should only be used when absolutely necessary to prevent event conflicts in complex layouts. Avoid using this prop when the button is nested inside other interactive elements, as it can create accessibility issues and confusing user experiences. Instead of using `stopPropagation`, consider restructuring your layout to avoid nested interactive elements entirely
+
+### Examples
+
+#### Basic App Store Button
+
+```jsx
+<ButtonMobileStore
+  type="appStore"
+  href="https://apps.apple.com/app/your-app/id123456789"
+  alt="Download on the App Store"
+/>
+```
+
+Screen reader announces: "link, image, Download on the App Store,"
+
+#### Google Play Button with Additional Context
+
+```jsx
+<ButtonMobileStore
+  type="googlePlay"
+  href="https://play.google.com/store/apps/details?id=com.yourapp"
+  alt="Get it on Google Play"
+  title="Download the Kiwi.com travel app (opens in new tab)"
+/>
+```
+
+Screen reader announces: "link, image, Get it on Google Play, Download the Kiwi.com travel app (opens in new tab)"
+
+#### Localized Store Button
+
+```jsx
+<ButtonMobileStore
+  type="appStore"
+  lang="DE"
+  href="https://apps.apple.com/de/app/your-app/id123456789"
+  alt="Im App Store herunterladen"
+/>
+```
+
+Screen reader announces: "link, image, Im App Store herunterladen"
+
+#### Button Behavior (without href)
+
+```jsx
+<ButtonMobileStore
+  type="appStore"
+  onClick={handleCustomAction}
+  alt="Download on the App Store"
+  title="Custom download action"
+/>
+```
+
+Screen reader announces: "Download on the App Store, Custom download action, button, group"

--- a/packages/orbit-components/src/ButtonMobileStore/ButtonMobileStore.stories.tsx
+++ b/packages/orbit-components/src/ButtonMobileStore/ButtonMobileStore.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof ButtonMobileStore> = {
 
   args: {
     lang: LANGUAGE.EN,
+    title: "",
   },
 
   argTypes: {
@@ -22,6 +23,11 @@ const meta: Meta<typeof ButtonMobileStore> = {
         type: "select",
       },
     },
+    title: {
+      control: {
+        type: "text",
+      },
+    },
   },
 };
 
@@ -29,7 +35,7 @@ export default meta;
 type Story = StoryObj<typeof ButtonMobileStore>;
 
 export const Default: Story = {
-  render: ({ lang }) => (
+  render: ({ lang, title }) => (
     <Stack flex>
       <ButtonMobileStore
         onClick={action("clicked")}
@@ -37,6 +43,7 @@ export const Default: Story = {
         lang={lang}
         type="appStore"
         alt="Download on the App Store"
+        title={title}
       />
       <ButtonMobileStore
         onClick={action("clicked")}
@@ -44,6 +51,7 @@ export const Default: Story = {
         lang={lang}
         type="googlePlay"
         alt="Download on the Google Play"
+        title={title}
       />
     </Stack>
   ),
@@ -51,7 +59,7 @@ export const Default: Story = {
   parameters: {
     info: "This is the default configuration of this component.",
     controls: {
-      exclude: ["type", "alt", "stopPropagation"],
+      exclude: ["type", "alt", "onClick", "href", "stopPropagation"],
     },
   },
 };

--- a/packages/orbit-components/src/ButtonMobileStore/index.tsx
+++ b/packages/orbit-components/src/ButtonMobileStore/index.tsx
@@ -22,26 +22,34 @@ const ButtonMobileStore = ({
   title,
   stopPropagation = false,
 }: Props) => {
-  const onClickHandler = (ev: React.MouseEvent<HTMLAnchorElement>) => {
+  const onClickHandler = (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
     if (stopPropagation) {
       ev.stopPropagation();
-      if (onClick) onClick(ev);
     }
-    if (onClick) onClick(ev);
+    if (onClick) onClick(ev as React.MouseEvent<HTMLAnchorElement>);
   };
 
+  const commonProps = {
+    className: "orbit-button-mobile-store h-1000 inline-block",
+    onClick: onClickHandler,
+    "data-test": dataTest,
+    id,
+  };
+
+  const imageElement = <img srcSet={getSrc(type, lang)} height="40px" alt={alt} title={title} />;
+
+  if (href) {
+    return (
+      <a {...commonProps} href={href} target="_blank" rel="noopener noreferrer">
+        {imageElement}
+      </a>
+    );
+  }
+
   return (
-    <a
-      className="orbit-button-mobile-store h-1000 inline-block"
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      onClick={onClickHandler}
-      data-test={dataTest}
-      id={id}
-    >
-      <img srcSet={getSrc(type, lang)} height="40px" alt={alt} title={title} />
-    </a>
+    <button {...commonProps} type="button">
+      {imageElement}
+    </button>
   );
 };
 

--- a/packages/orbit-components/src/ButtonMobileStore/index.tsx
+++ b/packages/orbit-components/src/ButtonMobileStore/index.tsx
@@ -32,7 +32,7 @@ const ButtonMobileStore = ({
 
   return (
     <a
-      className="h-1000 inline-block"
+      className="orbit-button-mobile-store h-1000 inline-block"
       href={href}
       target="_blank"
       rel="noopener noreferrer"

--- a/packages/orbit-components/src/ButtonMobileStore/types.ts
+++ b/packages/orbit-components/src/ButtonMobileStore/types.ts
@@ -13,5 +13,5 @@ export interface Props extends Common.Globals {
   readonly alt: string;
   readonly title?: string;
   readonly lang?: string;
-  readonly onClick?: (ev: React.MouseEvent<HTMLAnchorElement>) => void;
+  readonly onClick?: (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => void;
 }


### PR DESCRIPTION
Closes [FEPLT-2385](https://kiwicom.atlassian.net/browse/FEPLT-2360)

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds accessibility documentation for the ButtonMobileStore component, detailing its accessibility features, props, best practices, and examples.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant ButtonMobileStore
    participant Screen Reader
    
    Note over ButtonMobileStore: Component renders as either<br/>link (a) or button based on href

    alt Has href prop
        User->>ButtonMobileStore: Clicks store button
        ButtonMobileStore->>Screen Reader: Announces "link, image, [alt text], [title]"
        ButtonMobileStore-->>User: Opens store URL in new tab
    else No href prop
        User->>ButtonMobileStore: Clicks store button
        ButtonMobileStore->>Screen Reader: Announces "button, [alt text], [title]"
        ButtonMobileStore-->>User: Triggers onClick handler
    end

    Note over ButtonMobileStore: Handles events with optional<br/>stopPropagation & onClick
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4763/files#diff-127e6ea9b5c09b5e1a9e7113a7623ae49b75d0015b2bbe681ef1f11d7caa187c>docs/src/documentation/03-components/01-action/buttonmobilestore/03-accessibility.mdx</a></td><td>Added documentation for accessibility features and best practices for the ButtonMobileStore component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4763/files#diff-c1c2a7cbf6c4782d1c6d936b449ea3423762f211b695c6cd434a6703ccdd54b3>packages/orbit-components/src/ButtonMobileStore/ButtonMobileStore.stories.tsx</a></td><td>Updated story to include a title prop for the ButtonMobileStore component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4763/files#diff-28b0308a8f2a2d65174f825c5eecceb9f9a9c89a919dd1b07e69633f83a6b4ec>packages/orbit-components/src/ButtonMobileStore/index.tsx</a></td><td>Modified the ButtonMobileStore component to handle the title prop and adjusted the onClick handler.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4763/files#diff-d5052f41cb144ed24c3261a9d0685f4cc35b1245622ed44c1727bffc0461f22c>packages/orbit-components/src/ButtonMobileStore/types.ts</a></td><td>Updated the Props interface to allow onClick events for both anchor and button elements.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->
























[FEPLT-2385]: https://kiwicom.atlassian.net/browse/FEPLT-2385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ