### PR TITLE
fix(Stack): use 'id' prop on Stack's rendered tag

### DIFF
--- a/packages/orbit-components/src/Stack/README.md
+++ b/packages/orbit-components/src/Stack/README.md
@@ -30,6 +30,7 @@ The table below contains all types of props available in the Stack component.
 | direction    | [`enum`](#enum)            |            | The `flex-direction` of the Stack. [See Functional specs](#functional-specs)                        |
 | flex         | `boolean`                  | `false`    | If `true` or you specify some flex attribute, the Stack will use flex attributes.                   |
 | grow         | `boolean`                  | `true`     | If `true`, the Stack will have `flex-grow` set to `1`, otherwise it will be `0`.                    |
+| id           | `string`                   |            | Optional, sets the id for `Stack`.                                                                  |
 | inline       | `boolean`                  | `false`    | If `true`, the Stack will have `display` set to `inline-flex`.                                      |
 | justify      | [`enum`](#enum)            | `"start"`  | The `justify-content` of the Stack.                                                                 |
 | largeDesktop | [`Object`](#media-queries) |            | Object for setting up properties for the largeDesktop viewport. [See Media queries](#media-queries) |

--- a/packages/orbit-components/src/Stack/index.tsx
+++ b/packages/orbit-components/src/Stack/index.tsx
@@ -41,6 +41,7 @@ const Stack = (props: Props) => {
     children,
     as: ComponentTag = "div",
     dataTest,
+    id,
     basis,
     mediumMobile,
     largeMobile,
@@ -158,6 +159,7 @@ const Stack = (props: Props) => {
   return (
     // @ts-expect-error orbit string as
     <ComponentTag
+      id={id}
       data-test={dataTest}
       style={vars}
       className={cx(


### PR DESCRIPTION
# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds an `id` prop to the Stack component, allowing users to set an ID for the rendered Stack element.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant C as Client Code
    participant S as Stack Component
    participant D as DOM Element

    C->>S: Render Stack with id prop
    Note over S: Add id property to<br/>component props
    S->>D: Render div/custom element<br/>with id attribute
    Note over D: DOM element created<br/>with specified id

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4797/files#diff-d1e17442a3e06dde21743300583641ab4780c56ca56b480d397f338a11dfe455>packages/orbit-components/src/Stack/README.md</a></td><td>Updated documentation to include the new <code>id</code> prop for the Stack component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4797/files#diff-30c9103b612af0d457bcc391892bf0e96e77003fb02f1f0df204308229b934e0>packages/orbit-components/src/Stack/index.tsx</a></td><td>Modified the Stack component to accept and render the <code>id</code> prop.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


