### PR TITLE
feat(Modal): add new useTopSafeAreaInset prop

### DIFF
--- a/packages/orbit-components/src/Modal/Modal.stories.tsx
+++ b/packages/orbit-components/src/Modal/Modal.stories.tsx
@@ -11,7 +11,6 @@ import { NAMES } from "../Illustration/consts.mts";
 import ChevronBackward from "../icons/ChevronBackward";
 import FlightDirect from "../icons/FlightDirect";
 import Stack from "../Stack";
-import ButtonLink from "../ButtonLink";
 import RenderInRtl from "../utils/rtl/RenderInRtl";
 import Card from "../Card";
 import CardSection from "../Card/CardSection";
@@ -201,8 +200,33 @@ const meta: Meta<ModalPropsAndCustomArgs> = {
   title: "Modal",
   component: Modal,
 
+  args: {
+    lockScrolling: true,
+    preventOverlayClose: false,
+    isMobileFullPage: false,
+    useSafeAreaInset: false,
+    fixedFooter: false,
+    showBack: false,
+    mobileHeader: true,
+    size: SIZES.NORMAL,
+    hasCloseButton: true,
+    disableAnimation: false,
+  },
+
   parameters: {
     info: "Check Orbit.Kiwi for more detailed design guidelines.",
+    controls: {
+      exclude: [
+        "scrollingElementRef",
+        "labelClose",
+        "triggerRef",
+        "onClose",
+        "onScroll",
+        "ariaLabel",
+        "ariaLabelledby",
+        "ariaDescribedby",
+      ],
+    },
   },
 };
 
@@ -232,11 +256,11 @@ function useModal() {
 }
 
 export const RemovableSections: Story = {
-  render: ({ showSection, children }) => {
+  render: ({ showSection, children, showBack, ...args }) => {
     const { Container, onClose, triggerRef } = useModal();
     return (
       <Container>
-        <Modal triggerRef={triggerRef} onClose={onClose} labelClose="Close">
+        <Modal triggerRef={triggerRef} onClose={onClose} labelClose="Close" {...args}>
           <ModalHeader
             title="Enjoy something to eat while you fly"
             illustration={<Illustration name="Meal" size="small" />}
@@ -251,9 +275,11 @@ export const RemovableSections: Story = {
             <Text>Lorem ipsum dolor sit amet</Text>
           </ModalSection>
           <ModalFooter flex={["0 0 auto", "1 1 100%"]}>
-            <Button iconLeft={<ChevronBackward ariaHidden />} type="secondary">
-              Back
-            </Button>
+            {showBack && (
+              <Button iconLeft={<ChevronBackward ariaHidden />} type="secondary">
+                Back
+              </Button>
+            )}
             <Button fullWidth>Proceed to Payment (23.98€)</Button>
           </ModalFooter>
         </Modal>
@@ -269,26 +295,11 @@ export const RemovableSections: Story = {
 
   parameters: {
     info: "An example of a modal with a removable section. Check Orbit.Kiwi for more detailed design guidelines.",
-    controls: {
-      exclude: [
-        "size",
-        "title",
-        "mobileHeader",
-        "isMobileFullPage",
-        "preventOverlayClose",
-        "hasCloseButton",
-        "disableAnimation",
-        "labelClose",
-        "lockScrolling",
-        "fixedFooter",
-        "triggerRef",
-      ],
-    },
   },
 };
 
 export const WithFixedFooter: Story = {
-  render: args => {
+  render: ({ showBack, ...args }) => {
     const { Container, onClose, triggerRef } = useModal();
     return (
       <Container>
@@ -301,9 +312,11 @@ export const WithFixedFooter: Story = {
           <ModalSection suppressed>{modalOutboundSection}</ModalSection>
           <ModalSection>{modalInboundSection}</ModalSection>
           <ModalFooter flex={["0 0 auto", "1 1 100%"]}>
-            <Button iconLeft={<ChevronBackward ariaHidden />} type="secondary">
-              Back
-            </Button>
+            {showBack && (
+              <Button iconLeft={<ChevronBackward ariaHidden />} type="secondary">
+                Back
+              </Button>
+            )}
             <Button fullWidth>Proceed to Payment (23.98€)</Button>
           </ModalFooter>
         </Modal>
@@ -313,7 +326,6 @@ export const WithFixedFooter: Story = {
 
   args: {
     fixedFooter: true,
-    useTopSafeAreaInset: false,
     isMobileFullPage: false,
   },
 
@@ -321,27 +333,27 @@ export const WithFixedFooter: Story = {
     info: "An example of a modal with a fixed footer. Check Orbit.Kiwi for more detailed design guidelines.",
     controls: {
       exclude: [
-        "size",
-        "title",
-        "mobileHeader",
-        "preventOverlayClose",
-        "hasCloseButton",
-        "disableAnimation",
+        "children",
+        "scrollingElementRef",
         "labelClose",
         "triggerRef",
-        "lockScrolling",
+        "onClose",
+        "onScroll",
+        "ariaLabel",
+        "ariaLabelledby",
+        "ariaDescribedby",
       ],
     },
   },
 };
 
 export const WithForm: Story = {
-  render: ({ showSection }) => {
+  render: ({ showSection, showBack, ...args }) => {
     const { Container, onClose, triggerRef } = useModal();
 
     return (
       <Container>
-        <Modal triggerRef={triggerRef} onClose={onClose} labelClose="Close" fixedFooter>
+        <Modal triggerRef={triggerRef} onClose={onClose} labelClose="Close" {...args}>
           <ModalHeader title="Refund" description="Reservation number: 123456789" />
           <ModalSection>
             <Stack>
@@ -381,9 +393,11 @@ export const WithForm: Story = {
             </Stack>
           </ModalSection>
           <ModalFooter flex={["0 0 auto", "1 1 100%"]}>
-            <Button iconLeft={<ChevronBackward ariaHidden />} type="secondary">
-              Back
-            </Button>
+            {showBack && (
+              <Button iconLeft={<ChevronBackward ariaHidden />} type="secondary">
+                Back
+              </Button>
+            )}
             <Button fullWidth>Proceed to Payment (23.98€)</Button>
           </ModalFooter>
         </Modal>
@@ -399,24 +413,22 @@ export const WithForm: Story = {
     info: "An example of a modal with a form. Check Orbit.Kiwi for more detailed design guidelines.",
     controls: {
       exclude: [
-        "size",
-        "title",
-        "mobileHeader",
-        "isMobileFullPage",
-        "preventOverlayClose",
-        "hasCloseButton",
-        "disableAnimation",
+        "children",
+        "scrollingElementRef",
         "labelClose",
         "triggerRef",
-        "lockScrolling",
-        "fixedFooter",
+        "onClose",
+        "onScroll",
+        "ariaLabel",
+        "ariaLabelledby",
+        "ariaDescribedby",
       ],
     },
   },
 };
 
 export const WithItinerary: Story = {
-  render: () => {
+  render: args => {
     const { Container, onClose, triggerRef } = useModal();
 
     return (
@@ -426,6 +438,7 @@ export const WithItinerary: Story = {
           ariaLabel="Itinerary from Prague to Frankfurt"
           onClose={onClose}
           labelClose="Close"
+          {...args}
         >
           <ModalSection>
             <Itinerary>
@@ -461,7 +474,18 @@ export const WithItinerary: Story = {
   parameters: {
     info: "An example of a modal with an Itinerary component. Check Orbit.Kiwi for more detailed design guidelines.",
     controls: {
-      disable: true,
+      exclude: [
+        "children",
+        "scrollingElementRef",
+        "labelClose",
+        "triggerRef",
+        "onClose",
+        "onScroll",
+        "ariaLabel",
+        "ariaLabelledby",
+        "ariaDescribedby",
+        "showBack",
+      ],
     },
   },
 };
@@ -482,24 +506,21 @@ export const WithModalHeaderOnly: Story = {
     );
   },
 
-  args: {
-    mobileHeader: true,
-  },
-
   parameters: {
     info: "An example of a modal with a header only. Check Orbit.Kiwi for more detailed design guidelines.",
     controls: {
       exclude: [
-        "size",
-        "fixedFooter",
-        "title",
-        "isMobileFullPage",
-        "preventOverlayClose",
-        "hasCloseButton",
-        "disableAnimation",
+        "children",
+        "scrollingElementRef",
         "labelClose",
         "triggerRef",
-        "lockScrolling",
+        "onClose",
+        "onScroll",
+        "ariaLabel",
+        "ariaLabelledby",
+        "ariaDescribedby",
+        "showBack",
+        "fixedFooter",
       ],
     },
   },
@@ -546,7 +567,6 @@ export const Playground: StoryObj<PlaygroundStoryProps> = {
                   <Button type="secondary" iconLeft={<ChevronBackward ariaHidden />}>
                     Back
                   </Button>
-                  <ButtonLink type="secondary">Button</ButtonLink>
                 </Stack>
               )}
               <Box justify="end" display="flex">
@@ -563,7 +583,6 @@ export const Playground: StoryObj<PlaygroundStoryProps> = {
     lockScrolling: false,
     preventOverlayClose: false,
     isMobileFullPage: false,
-    useTopSafeAreaInset: false,
     suppressed: false,
     showBack: false,
     illustration: NAMES[0],
@@ -600,7 +619,17 @@ export const Playground: StoryObj<PlaygroundStoryProps> = {
   parameters: {
     info: "Playground of Modal component. Check Orbit.Kiwi for more detailed design guidelines.",
     controls: {
-      exclude: ["children", "triggerRef"],
+      exclude: [
+        "children",
+        "triggerRef",
+        "onClose",
+        "onScroll",
+        "scrollingElementRef",
+        "ariaLabel",
+        "ariaLabelledby",
+        "ariaDescribedby",
+        "id",
+      ],
     },
   },
 };
@@ -630,7 +659,7 @@ export const Rtl: Story = {
               </Text>
             </ModalSection>
             <ModalFooter flex={["0 0 auto", "1 1 100%"]}>
-              <Button type="secondary" iconLeft={<ChevronBackward ariaHidden />}>
+              <Button type="secondary" iconLeft={<ChevronBackward ariaHidden reverseOnRtl />}>
                 Back
               </Button>
               <Button fullWidth>Continue to Payment</Button>

--- a/packages/orbit-components/src/Modal/ModalContext.tsx
+++ b/packages/orbit-components/src/Modal/ModalContext.tsx
@@ -17,7 +17,7 @@ export interface Props {
   readonly closable?: boolean;
   readonly titleID?: string;
   readonly descriptionID?: string;
-  readonly useTopSafeAreaInset?: boolean;
+  readonly useSafeAreaInset?: boolean;
 }
 
 export const ModalContext = React.createContext<Props>({
@@ -32,7 +32,7 @@ export const ModalContext = React.createContext<Props>({
   isMobileFullPage: false,
   isInsideModal: false,
   closable: false,
-  useTopSafeAreaInset: false,
+  useSafeAreaInset: false,
 });
 ModalContext.displayName = "ModalOrbitContext";
 

--- a/packages/orbit-components/src/Modal/ModalHeader/index.tsx
+++ b/packages/orbit-components/src/Modal/ModalHeader/index.tsx
@@ -55,7 +55,7 @@ const ModalHeader = ({
     isMobileFullPage,
     titleID,
     descriptionID,
-    useTopSafeAreaInset,
+    useSafeAreaInset,
   } = React.useContext(ModalContext);
 
   useModalContextFunctions();
@@ -116,8 +116,8 @@ const ModalHeader = ({
             "orbit-modal-mobile-header bg-white-normal",
             "font-base font-heading-display text-extra-large text-heading-foreground ps-600 z-overlay end-1200 h-1300 invisible fixed start-0 box-border inline-block truncate py-0 pe-0 leading-[52px] opacity-0",
             "lm:start-auto lm:end-auto lm:p-0",
-            isMobileFullPage && !useTopSafeAreaInset && "top-0",
-            isMobileFullPage && useTopSafeAreaInset && "top-safe-top",
+            isMobileFullPage && !useSafeAreaInset && "top-0",
+            isMobileFullPage && useSafeAreaInset && "top-safe-top",
             !isMobileFullPage && "top-400",
           )}
           role="presentation"

--- a/packages/orbit-components/src/Modal/README.md
+++ b/packages/orbit-components/src/Modal/README.md
@@ -43,7 +43,7 @@ Table below contains all types of the props available in the Modal component.
 | ariaLabelledby      | `string`                   |            | The `aria-labelledby` attribute of the Modal. It should be used if `title` is not defined on the ModalHeader.                                                                                         |
 | ariaDescribedby     | `string`                   |            | The `aria-describedby` attribute of the Modal. It should be used if `description` is not defined on the ModalHeader.                                                                                  |
 | ariaLabel           | `string`                   |            | The `aria-label` attribute of the Modal. It should be used if `title` is not defined on the ModalHeader and `ariaLabelledby` is undefined.                                                            |
-| useTopSafeAreaInset | `boolean`                  | `false`    | When enabled, the Modal will respect mobile device top safe area to prevent content from being obscured by system UI elements like the notch or status bar.                                           |
+| useSafeAreaInset    | `boolean`                  | `false`    | When enabled, the Modal will respect mobile device safe areas to prevent content from being obscured by system UI elements like the notch, status bar, or home indicator.                             |
 
 ### Modal enum
 

--- a/packages/orbit-components/src/Modal/index.tsx
+++ b/packages/orbit-components/src/Modal/index.tsx
@@ -62,7 +62,7 @@ const Modal = React.forwardRef<Instance, Props>(
       ariaLabel,
       ariaLabelledby,
       ariaDescribedby,
-      useTopSafeAreaInset = false,
+      useSafeAreaInset = false,
     }: Props,
     ref,
   ) => {
@@ -377,7 +377,7 @@ const Modal = React.forwardRef<Instance, Props>(
         isInsideModal: true,
         titleID: modalTitleID,
         descriptionID: modalDescriptionID,
-        useTopSafeAreaInset,
+        useSafeAreaInset,
       }),
       [
         callContextFunctions,
@@ -387,7 +387,7 @@ const Modal = React.forwardRef<Instance, Props>(
         onClose,
         modalTitleID,
         modalDescriptionID,
-        useTopSafeAreaInset,
+        useSafeAreaInset,
       ],
     );
 
@@ -395,14 +395,26 @@ const Modal = React.forwardRef<Instance, Props>(
       ...(!isLargeMobile
         ? {
             maxHeight: isMobileFullPage
-              ? "100%"
+              ? [
+                  useSafeAreaInset
+                    ? "calc(100% - var(--safe-area-inset-top, env(safe-area-inset-top, 0px)))"
+                    : "100%",
+                ]
               : `calc(100% - ${theme.orbit.space800} - ${
                   fixedFooter && Boolean(footerHeight) ? footerHeight : 0
                 }px)`,
-            bottom: `${
-              (!isMobileFullPage ? parseInt(theme.orbit.space800, 10) : 0) +
-              (fixedFooter && Boolean(footerHeight) ? footerHeight : 0)
-            }px`,
+            bottom: useSafeAreaInset
+              ? `calc(${!isMobileFullPage ? parseInt(theme.orbit.space800, 10) : 0}px + ${
+                  fixedFooter && Boolean(footerHeight) ? footerHeight : 0
+                }px + ${
+                  fixedFooter
+                    ? "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))"
+                    : "0px"
+                })`
+              : `${
+                  (!isMobileFullPage ? parseInt(theme.orbit.space800, 10) : 0) +
+                  (fixedFooter && Boolean(footerHeight) ? footerHeight : 0)
+                }px`,
           }
         : {
             "--orbit-modal-footer-height": fixedFooter ? `${footerHeight}px` : "0",
@@ -418,7 +430,7 @@ const Modal = React.forwardRef<Instance, Props>(
           "z-overlay font-base fixed inset-0 box-border size-full overflow-x-hidden outline-none",
           !isMobileFullPage && "bg-[black]/50",
           "lm:overflow-y-auto lm:p-1000 lm:bg-[black]/50",
-          isMobileFullPage && useTopSafeAreaInset && "bg-white-normal",
+          isMobileFullPage && useSafeAreaInset && "bg-white-normal",
         )}
         tabIndex={-1}
         onKeyDown={handleKeyDown}
@@ -453,8 +465,12 @@ const Modal = React.forwardRef<Instance, Props>(
               "orbit-modal-wrapper-content",
               "lm:rounded-modal lm:overflow-visible overflow-y-auto overflow-x-hidden",
               "font-base bg-elevation-flat absolute box-border w-full",
-              isMobileFullPage && useTopSafeAreaInset && "mt-safe-top",
-              !useTopSafeAreaInset && "shadow-level4",
+              isMobileFullPage && useSafeAreaInset && "mt-safe-top",
+              !useSafeAreaInset && "shadow-level4",
+              useSafeAreaInset &&
+                (fixedFooter
+                  ? "after:h-safe-bottom after:bg-elevation-flat after:z-modal lm:after:content-none after:fixed after:inset-x-0 after:bottom-0 after:mx-auto after:w-full after:content-['']"
+                  : "pb-safe-bottom"),
               "lm:relative lm:bottom-auto lm:pb-0",
               "lm:[&_.orbit-modal-section:last-of-type]:pb-1000 lm:[&_.orbit-modal-section:last-of-type:after]:content-none lm:[&_.orbit-modal-section:last-of-type]:mb-[var(--orbit-modal-footer-height,0px)]",
               "lm:[&_.orbit-modal-mobile-header]:w-[calc(var(--orbit-modal-width)-48px-theme(spacing.1000))]",
@@ -478,6 +494,8 @@ const Modal = React.forwardRef<Instance, Props>(
                     ? "[&_.orbit-modal-footer]:shadow-modal-scrolled"
                     : "[&_.orbit-modal-footer]:shadow-modal lm:[&_.orbit-modal-footer]:rounded-b-none",
                   "[&_.orbit-modal-section:last-of-type]:pb-600 [&_.orbit-modal-section:last-of-type]:mb-0",
+                  useSafeAreaInset &&
+                    "[&_.orbit-modal-footer]:bottom-safe-bottom lm:[&_.orbit-modal-footer]:bottom-0",
                 ],
               fixedFooter
                 ? [
@@ -510,7 +528,7 @@ const Modal = React.forwardRef<Instance, Props>(
                   fixedClose || scrolled
                     ? [
                         "lm:right-auto fixed",
-                        isMobileFullPage && useTopSafeAreaInset && "top-safe-top",
+                        isMobileFullPage && useSafeAreaInset && "top-safe-top",
                         "lm:top-0",
                       ]
                     : "absolute",
@@ -519,7 +537,7 @@ const Modal = React.forwardRef<Instance, Props>(
                   modalWidth ? "max-w-[var(--orbit-modal-width)]" : maxWidthClasses[size],
                   scrolled && [
                     "bg-white-normal",
-                    useTopSafeAreaInset
+                    useSafeAreaInset
                       ? // Modified shadow-fixed values to remove top shadow effect for a seamless appearance on mobile
                         "shadow-[0_2px_2px_0_rgba(37,42,49,0.16),_0_4px_4px_0_rgba(37,42,49,0.12)]"
                       : "shadow-fixed",

--- a/packages/orbit-components/src/Modal/types.ts
+++ b/packages/orbit-components/src/Modal/types.ts
@@ -37,7 +37,7 @@ export type Props = Common.Globals &
     readonly ariaLabel?: string;
     readonly ariaLabelledby?: string;
     readonly ariaDescribedby?: string;
-    readonly useTopSafeAreaInset?: boolean;
+    readonly useSafeAreaInset?: boolean;
   };
 
 export interface Instance {


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2761

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces a new prop `useSafeAreaInset` to the Modal component, which allows the modal to respect mobile device safe areas. It includes updates to the Modal context, header, and various stories to demonstrate the new functionality.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Modal
    participant ModalContext
    participant ModalHeader
    participant SafeArea

    User->>Modal: Opens modal
    Modal->>ModalContext: Sets useSafeAreaInset (true/false)
    
    alt useSafeAreaInset is true
        Modal->>SafeArea: Applies safe area insets
        SafeArea-->>Modal: Adjusts for device notch/status bar
        SafeArea-->>Modal: Adjusts for bottom safe area
        ModalHeader-->>SafeArea: Respects top safe area
    else useSafeAreaInset is false
        Modal->>Modal: Uses default spacing
        ModalHeader-->>Modal: Uses default top position
    end

    Modal-->>User: Displays modal with proper spacing
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4779/files#diff-afd413d42814d37946f808743eb69527f22ce2a8fae5f885ec75a096b2074677>packages/orbit-components/src/Modal/Modal.stories.tsx</a></td><td>Added <code>useSafeAreaInset</code> prop to Modal stories and updated render functions to include this prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4779/files#diff-71fe17daf17fd3ac5b0b2c5a6bf9a0b6d5453ae7ca9b46c42d114c01af3fe867>packages/orbit-components/src/Modal/ModalContext.tsx</a></td><td>Updated ModalContext to include <code>useSafeAreaInset</code> in the context props.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4779/files#diff-4675bc170bad59829b9860ce33a01ab430911f561e4891f819ab6afec3eec150>packages/orbit-components/src/Modal/ModalHeader/index.tsx</a></td><td>Modified ModalHeader to utilize the new <code>useSafeAreaInset</code> prop for positioning.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4779/files#diff-868da456755cdd33c11561a2ced4d425d5de820383d387bac0ab85a93e74c56e>packages/orbit-components/src/Modal/README.md</a></td><td>Updated documentation to include <code>useSafeAreaInset</code> prop details.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4779/files#diff-9a3d7525e5a961e314bd72a8e1b0fd737de3adcf97ea62cd44a6e01142faf132>packages/orbit-components/src/Modal/index.tsx</a></td><td>Integrated <code>useSafeAreaInset</code> into the Modal component's props and context.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4779/files#diff-5749681f54a03f2290ce215fec84316d45ccd81cd206f14ce97d8f521369d028>packages/orbit-components/src/Modal/types.ts</a></td><td>Added <code>useSafeAreaInset</code> to the Modal props type definition.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


















