### PR TITLE
feat(InputGroup): add required prop to display visual indicator

### DIFF
--- a/packages/orbit-components/src/InputGroup/InputGroup.stories.tsx
+++ b/packages/orbit-components/src/InputGroup/InputGroup.stories.tsx
@@ -389,6 +389,7 @@ export const Playground: Story = {
     inputValue: "",
     spaceAfter: SPACINGS_AFTER.MEDIUM,
     disabled: false,
+    required: false,
   },
 
   argTypes: {

--- a/packages/orbit-components/src/InputGroup/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/InputGroup/__tests__/index.test.tsx
@@ -82,4 +82,17 @@ describe("InputGroup", () => {
 
     expect(ref.current).toBeDefined();
   });
+
+  it("should render required indicator when required prop is true", () => {
+    render(
+      <InputGroup label="Required Field" required>
+        <InputField />
+      </InputGroup>,
+    );
+
+    // Check that the required asterisk is rendered and aria-required is true
+    expect(screen.getByText("*")).toBeInTheDocument();
+    expect(screen.getByText("*")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByRole("group")).toHaveAttribute("aria-required", "true");
+  });
 });

--- a/packages/orbit-components/src/InputGroup/index.tsx
+++ b/packages/orbit-components/src/InputGroup/index.tsx
@@ -36,6 +36,7 @@ const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
       onBlurGroup,
       ariaLabel,
       ariaLabelledby,
+      required,
     },
     ref,
   ) => {
@@ -109,6 +110,7 @@ const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
           data-state={getFieldDataState(!!errorReal)}
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledby}
+          aria-required={required}
         >
           {label && (
             <legend>
@@ -120,6 +122,7 @@ const InputGroup = React.forwardRef<HTMLFieldSetElement, Props>(
                 iconRef={iconRef}
                 onMouseEnter={() => (hasTooltip ? setTooltipShownHover(true) : undefined)}
                 onMouseLeave={() => (hasTooltip ? setTooltipShownHover(false) : undefined)}
+                required={required}
               >
                 {label}
               </FormLabel>

--- a/packages/orbit-components/src/InputGroup/types.ts
+++ b/packages/orbit-components/src/InputGroup/types.ts
@@ -24,4 +24,5 @@ export interface Props extends Common.Globals, Common.SpaceAfter {
   >;
   readonly ariaLabel?: string;
   readonly ariaLabelledby?: string;
+  readonly required?: boolean;
 }


### PR DESCRIPTION
resolves FEPLT-2750


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds a `required` prop to the `InputGroup` component to display a visual indicator for required fields.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant InputGroup
    participant FormLabel
    participant ARIA

    User->>InputGroup: Render with required=true
    InputGroup->>FormLabel: Pass required prop
    FormLabel-->>InputGroup: Render label with asterisk (*)
    InputGroup->>ARIA: Set aria-required=true
    ARIA-->>User: Accessible required state
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4770/files#diff-9039401357cf53e1a6db8986d0a596abc9694f7b6583bd715a1fc0dd12516f97>packages/orbit-components/src/InputGroup/InputGroup.stories.tsx</a></td><td>Added a default value for the <code>required</code> prop in the Playground story.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4770/files#diff-01972f4711ca32a13c7eee1542b06e422499467e752b5d4b88932a24594360ad>packages/orbit-components/src/InputGroup/__tests__/index.test.tsx</a></td><td>Added a test case to check if the required indicator is rendered when the <code>required</code> prop is true.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4770/files#diff-57fefd5d0ae43e5d10e62df7aa73be8d4237c139be050f358fc3c0a9891f032b>packages/orbit-components/src/InputGroup/index.tsx</a></td><td>Updated the <code>InputGroup</code> component to accept and handle the <code>required</code> prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4770/files#diff-74b6035164e2d001a1fd4ffac08d8b8e53dff94162a853f62f258b0bf2fb2f3f>packages/orbit-components/src/InputGroup/types.ts</a></td><td>Extended the <code>Props</code> interface to include the <code>required</code> prop.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


