### PR TITLE
feat(Toast): add new useTopSafeAreaInset prop

### DIFF
--- a/packages/orbit-components/src/Toast/README.md
+++ b/packages/orbit-components/src/Toast/README.md
@@ -54,17 +54,18 @@ const notify = () =>
 
 Table below contains all types of the props available for `ToastRoot` component
 
-| Name           | Type                      | Default | Description                           |
-| :------------- | :------------------------ | :------ | :------------------------------------ |
-| dataTest       | `string`                  |         | optional prop for testing purposes.   |
-| id             | `string`                  |         | Set `id` for `Toast` wrapper          |
-| topOffset      | `number`                  | `8`     | top offset for toast container        |
-| leftOffset     | `number`                  | `8`     | left offset for toast container       |
-| rightOffset    | `number`                  | `8`     | right offset for toast container      |
-| bottomOffset   | `number`                  | `8`     | bottom offset for toast container     |
-| gutter         | `number`                  | `8`     | distance between toast notifications  |
-| dismissTimeout | `number`                  | `5000`  | timeout until toast will be dismissed |
-| placement      | [`Placement`](#Placement) |         | position for toast container          |
+| Name                | Type                      | Default | Description                                                                                                                                                                 |
+| :------------------ | :------------------------ | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dataTest            | `string`                  |         | optional prop for testing purposes.                                                                                                                                         |
+| id                  | `string`                  |         | Set `id` for `Toast` wrapper                                                                                                                                                |
+| topOffset           | `number`                  | `8`     | top offset for toast container                                                                                                                                              |
+| leftOffset          | `number`                  | `8`     | left offset for toast container                                                                                                                                             |
+| rightOffset         | `number`                  | `8`     | right offset for toast container                                                                                                                                            |
+| bottomOffset        | `number`                  | `8`     | bottom offset for toast container                                                                                                                                           |
+| gutter              | `number`                  | `8`     | distance between toast notifications                                                                                                                                        |
+| dismissTimeout      | `number`                  | `5000`  | timeout until toast will be dismissed                                                                                                                                       |
+| placement           | [`Placement`](#Placement) |         | position for toast container                                                                                                                                                |
+| useTopSafeAreaInset | `boolean`                 | `false` | When enabled, the Toast container will respect mobile device top safe area to prevent notifications from being obscured by system UI elements like the notch or status bar. |
 
 ### Placement
 

--- a/packages/orbit-components/src/Toast/Toast.stories.tsx
+++ b/packages/orbit-components/src/Toast/Toast.stories.tsx
@@ -58,6 +58,7 @@ export const Default: Story = {
         "gutter",
         "dismissTimeout",
         "placement",
+        "useTopSafeAreaInset",
       ],
     },
   },
@@ -130,6 +131,7 @@ export const Playground: Story = {
     gutter: 8,
     dismissTimeout: 5000,
     placement: PLACEMENTS.TOP_CENTER,
+    useTopSafeAreaInset: false,
   },
 
   argTypes: {
@@ -167,6 +169,7 @@ export const RTL: Story = {
         "gutter",
         "dismissTimeout",
         "placement",
+        "useTopSafeAreaInset",
       ],
     },
   },

--- a/packages/orbit-components/src/Toast/ToastRoot.tsx
+++ b/packages/orbit-components/src/Toast/ToastRoot.tsx
@@ -17,6 +17,7 @@ const ToastRoot = ({
   gutter = 8,
   dismissTimeout = 5000,
   placement = "top-center",
+  useTopSafeAreaInset = false,
 }: Props) => {
   const { toasts, handlers } = useToaster({
     duration: dismissTimeout,
@@ -34,7 +35,9 @@ const ToastRoot = ({
       )}
       style={
         {
-          "--toast-root-top": `${topOffset}px`,
+          "--toast-root-top": useTopSafeAreaInset
+            ? `calc(${topOffset}px + var(--safe-area-inset-top, env(safe-area-inset-top)))`
+            : `${topOffset}px`,
           "--toast-root-bottom": `${bottomOffset}px`,
           "--toast-root-start": `${leftOffset}px`,
           "--toast-root-end": `${rightOffset}px`,

--- a/packages/orbit-components/src/Toast/types.ts
+++ b/packages/orbit-components/src/Toast/types.ts
@@ -27,6 +27,7 @@ export interface Props extends Common.Globals {
   readonly gutter?: number;
   readonly dismissTimeout?: number;
   readonly placement?: Placement;
+  readonly useTopSafeAreaInset?: boolean;
 }
 
 interface ToastProps {


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2767


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces a new prop `useTopSafeAreaInset` to the `Toast` component, allowing it to respect the mobile device's top safe area to prevent notifications from being obscured by system UI elements.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant App
    participant ToastRoot
    participant Device

    App->>ToastRoot: Initialize Toast with useTopSafeAreaInset
    alt useTopSafeAreaInset is true
        ToastRoot->>Device: Get safe-area-inset-top value
        Device-->>ToastRoot: Return safe area inset
        ToastRoot->>ToastRoot: Calculate top offset with safe area
    else useTopSafeAreaInset is false
        ToastRoot->>ToastRoot: Use default top offset
    end
    ToastRoot-->>App: Render Toast with adjusted position

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4783/files#diff-4b786588fe54bd442ee9aca0550d90c72d2df154ad7084214cd2907a66fcb004>packages/orbit-components/src/Toast/README.md</a></td><td>Updated the documentation to include the new <code>useTopSafeAreaInset</code> prop.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4783/files#diff-d185cb9f16142057c648512b47016ea3737d58d9efd58bea84f04e15126b4c45>packages/orbit-components/src/Toast/Toast.stories.tsx</a></td><td>Added the <code>useTopSafeAreaInset</code> prop to the story configurations.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4783/files#diff-76b9a56bdf07f544ac025acd828163df8d8f69a8cdcafcbedb1269ea76b64062>packages/orbit-components/src/Toast/ToastRoot.tsx</a></td><td>Implemented the <code>useTopSafeAreaInset</code> prop in the <code>ToastRoot</code> component to adjust the top offset.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4783/files#diff-9f19f4f04b12b4fb25728fa3893205418661de7905404f19c4fa26986549c8fa>packages/orbit-components/src/Toast/types.ts</a></td><td>Updated the <code>Props</code> interface to include the new <code>useTopSafeAreaInset</code> prop.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




