### PR TITLE
Adjust keyboard focus itinerary segment

### DIFF
--- a/packages/orbit-components/src/HorizontalScroll/index.tsx
+++ b/packages/orbit-components/src/HorizontalScroll/index.tsx
@@ -180,7 +180,7 @@ const HorizontalScroll = ({
         <div
           className={cx("relative inline-flex size-full", isDragging && "pointer-events-none")}
           // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-          tabIndex={0}
+          tabIndex={isOverflowing ? 0 : undefined}
         >
           <Stack inline spacing={spacing}>
             {children}

--- a/packages/orbit-components/src/Itinerary/Itinerary.stories.tsx
+++ b/packages/orbit-components/src/Itinerary/Itinerary.stories.tsx
@@ -379,7 +379,7 @@ export const SegmentStop: StoryObj<typeof ItinerarySegmentStop> = {
         <Heading type="title2">Examples</Heading>
         <Heading type="title2">Cancelled date and time, changed city and station</Heading>
         <Itinerary>
-          <ItinerarySegment>
+          <ItinerarySegment actionable={false}>
             <ItinerarySegmentStop
               {...args}
               icon={<Icon ariaHidden />}

--- a/packages/orbit-components/src/Itinerary/ItinerarySegment/index.tsx
+++ b/packages/orbit-components/src/Itinerary/ItinerarySegment/index.tsx
@@ -42,13 +42,17 @@ const ItinerarySegment = ({
     setOpened(prev => !prev);
   };
 
+  const isInteractive = actionable || onClick || onExpand || onCollapse;
+
   const parts = (
     <div
       className="pt-300"
-      role="button"
-      tabIndex={0}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown(() => setOpened(prev => !prev))}
+      {...(isInteractive && {
+        role: "button",
+        tabIndex: 0,
+        onClick: handleClick,
+        onKeyDown: handleKeyDown(() => setOpened(prev => !prev)),
+      })}
     >
       {React.Children.map(children, (el, i) => {
         if (!React.isValidElement<{ hidden?: boolean }>(el)) return null;


### PR DESCRIPTION
As reported, ItinerarySegment could be focused via keyboard even if it was not interactive. The same for HorizontalScroll (it only becomes interactive if there is some overflow).

This PR addresses both scenarios

FEPLT-2976

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adjusts the keyboard focus behavior for `ItinerarySegment` and `HorizontalScroll` components to ensure they are only focusable when interactive.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    actor User
    participant HorizontalScroll
    participant ItinerarySegment
    participant Keyboard

    Note over HorizontalScroll: Adds tabIndex when overflowing
    
    alt When Segment is Interactive
        User->>ItinerarySegment: Clicks segment
        ItinerarySegment->>ItinerarySegment: handleClick()
        ItinerarySegment->>ItinerarySegment: Toggle opened state
        
        Keyboard->>ItinerarySegment: Press key
        ItinerarySegment->>ItinerarySegment: handleKeyDown()
        ItinerarySegment->>ItinerarySegment: Toggle opened state
    else When Segment is Non-Interactive
        Note over ItinerarySegment: No keyboard/click handlers
        Note over ItinerarySegment: actionable=false
    end

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4827/files#diff-5e4666ed656ec6d4f6ae034f5afba2ee28d3ff2865fdd035723e94be0027ace2>packages/orbit-components/src/HorizontalScroll/index.tsx</a></td><td>Updated <code>tabIndex</code> to be conditional based on <code>isOverflowing</code>.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4827/files#diff-4119d61891682a46869773fbd15aad5ed92248cabde72e9dbe72c65f90d22d1e>packages/orbit-components/src/Itinerary/Itinerary.stories.tsx</a></td><td>Modified <code>ItinerarySegment</code> to set <code>actionable</code> prop to false.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4827/files#diff-06c8e2969470d4179b32c684c515477206ba254df3b7b90c5eeb1c9adeff8fd1>packages/orbit-components/src/Itinerary/ItinerarySegment/index.tsx</a></td><td>Introduced <code>isInteractive</code> to conditionally apply role, tabIndex, and event handlers.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->




