### PR TITLE
fix(InputField): add autofill rounded styles for better appearance

### DIFF
--- a/packages/orbit-components/src/InputField/index.tsx
+++ b/packages/orbit-components/src/InputField/index.tsx
@@ -250,6 +250,8 @@ const InputField = (props: Props) => {
             "[&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
             "[&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:m-0",
             "[&[data-com-onepassword-filled]]:!bg-inherit",
+            "[&:-webkit-autofill]:rounded-200",
+            "[&:autofill]:rounded-200",
             "peer",
             insideInputGroup
               ? "focus:outline-blue-normal focus:rounded-200 duration-fast transition-all ease-in-out focus:outline-2 focus:-outline-offset-1"


### PR DESCRIPTION
closes FEPLT-3058


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds rounded styles for autofill inputs in the `InputField` component to enhance its appearance.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant User
    participant Browser
    participant InputField
    participant AutofillSystem

    User->>InputField: Interacts with input field
    Browser->>AutofillSystem: Triggers autofill
    AutofillSystem->>InputField: Applies autofill
    Note over InputField: Applies rounded corners (200px)<br/>for both webkit and standard<br/>autofill states
    InputField-->>User: Shows styled autofilled input

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/kiwicom/orbit/pull/4858/files#diff-a22047902ec5dad314f04706476107ebd04df90a6577b33c7fdf40c9887e6355>packages/orbit-components/src/InputField/index.tsx</a></td><td>Added styles for autofill inputs to improve visual appearance.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


