### PR TITLE
ServiceLogo: add alt and role props to improve accessibility, add accessibility doc tab

### DIFF
--- a/docs/src/documentation/03-components/08-visuals/servicelogo/03-accessibility.mdx
+++ b/docs/src/documentation/03-components/08-visuals/servicelogo/03-accessibility.mdx
@@ -1,0 +1,67 @@
+---
+title: Accessibility
+redirect_from:
+  - /components/servicelogo/accessibility/
+---
+
+## Accessibility
+
+The ServiceLogo component has been designed with accessibility in mind, providing flexible display options for service and payment provider logos that can be either decorative or semantic depending on context.
+
+### Accessibility Props
+
+The following prop is available to improve the accessibility of your ServiceLogo component:
+
+| Name | Type     | Description                                                                                                          |
+| :--- | :------- | :------------------------------------------------------------------------------------------------------------------- |
+| alt  | `string` | Specifies the alternative text for the image to provide context about the service logo component for screen readers. |
+
+### Automatic Accessibility Features
+
+- The component automatically manages ARIA attributes:
+  - When `alt` is **not** provided, default role of `"presentation"` is set. This makes the logo decorative and hidden from screen readers.
+  - When `alt` is provided, the role is set to `"img"` and the logo becomes accessible to assistive technologies.
+- Grayscale mode applies visual styling without affecting accessibility (except for the color contrast)
+
+### Best Practices
+
+- If descriptive text should be provided, fill in the `alt` prop. Role of the ServiceLogo component is automatically set to `"img"`, otherwise it is set to `"presentation"` by default.
+- For payment logos, include the payment method name in the alt text (e.g., "Visa", "PayPal", "American Express").
+- For service logos, include the service name and context if relevant (e.g., "Kiwi.com guarantee", "AirHelp assistance").
+- The `alt` text should always be translated to the user’s language.
+- Avoid redundant `alt` text when the logo appears next to visible text containing the same information.
+- Ensure sufficient color contrast when using `grayScale` mode, especially against non-white backgrounds.
+
+### Examples
+
+#### Decorative logo alongside text
+
+```jsx
+<Stack>
+  <ServiceLogo name="Visa" />
+  <Text>Pay with Visa</Text>
+</Stack>
+```
+
+Screen reader announces: "Pay with Visa".
+
+#### Semantic logo with descriptive text
+
+```jsx
+<ServiceLogo name="PayPal" role="img" alt="PayPal payment method" />
+```
+
+Screen reader announces: "PayPal payment method, image".
+
+#### Multiple payment methods (decorative)
+
+```jsx
+<Stack>
+  <ServiceLogo name="Visa" />
+  <ServiceLogo name="MasterCard" />
+  <ServiceLogo name="Amex" />
+  <Text>Visa, MasterCard, and American Express accepted</Text>
+</Stack>
+```
+
+Screen reader announces: "Visa, MasterCard, and American Express accepted".

--- a/packages/orbit-components/src/ServiceLogo/README.md
+++ b/packages/orbit-components/src/ServiceLogo/README.md
@@ -16,13 +16,14 @@ After adding import into your project you can use it simply like:
 
 Table below contains all types of the props available in ServiceLogo component.
 
-| Name      | Type            | Default    | Description                              |
-| :-------- | :-------------- | :--------- | :--------------------------------------- |
-| dataTest  | `string`        |            | Optional prop for testing purposes.      |
-| id        | `string`        |            | Set `id` for `ServiceLogo`               |
-| grayScale | `boolean`       |            | If `true`, logo will be in gray scale.   |
-| **name**  | [`enum`](#enum) |            | The name for the displayed service logo. |
-| size      | [`enum`](#enum) | `"medium"` | The size of the displayed service logo.  |
+| Name      | Type            | Default    | Description                                                                 |
+| :-------- | :-------------- | :--------- | :-------------------------------------------------------------------------- |
+| dataTest  | `string`        |            | Optional prop for testing purposes.                                         |
+| id        | `string`        |            | Set `id` for `ServiceLogo`                                                  |
+| grayScale | `boolean`       |            | If `true`, logo will be in gray scale.                                      |
+| **name**  | [`enum`](#enum) |            | The name for the displayed service logo.                                    |
+| size      | [`enum`](#enum) | `"medium"` | The size of the displayed service logo.                                     |
+| alt       | `string`        |            | Optional property for passing own `alt` attribute to the DOM image element. |
 
 ### enum
 

--- a/packages/orbit-components/src/ServiceLogo/ServiceLogo.stories.tsx
+++ b/packages/orbit-components/src/ServiceLogo/ServiceLogo.stories.tsx
@@ -17,6 +17,7 @@ const meta: Meta<typeof ServiceLogo> = {
     size: SIZE_OPTIONS.MEDIUM,
     grayScale: false,
     id: "ID",
+    alt: "Service logo",
   },
 
   argTypes: {

--- a/packages/orbit-components/src/ServiceLogo/TYPESCRIPT_TEMPLATE.template
+++ b/packages/orbit-components/src/ServiceLogo/TYPESCRIPT_TEMPLATE.template
@@ -8,5 +8,6 @@ type Name =%NAMES%
 export interface Props extends Common.Globals {
   readonly name: Name;
   readonly size?: Size;
+  readonly alt?: string;
   readonly grayScale?: boolean;
 }

--- a/packages/orbit-components/src/ServiceLogo/__tests__/index.test.tsx
+++ b/packages/orbit-components/src/ServiceLogo/__tests__/index.test.tsx
@@ -11,13 +11,14 @@ describe(`ServiceLogo`, () => {
     const IMAGE_PATH = `${baseURL}/logos/0x24/${name}.png`;
     const IMAGE_PATH_RETINA = `${baseURL}/logos/0x48/${name}.png`;
     const dataTest = "test";
+    const alt = "Service logo";
     const id = "ID";
 
-    render(<ServiceLogo dataTest={dataTest} name={name} id={id} />);
+    render(<ServiceLogo dataTest={dataTest} name={name} id={id} alt={alt} />);
 
     expect(screen.getByRole("img")).toHaveAttribute("src", IMAGE_PATH);
     expect(screen.getByRole("img")).toHaveAttribute("srcSet", `${IMAGE_PATH_RETINA} 2x`);
-    expect(screen.getByAltText(name)).toBeInTheDocument();
+    expect(screen.getByAltText(alt)).toBeInTheDocument();
     const el = screen.getByTestId(dataTest);
     expect(el).toBeInTheDocument();
     expect(el).toHaveAttribute("id", id);
@@ -29,8 +30,8 @@ describe(`ServiceLogo`, () => {
     const IMAGE_PATH = `${baseURL}/logos-grayscale/0x24/${name}.png`;
     const IMAGE_PATH_RETINA = `${baseURL}/logos-grayscale/0x48/${name}.png`;
 
-    expect(screen.getByRole("img")).toHaveAttribute("src", IMAGE_PATH);
-    expect(screen.getByRole("img")).toHaveAttribute("srcSet", `${IMAGE_PATH_RETINA} 2x`);
+    expect(screen.getByRole("presentation")).toHaveAttribute("src", IMAGE_PATH);
+    expect(screen.getByRole("presentation")).toHaveAttribute("srcSet", `${IMAGE_PATH_RETINA} 2x`);
   });
 
   it("should be small", () => {
@@ -39,8 +40,8 @@ describe(`ServiceLogo`, () => {
     const IMAGE_PATH = `${baseURL}/logos/0x12/${name}.png`;
     const IMAGE_PATH_RETINA = `${baseURL}/logos/0x24/${name}.png`;
 
-    expect(screen.getByRole("img")).toHaveAttribute("src", IMAGE_PATH);
-    expect(screen.getByRole("img")).toHaveAttribute("srcSet", `${IMAGE_PATH_RETINA} 2x`);
+    expect(screen.getByRole("presentation")).toHaveAttribute("src", IMAGE_PATH);
+    expect(screen.getByRole("presentation")).toHaveAttribute("srcSet", `${IMAGE_PATH_RETINA} 2x`);
   });
 
   it("should be large", () => {
@@ -49,7 +50,7 @@ describe(`ServiceLogo`, () => {
     const IMAGE_PATH = `${baseURL}/logos/0x48/${name}.png`;
     const IMAGE_PATH_RETINA = `${baseURL}/logos/0x96/${name}.png`;
 
-    expect(screen.getByRole("img")).toHaveAttribute("src", IMAGE_PATH);
-    expect(screen.getByRole("img")).toHaveAttribute("srcSet", `${IMAGE_PATH_RETINA} 2x`);
+    expect(screen.getByRole("presentation")).toHaveAttribute("src", IMAGE_PATH);
+    expect(screen.getByRole("presentation")).toHaveAttribute("srcSet", `${IMAGE_PATH_RETINA} 2x`);
   });
 });

--- a/packages/orbit-components/src/ServiceLogo/index.tsx
+++ b/packages/orbit-components/src/ServiceLogo/index.tsx
@@ -32,6 +32,7 @@ const ServiceLogo = ({
   size = SIZE_OPTIONS.MEDIUM,
   grayScale = false,
   dataTest,
+  alt = "",
   id,
 }: Props) => {
   const color = getColorUrlParam(grayScale);
@@ -42,7 +43,7 @@ const ServiceLogo = ({
       className={cx("orbit-service-logo w-auto bg-transparent", heightClasses[size])}
       src={`${baseURL}/${color}/${lowRes}/${name}.png`}
       srcSet={`${baseURL}/${color}/${highRes}/${name}.png 2x`}
-      alt={name}
+      alt={alt}
       id={id}
       data-test={dataTest}
     />

--- a/packages/orbit-components/src/ServiceLogo/types.ts
+++ b/packages/orbit-components/src/ServiceLogo/types.ts
@@ -52,5 +52,6 @@ type Name =
 export interface Props extends Common.Globals {
   readonly name: Name;
   readonly size?: Size;
+  readonly alt?: string;
   readonly grayScale?: boolean;
 }


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2381 and https://kiwicom.atlassian.net/browse/FEPLT-2382

# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds accessibility features to the `ServiceLogo` component by introducing `alt` and `role` props, along with an accessibility documentation tab.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant ServiceLogo
    participant ScreenReader

    User->>ServiceLogo: Render with alt text
    alt Has alt prop
        ServiceLogo->>ServiceLogo: Set role="img"
        ServiceLogo->>ScreenReader: Announce logo with alt text
    else No alt prop
        ServiceLogo->>ServiceLogo: Set role="presentation"
        ServiceLogo->>ScreenReader: Skip logo announcement
    end

    Note over ServiceLogo: Supports multiple sizes<br/>and grayscale mode<br/>without affecting accessibility

    User->>ServiceLogo: Use with visible text
    ServiceLogo->>ScreenReader: Announce only visible text<br/>(avoid redundancy)
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4812/files#diff-f7967c6bce9b025a439150bc99815b6f48f56f7e2f43a31318d7eaf878ab40e5>docs/src/documentation/03-components/08-visuals/servicelogo/03-accessibility.mdx</a></td><td>Added documentation for accessibility features of the ServiceLogo component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4812/files#diff-972ad146a04846a36b353e7922f47dc15eacaf3bb648040832771808265730ae>packages/orbit-components/src/ServiceLogo/README.md</a></td><td>Updated README to include the new <code>alt</code> prop for the ServiceLogo component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4812/files#diff-90221a6c3fabda45870c70b8a9d4e7bea74bc98700c948b13ead045054342f96>packages/orbit-components/src/ServiceLogo/ServiceLogo.stories.tsx</a></td><td>Added example usage of the <code>alt</code> prop in the ServiceLogo stories.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4812/files#diff-13d77ce26ce986e8b3428ad782255fb3cfd786e8c2c6ed1ca195d23a19aab040>packages/orbit-components/src/ServiceLogo/TYPESCRIPT_TEMPLATE.template</a></td><td>Updated TypeScript template to include the <code>alt</code> prop in the ServiceLogo component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4812/files#diff-37a7cdce993edb63df62e0d60b4f38cdc27e6194b8bb4e32663b335c89e1fa3f>packages/orbit-components/src/ServiceLogo/__tests__/index.test.tsx</a></td><td>Updated tests to check for the presence of the <code>alt</code> attribute in the ServiceLogo component.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4812/files#diff-9d0aad2d4fa75066facfb43e1daecf2e67fc573c5a59bf7565d8a6ed58a6dab3>packages/orbit-components/src/ServiceLogo/index.tsx</a></td><td>Modified the ServiceLogo component to use the <code>alt</code> prop instead of the name for the alt attribute.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4812/files#diff-45beca3fc9c0d5f53000b48dc37090bc796f6a92259e83430c2342909716dba7>packages/orbit-components/src/ServiceLogo/types.ts</a></td><td>Updated types to include the <code>alt</code> prop in the ServiceLogo component.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.mdx`, `.md`, `.template`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->












































