### PR TITLE
Adjust update visual tests action

### DIFF
--- a/.github/workflows/update-visual-tests.yml
+++ b/.github/workflows/update-visual-tests.yml
@@ -6,7 +6,7 @@ on:
       commitMessage:
         description: "Commit message for the update"
         required: true
-        default: "chore: update visual tests"
+        default:
 
 jobs:
   update-visual-tests-ubuntu:
@@ -34,12 +34,25 @@ jobs:
       - name: Update Visual Tests
         run: yarn components test-ct --update-snapshots
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ubuntu-snapshots
-          path: "**/*.png"
-          retention-days: 1
+      - name: Setup git config
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config user.name "kiwicom-orbit-bot"
+          git config user.email "frontend-platform@kiwi.com"
+
+      - name: Commit changes
+        run: |
+          git fetch
+          git add **/*.png
+          if git diff-index --quiet HEAD; then
+            echo "No changes to linux visual tests. Exiting."
+            exit 0
+          else
+            echo "Commiting changes to linux visual tests"
+            git commit -m "${{ github.event.inputs.commitMessage || 'chore: update visual tests (linux)' }}"
+            git pull --rebase
+            git push
+          fi
 
   update-visual-tests-macos:
     runs-on: macos-latest
@@ -65,33 +78,6 @@ jobs:
       - name: Update Visual Tests
         run: yarn components test-ct --update-snapshots
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-snapshots
-          path: "**/*.png"
-          retention-days: 1
-
-  commit-changes:
-    needs: [update-visual-tests-ubuntu, update-visual-tests-macos]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT }}
-          ref: ${{ github.head_ref }}
-
-      - name: Download Ubuntu snapshots
-        uses: actions/download-artifact@v4
-        with:
-          name: ubuntu-snapshots
-
-      - name: Download macOS snapshots
-        uses: actions/download-artifact@v4
-        with:
-          name: macos-snapshots
-
       - name: Setup git config
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -100,12 +86,14 @@ jobs:
 
       - name: Commit changes
         run: |
-          git add \*.png
+          git fetch
+          git add **/*.png
           if git diff-index --quiet HEAD; then
-            echo "No changes to visual tests. Exiting."
+            echo "No changes to macos visual tests. Exiting."
             exit 0
           else
-            echo "Commiting changes to visual tests"
-            git commit -m "${{ github.event.inputs.commitMessage || 'chore: update visual tests' }}"
+            echo "Commiting changes to macos visual tests"
+            git commit -m "${{ github.event.inputs.commitMessage || 'chore: update visual tests (macos)' }}"
+            git pull --rebase
             git push
           fi


### PR DESCRIPTION
Instead of using artifacts, commits are now done separately.

This change happens because only the macos artifacts (fetched later) were being commited, which was not desired when we wanted to update both linux and macos snapshots.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adjusts the update visual tests action to commit changes separately for Linux and macOS snapshots instead of using artifacts.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Workflow
    participant Ubuntu as Ubuntu Runner
    participant MacOS as MacOS Runner
    participant Git as Git Repository

    GH->>Ubuntu: Run visual tests update
    Ubuntu->>Ubuntu: Execute yarn test-ct
    Ubuntu->>Ubuntu: Configure git (bot credentials)
    Ubuntu->>Git: Fetch latest changes
    Ubuntu->>Ubuntu: Add PNG files
    alt Has Changes
        Ubuntu->>Git: Commit & push linux test updates
    else No Changes
        Ubuntu->>Ubuntu: Skip commit (no changes)
    end

    GH->>MacOS: Run visual tests update
    MacOS->>MacOS: Execute yarn test-ct
    MacOS->>MacOS: Configure git
    MacOS->>Git: Fetch latest changes
    MacOS->>MacOS: Add PNG files
    alt Has Changes
        MacOS->>Git: Commit & push macos test updates
    else No Changes
        MacOS->>MacOS: Skip commit (no changes)
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4768/files#diff-8d2288c0c78037dbbc772a1afbaeaf8f1504b04ff4182c844309dfab0f1a1b16>.github/workflows/update-visual-tests.yml</a></td><td>Updated the workflow to commit visual test changes directly instead of uploading artifacts.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.yml`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




















