### PR TITLE
fix(Radio): remove fullwidth property for FakeRadio

### DIFF
--- a/packages/orbit-components/src/Radio/FakeRadio/index.tsx
+++ b/packages/orbit-components/src/Radio/FakeRadio/index.tsx
@@ -13,49 +13,33 @@ const FakeRadio = ({
   return (
     <div
       className={cx(
-        "font-base text-form-element-label-foreground relative flex w-full [align-items:self-start]",
-        "[&_.orbit-radio-icon-container]:has-[:checked]:border-2 [&_.orbit-radio-icon-container_span]:has-[:checked]:visible",
-        "[&_.orbit-radio-icon-container]:has-[:focus]:outline-blue-normal [&_.orbit-radio-icon-container]:has-[:focus]:outline [&_.orbit-radio-icon-container]:has-[:focus]:outline-2",
-        disabled
-          ? [
-              "cursor-not-allowed",
-              "[&_.orbit-radio-icon-container]:bg-cloud-light [&_.orbit-radio-icon-container]:border-cloud-dark",
-            ]
-          : [
-              "cursor-pointer",
-              "[&_.orbit-radio-icon-container]:has-[:checked]:border-form-element-focus [&_.orbit-radio-icon-container]:has-[:checked]:active:border-form-element-focus [&_.orbit-radio-icon-container]:has-[:checked]:bg-white-normal [&_.orbit-radio-icon-container]:bg-form-element-background",
-              !checked &&
-                hasError &&
-                "[&_.orbit-radio-icon-container]:border-form-element-error [&_.orbit-radio-icon-container]:hover:border-form-element-error-hover [&_.orbit-radio-icon-container]:active:border-form-element-error",
-              !hasError &&
-                "[&_.orbit-radio-icon-container]:border-form-element [&_.orbit-radio-icon-container]:hover:border-form-element-hover [&_.orbit-radio-icon-container]:active:border-form-element-active",
-              checked &&
-                !hasError &&
-                "[&_.orbit-radio-icon-container]:border-form-element-focus active:border-form-element-focus [&_.orbit-radio-icon-container]:bg-white-normal",
-            ],
+        "relative box-border",
+        "flex flex-none items-center justify-center",
+        "size-icon-medium rounded-full",
+        "duration-fast scale-100 transition-all ease-in-out",
+        "border-solid",
+        checked ? "border-2" : "border",
+        disabled && "bg-cloud-light border-cloud-dark cursor-not-allowed",
+        !disabled && [
+          "bg-form-element-background cursor-pointer active:scale-95",
+          checked &&
+            "border-form-element-focus hover:border-form-element-focus active:border-form-element-focus",
+          !checked &&
+            hasError &&
+            "border-form-element-error hover:border-form-element-error-hover active:border-form-element-error",
+          !checked &&
+            !hasError &&
+            "border-cloud-dark hover:border-cloud-dark-hover active:border-cloud-dark-active",
+        ],
       )}
     >
-      <div
+      <span
         className={cx(
-          "orbit-radio-icon-container",
-          "relative box-border",
-          "flex flex-none items-center justify-center",
-          "size-icon-medium rounded-full",
-          "duration-fast scale-100 transition-all ease-in-out",
-          "border-solid",
-          checked ? "border-2" : "border",
-          !disabled && "active:scale-95",
-          hasError && "border-blue-normal",
+          "size-[10px] rounded-full",
+          disabled ? "bg-cloud-dark" : "bg-blue-normal",
+          checked ? "visible" : "invisible",
         )}
-      >
-        <span
-          className={cx(
-            "size-[10px] rounded-full",
-            disabled ? "bg-cloud-dark" : "bg-blue-normal",
-            checked ? "visible" : "invisible",
-          )}
-        />
-      </div>
+      />
     </div>
   );
 };


### PR DESCRIPTION
Closes https://kiwicom.atlassian.net/browse/FEPLT-2927

I've checked the change in the following scenarios:
- wrapped by Stack, Box, div, span ✅ 
- with set BG color on a wrapping element ✅ 
- added local build into Booking repo ✅ 
- checked in MMB locally ✅ 

Playroom:


# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR removes the `fullwidth` property from the `FakeRadio` component and adjusts the styling accordingly.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    actor User
    participant Radio
    participant FakeRadio
    participant Styles

    User->>Radio: Interacts with radio
    Radio->>FakeRadio: Updates state (checked/disabled/error)
    FakeRadio->>Styles: Applies visual feedback
    
    alt is checked
        Styles-->>FakeRadio: Show blue dot + focus border
    else is disabled
        Styles-->>FakeRadio: Show cloud-dark styling + not-allowed cursor
    else has error
        Styles-->>FakeRadio: Show error border styling
    else default
        Styles-->>FakeRadio: Show default border styling
    end
    
    FakeRadio-->>User: Display updated visual state

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4816/files#diff-343e8340270b0ee5d843c566844a50fd04360e593d3f8e8b32faf26ada749e2e>packages/orbit-components/src/Radio/FakeRadio/index.tsx</a></td><td>Updated the styling of the <code>FakeRadio</code> component to remove the <code>fullwidth</code> property and improve layout.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->




