### PR TITLE
feat: migrate to Tailwind CSS v4.1

### DIFF
--- a/docs/tailwind.config.ts
+++ b/docs/tailwind.config.ts
@@ -8,10 +8,8 @@ export default {
     path.join(path.dirname(require.resolve("@kiwicom/orbit-components")), "**/*.js"),
   ],
   theme: {
-    extend: {
-      fontFamily: {
-        base: "Dm Sans, sans-serif",
-      },
+    fontFamily: {
+      base: "Dm Sans, sans-serif",
     },
   },
   presets: [

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "stylelint-config-recommended": "^13.0.0",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-config-tailwindcss": "^0.0.7",
-    "tailwindcss": "^3.4.4",
+    "tailwindcss": "^4.1.0",
     "ts-node": "^10.9.2",
     "tsc-files": "^1.1.3",
     "tsup": "^6.7.0",

--- a/packages/orbit-components/package.json
+++ b/packages/orbit-components/package.json
@@ -141,7 +141,7 @@
     "surge": "^0.23.0",
     "svg2ttf": "^6.0.0",
     "svgicons2svgfont": "^12.0.0",
-    "tailwindcss": "^3.4.4",
+    "tailwindcss": "^4.1.0",
     "ttf2woff2": "^4.0.1",
     "vite": "^4.5.14",
     "webpack": "^5.94.0",

--- a/packages/orbit-components/tailwind.config.ts
+++ b/packages/orbit-components/tailwind.config.ts
@@ -2,16 +2,10 @@ import type { Config } from "tailwindcss";
 import orbitPreset from "@kiwicom/orbit-tailwind-preset";
 
 export default {
-  mode: "jit",
   content: ["./src/**/*.{ts,tsx}"],
   presets: [
     orbitPreset({
       disablePreflight: process.env.NODE_ENV === "test",
     }),
   ],
-  // This flag will likely be in v4.
-  // https://github.com/tailwindlabs/tailwindcss/discussions/1739#discussioncomment-3630717
-  // future: {
-  //   hoverOnlyWhenSupported: true,
-  // },
 } satisfies Config;

--- a/packages/orbit-tailwind-preset/package.json
+++ b/packages/orbit-tailwind-preset/package.json
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "tailwindcss": ">=3.4.4"
+    "tailwindcss": ">=4.1.0"
   },
   "dependencies": {
     "@kiwicom/orbit-design-tokens": "^11.0.0",

--- a/packages/orbit-tailwind-preset/src/foundation/index.ts
+++ b/packages/orbit-tailwind-preset/src/foundation/index.ts
@@ -29,16 +29,14 @@ const config = (tokens: typeof defaultTokens): Config => {
         normal: tokens.durationNormal,
         slow: tokens.durationSlow,
       },
-      extend: {
-        zIndex: {
-          default: String(tokens.zIndexDefault),
-          sticky: String(tokens.zIndexSticky),
-          "navigation-bar": String(tokens.zIndexNavigationBar),
-          modal: String(tokens.zIndexModal),
-          overlay: String(tokens.zIndexModalOverlay),
-          drawer: String(tokens.zIndexDrawer),
-          onTop: String(tokens.zIndexOnTheTop),
-        },
+      zIndex: {
+        default: String(tokens.zIndexDefault),
+        sticky: String(tokens.zIndexSticky),
+        "navigation-bar": String(tokens.zIndexNavigationBar),
+        modal: String(tokens.zIndexModal),
+        overlay: String(tokens.zIndexModalOverlay),
+        drawer: String(tokens.zIndexDrawer),
+        onTop: String(tokens.zIndexOnTheTop),
       },
     },
   };

--- a/packages/orbit-tailwind-preset/src/index.ts
+++ b/packages/orbit-tailwind-preset/src/index.ts
@@ -1,4 +1,4 @@
-import plugin from "tailwindcss/plugin";
+import { plugin } from "tailwindcss";
 import { convertHexToRgba, defaultTokens, getTokens } from "@kiwicom/orbit-design-tokens";
 import type { Config } from "tailwindcss";
 
@@ -91,8 +91,7 @@ export default function orbitTailwindPreset(options?: Options): Config {
       preflight: !disablePreflight,
     },
     theme: {
-      extend: {
-        fontSize: {
+      fontSize: {
           "heading-display": tokens.headingDisplayFontSize,
           "heading-display-subtitle": tokens.headingDisplaySubtitleFontSize,
           "heading-title0": tokens.headingTitle0FontSize,
@@ -362,30 +361,27 @@ export default function orbitTailwindPreset(options?: Options): Config {
           "safe-bottom": "var(--safe-area-inset-bottom, env(safe-area-inset-bottom))",
           "safe-left": "var(--safe-area-inset-left, env(safe-area-inset-left))",
         },
-      },
     },
     plugins: [
       plugin(({ addVariant, addUtilities }) => {
-        return (
-          addVariant("not-last", "&:not(:last-child)"),
-          addVariant("not-first", "&:not(:first-child)"),
-          addVariant("type-even", "&:nth-of-type(even)"),
-          addVariant("type-odd", "&:nth-of-type(odd)"),
-          addVariant("target-blank", "&[target='_blank']"),
-          addUtilities({
-            ".scrollbar-none": {
-              "-ms-overflow-style": "none",
-              "scrollbar-width": "none",
-              "&::-webkit-scrollbar": {
-                display: "none",
-              },
+        addVariant("not-last", "&:not(:last-child)");
+        addVariant("not-first", "&:not(:first-child)");
+        addVariant("type-even", "&:nth-of-type(even)");
+        addVariant("type-odd", "&:nth-of-type(odd)");
+        addVariant("target-blank", "&[target='_blank']");
+        addUtilities({
+          ".scrollbar-none": {
+            "-ms-overflow-style": "none",
+            "scrollbar-width": "none",
+            "&::-webkit-scrollbar": {
+              display: "none",
             },
-            ".tap-color-none": {
-              "-webkit-tap-highlight-color": "transparent",
-              "-webkit-touch-callout": "none",
-            },
-          })
-        );
+          },
+          ".tap-color-none": {
+            "-webkit-tap-highlight-color": "transparent",
+            "-webkit-touch-callout": "none",
+          },
+        });
       }),
     ],
   };


### PR DESCRIPTION
- Update package.json files to use Tailwind CSS ^4.1.0
- Remove deprecated 'mode: jit' configuration (JIT is default in v4)
- Flatten theme.extend configurations (v4 requirement)
- Update plugin import syntax from 'tailwindcss/plugin' to 'tailwindcss'
- Fix plugin function returns to use statements instead of return expressions
- Remove nested extend structure in foundation preset

Breaking changes:
- Requires Tailwind CSS v4.1.0 or higher
- Configuration files updated for v4 compatibility

# This Pull Request meets the following criteria:

### For new components:

- [ ] Unit and visual regression tests have been added/adjusted for my new feature
- [ ] New Components are registered in index.js of my project
- [ ] New Components have `d.ts` files and are exported in `index.d.ts`


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the project to use Tailwind CSS v4.1, removes deprecated configurations, and flattens theme.extend settings for compatibility.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant TC as Tailwind Config
    participant TP as Tailwind Preset
    participant App as Application

    TC->>TP: Configure base font family (DM Sans)
    TP->>TP: Add new z-index tokens
    TP->>TP: Add utility variants (not-last, not-first, etc.)
    TP->>TP: Add scrollbar utilities
    TP->>TP: Add tap color utilities
    TP-->>App: Apply enhanced styling capabilities
    Note over TC,App: Tailwind v4.1.0 required as peer dependency
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4839/files#diff-0da7d95c5b989f89f1099b640118ab54b3131e6652c6eba631e1b18502cd256b>docs/tailwind.config.ts</a></td><td>Flattened the <code>theme.extend</code> configuration for Tailwind CSS v4 compatibility.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4839/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519>package.json</a></td><td>Updated Tailwind CSS version to ^4.1.0.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4839/files#diff-ced9b8c475e111867f2bd565020cd6b2ae431ef7d69db7e7cb5a8bdb57bc46f8>packages/orbit-components/package.json</a></td><td>Updated Tailwind CSS version to ^4.1.0.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4839/files#diff-2e705ae7c195f8ec3139079a89ed7d14904e120b673e923f2aebed6bdf8e9165>packages/orbit-components/tailwind.config.ts</a></td><td>Removed deprecated 'mode: jit' configuration.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4839/files#diff-f9b16448c4f94c2bbf97784a994729f04660b40be93360cdfd77135327c3117f>packages/orbit-tailwind-preset/package.json</a></td><td>Updated peer dependency for Tailwind CSS to >=4.1.0.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4839/files#diff-b2ed87ba4c7ab51e2f244788460464992e7d78d22ec81bca5a4fdca9313554d1>packages/orbit-tailwind-preset/src/foundation/index.ts</a></td><td>Flattened the <code>extend</code> structure in zIndex configuration.</td></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4839/files#diff-3630044e658d9ad9e0bde2aa81ac0ff0bac0a97ffd8a85ce9eff444412226026>packages/orbit-tailwind-preset/src/index.ts</a></td><td>Updated plugin import syntax for Tailwind CSS.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.json`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


