### PR TITLE
Fix import of Check icon in FakeCheckbox

### DIFF
--- a/packages/orbit-components/src/Checkbox/FakeCheckbox/index.tsx
+++ b/packages/orbit-components/src/Checkbox/FakeCheckbox/index.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import cx from "clsx";
 
 import type { Props } from "../types";
-import { Check } from "../../icons";
+import Check from "../../icons/Check";
 
 const FakeCheckbox = ({
   checked,


### PR DESCRIPTION
Directly import the only needed icon, to reduce the bundle size.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the import statement for the `Check` icon in the `FakeCheckbox` component to directly import the needed icon, which helps in reducing the bundle size.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant FC as FakeCheckbox
    participant CI as Check Icon

    Note over FC,CI: Import Check icon component
    FC->>CI: Import from "../../icons/Check"

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4814/files#diff-0109bedee1be985ed0e8e1573093795e5db8cab4b3c6f0f634b8f3849c59763f>packages/orbit-components/src/Checkbox/FakeCheckbox/index.tsx</a></td><td>Changed the import statement for the <code>Check</code> icon to directly import from its file.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


