### PR TITLE
fix(Drawer): make shown prop optional as it has default value

### DIFF
--- a/packages/orbit-components/src/Drawer/types.ts
+++ b/packages/orbit-components/src/Drawer/types.ts
@@ -15,7 +15,7 @@ export interface Props extends Common.Globals {
   readonly onClose?: Common.Callback;
   readonly fixedHeader?: boolean;
   readonly position?: Position;
-  readonly shown: boolean;
+  readonly shown?: boolean;
   readonly labelHide?: string;
   readonly suppressed?: boolean;
   readonly title?: string;


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR makes the `shown` prop optional in the `Props` interface of the Drawer component, reflecting its default value.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant App
    participant Drawer
    
    Note over Drawer: Added 'shown' boolean prop
    
    App->>Drawer: Initialize with shown={boolean}
    Note right of Drawer: Controls visibility state

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4851/files#diff-e64811f2b979e0413670bda1ff68c1a5338c8009c0b6044b1df51a529f27dd49>packages/orbit-components/src/Drawer/types.ts</a></td><td>Updated the <code>shown</code> prop in the <code>Props</code> interface to be optional.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


